### PR TITLE
DEBUG and ALLOWED_HOSTS configuration + minor makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ dockerpush: $(DOCKER_BUILD_TIMESTAMP)
 
 .PHONY: dockerrun
 dockerrun: $(DOCKER_BUILD_TIMESTAMP)
+	@echo "Listening on port $(HTTP_PORT)"
 	HTTP_PORT=$(HTTP_PORT) docker-compose up
 
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ SYSTEM_PYTHON := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR}
 
 # default configuration
 HTTP_PORT ?= 5000
+DEBUG ?= 1
 
 # Commands
 DJANGO_MANAGER := $(DJANGO_PROJECT_DIR)/manage.py
@@ -115,13 +116,13 @@ test: $(DEV_REQUIREMENTS_TIMESTAMP) $(TEST_REPORT_DIR)
 
 .PHONY: serve
 serve: $(REQUIREMENTS_TIMESTAMP)
-	$(PYTHON) $(DJANGO_MANAGER) runserver $(HTTP_PORT)
+	DEBUG=$(DEBUG) $(PYTHON) $(DJANGO_MANAGER) runserver $(HTTP_PORT)
 
 
 .PHONY: gunicornserve
 gunicornserve: $(REQUIREMENTS_TIMESTAMP)
 	#$(GUNICORN) --chdir $(DJANGO_PROJECT_DIR) $(DJANGO_PROJECT).wsgi
-	$(PYTHON) $(DJANGO_PROJECT_DIR)/wsgi.py
+	DEBUG=$(DEBUG) $(PYTHON) $(DJANGO_PROJECT_DIR)/wsgi.py
 
 
 # Docker related functions.

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ SYSTEM_PYTHON_TIMESTAMP = $(TIMESTAMPS)/.python-system.timestamp
 PYTHON_LOCAL_BUILD_TIMESTAMP = $(TIMESTAMPS)/.python-build.timestamp
 DOCKER_BUILD_TIMESTAMP = $(TIMESTAMPS)/.dockerbuild.timestamp
 
+# Docker variables
+DOCKER_IMG_LOCAL_TAG = swisstopo/$(SERVICE_NAME):local
+
 # Find all python files that are not inside a hidden directory (directory starting with .)
 PYTHON_FILES := $(shell find ${DJANGO_PROJECT_DIR}/* -type f -name "*.py" -print)
 
@@ -71,7 +74,9 @@ help:
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
 	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 5000)"
 	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable DEBUG_HTTP_PORT (default: 5000)"
-	@echo "- dockerbuild        Build the project localy using the gunicorn WSGI server inside a container"
+	@echo -e " \033[1mDocker TARGETS\033[0m "
+	@echo "- dockerbuild        Build the project localy (with tag := $(DOCKER_IMG_LOCAL_TAG)) using the gunicorn WSGI server inside a container"
+	@echo "- dockerpush         Build and push the project localy (with tag := $(DOCKER_IMG_LOCAL_TAG))"
 	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (exposed port: 5000)"
 	@echo "- shutdown           Stop the aforementioned container"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "
@@ -131,6 +136,11 @@ gunicornserve: $(REQUIREMENTS_TIMESTAMP)
 dockerbuild: $(DOCKER_BUILD_TIMESTAMP)
 
 
+.PHONY: dockerpush
+dockerpush: $(DOCKER_BUILD_TIMESTAMP)
+	docker push $(DOCKER_IMG_LOCAL_TAG)
+
+
 .PHONY: dockerrun
 dockerrun: $(DOCKER_BUILD_TIMESTAMP)
 	HTTP_PORT=$(HTTP_PORT) docker-compose up
@@ -177,7 +187,7 @@ $(DEV_REQUIREMENTS_TIMESTAMP): $(REQUIREMENTS_TIMESTAMP) $(DEV_REQUIREMENTS)
 
 
 $(DOCKER_BUILD_TIMESTAMP): $(TIMESTAMPS) $(PYTHON_FILES) $(CURRENT_DIR)/Dockerfile
-	docker build -t swisstopo/$(SERVICE_NAME):local .
+	docker build -t $(DOCKER_IMG_LOCAL_TAG) .
 	touch $(DOCKER_BUILD_TIMESTAMP)
 
 

--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,12 @@ dockerbuild: $(DOCKER_BUILD_TIMESTAMP)
 
 .PHONY: dockerrun
 dockerrun: $(DOCKER_BUILD_TIMESTAMP)
-	export HTTP_PORT=$(HTTP_PORT); docker-compose up -d
-	sleep 10
+	HTTP_PORT=$(HTTP_PORT) docker-compose up
 
 
 .PHONY: shutdown
 shutdown:
-	export HTTP_PORT=$(HTTP_PORT); docker-compose down
+	HTTP_PORT=$(HTTP_PORT) docker-compose down
 
 
 .PHONY: clean_venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     image: swisstopo/service-stac:local
     ports:
       - "${HTTP_PORT}:8080"
+    environment:
+      - DEBUG=1

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -27,6 +27,10 @@ SECRET_KEY = '%5+eq2851!d7qi^sze(nv2g#kt8v$7)4ck3cq*e!5c2rx%13p+'
 DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
 
 ALLOWED_HOSTS = []
+if DEBUG:
+    # When the debug flag is set allow local host
+    ALLOWED_HOSTS = ['.localhost', '127.0.0.1', '[::1]']
+ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')
 
 # Application definition
 

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
+from distutils.util import strtobool
 from pathlib import Path
 import os
 
@@ -23,7 +24,7 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 SECRET_KEY = '%5+eq2851!d7qi^sze(nv2g#kt8v$7)4ck3cq*e!5c2rx%13p+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
 
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
Made the `DEBUG` and `ALLOWED_HOSTS` flags configurable via environment variables. 
The `DEBUG` flag is per default to `False` and set to `True` in the makefile for local development.
The `ALLOWED_HOSTS` will be then set to the DEV, INT or PROD host name by k8s.

Also improved the makefile with usefull targets for local development.