### PR TITLE
Updated doc summary and added links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Table of Content
 
 - [Summary of the project](#summary-of-the-project)
+- [Links](#links)
 - [Local development](#local-development)
   - [Dependencies](#dependencies)
   - [Setting up to work](#setting-up-to-work)
@@ -18,7 +19,15 @@
 
 ## Summary of the project
 
-`service-stac` provides and manages access to packaged geospatial data and their metadata. It implements and extends the STAC API specification ([https://github.com/radiantearth/stac-api-spec](https://github.com/radiantearth/stac-api-spec)), currently in version 0.9.
+`service-stac` provides and manages access to packaged geospatial data and their metadata. It implements and extends the **STAC API** specification version 0.9.0 [radiantearth/stac-spec/tree/v0.9.0/api-spec](https://github.com/radiantearth/stac-spec/tree/v0.9.0/api-spec). Currently the **STAC API** has been splitted from the main **STAC SPEC** repository into [radiantearth/stac-api-spec](https://github.com/radiantearth/stac-api-spec), which is under active development until the release 1.0-beta.
+
+## Links
+
+- [STAC Specification version 0.9.0](https://github.com/radiantearth/stac-spec/tree/v0.9.0)
+- [STAC API Specification version 0.9.0](https://stacspec.org/STAC-api.html)
+- [STAC Lint](https://staclint.com/)
+- [data.geo.admin.ch STAC API Specification](https://data.geo.admin.ch/api/stac/v0.9/api.html)
+- [geoadmin/doc-api-specs](https://github.com/geoadmin/doc-api-specs/)
 
 ## Local development
 


### PR DESCRIPTION
The STAC API link in the summary refered to the STAC API 1.0beta instead of the 0.9.0