### PR TITLE
BGDIINF_SB-1317: corrected the landing page

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -18,7 +18,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys; sys.path.append("./project")'
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.

--- a/.style.yapf
+++ b/.style.yapf
@@ -17,6 +17,7 @@ based_on_style=google
 #       end_ts=now(),
 #   )        # <--- this bracket is dedented and on a separate line
 dedent_closing_brackets=True
+coalesce_brackets=True
 
 # Split before arguments, but do not split all subexpressions recursively
 # (unless needed).

--- a/project/app/urls.py
+++ b/project/app/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
+from project.settings import API_BASE_PATH
 from . import views
 
 urlpatterns = [
-    path('api/stac/v0.9/', views.index, name='index'),
+    path(API_BASE_PATH, views.landing_page, name='landing-page'),
     path('checker/', views.checker, name='checker'),
 ]

--- a/project/app/views.py
+++ b/project/app/views.py
@@ -1,18 +1,49 @@
 import logging
 
 from django.http import JsonResponse
-# from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 
-def index(request):
+def landing_page(request):
+    url_base = request.build_absolute_uri()
+    # Somehow yapf 0.30.0 cannot format the data dictionary nicely with the links embedded array
+    # it split the first key: value into two lines and add wrong indentation to the links items
+    # therefore we disable yapf for this line here (see https://github.com/google/yapf/issues/392)
+    # yapf: disable
     data = {
-        "description": "Catalog of Swiss Geodata Downloads",
+        "description": "Data Catalog of the Swiss Federal Spatial Data Infrastructure",
         "id": "ch",
         "stac_version": "0.9.0",
-        "title": "data.geo.admin.ch"
+        "title": "data.geo.admin.ch",
+        "links": [{
+            "href": url_base,
+            "rel": "self",
+            "type": "application/json",
+            "title": "this document",
+        }, {
+            "href": f"{url_base}api.html",
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "the API documentation"
+        }, {
+            "href": f"{url_base}conformance",
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "OGC API conformance classes implemented by this server"
+        }, {
+            "href": f"{url_base}collections",
+            "rel": "data",
+            "type": "application/json",
+            "title": "Information about the feature collections"
+        }, {
+            "href": f"{url_base}search",
+            "rel": "search",
+            "type": "application/json",
+            "title": "Search across feature collections"
+        }]
     }
+    # yapf: enable
 
     logger.debug('Landing page: %s', data)
 

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -64,16 +64,14 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
         'APP_DIRS': True,
-        'OPTIONS':
-            {
-                'context_processors':
-                    [
-                        'django.template.context_processors.debug',
-                        'django.template.context_processors.request',
-                        'django.contrib.auth.context_processors.auth',
-                        'django.contrib.messages.context_processors.messages',
-                    ],
-            },
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
     },
 ]
 

--- a/project/project/settings.py
+++ b/project/project/settings.py
@@ -58,6 +58,7 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'project.urls'
+API_BASE_PATH = 'api/stac/v0.9/'
 
 TEMPLATES = [
     {

--- a/tests/unit/test_landing_page.py
+++ b/tests/unit/test_landing_page.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.test import Client
 
+from project.settings import API_BASE_PATH
+
 
 class IndexTestCase(TestCase):
 
@@ -8,8 +10,21 @@ class IndexTestCase(TestCase):
         self.client = Client()
 
     def test_landing_page(self):
-        response = self.client.get('/api/stac/v0.9/')
+        response = self.client.get(f"/{API_BASE_PATH}")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
+        required_keys = ['description', 'id', 'stac_version', 'links']
+        self.assertEqual(
+            set(required_keys).difference(response.json().keys()),
+            set(),
+            msg="missing required attribute in json answer"
+        )
         self.assertEqual(response.json()['id'], 'ch')
         self.assertEqual(response.json()['stac_version'], '0.9.0')
+        for link in response.json()['links']:
+            required_keys = ['href', 'rel']
+            self.assertEqual(
+                set(required_keys).difference(link.keys()),
+                set(),
+                msg="missing required attribute in the answer['links'] array"
+            )


### PR DESCRIPTION

The `links` attribute was missing in the landing page. The description has
also been updated as required by management.

Also renamed the landing page function called `index` to `landing_page`
which is the name of the page as defined in the ticket and spec.