### PR TITLE
Added django migrate and django check in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ format: $(DEV_REQUIREMENTS_TIMESTAMP)
 
 
 .PHONY: lint
-lint: $(DEV_REQUIREMENTS_TIMESTAMP)
+lint: $(DEV_REQUIREMENTS_TIMESTAMP) django-check
+	@echo "Run pylint..."
 	$(PYLINT) $(PYTHON_FILES)
 
 
@@ -159,6 +160,8 @@ shutdown:
 	HTTP_PORT=$(HTTP_PORT) docker-compose down
 
 
+# clean targets
+
 .PHONY: clean_venv
 clean_venv:
 	rm -rf $(VENV)
@@ -171,6 +174,19 @@ clean: clean_venv
 	rm -rf $(PYTHON_LOCAL_DIR)
 	rm -rf $(TEST_REPORT_DIR)
 	rm -rf $(TIMESTAMPS)
+
+
+# django targets
+
+.PHONY: django-check
+django-check: $(REQUIREMENTS)
+	@echo "Run django check"
+	$(PYTHON) $(DJANGO_MANAGER) check --fail-level WARNING
+
+
+.PHONY: django-migrate
+django-migrate: $(REQUIREMENTS)
+	$(PYTHON) $(DJANGO_MANAGER) migrate
 
 
 # Actual builds targets with dependencies


### PR DESCRIPTION

It seems that the `manage.py migrate` command will be often used,
therefore add it as makefile target to simplify its uses.

Also added the `manage.py check` command to the lint target. This
command is kind of a django linting command as it does some static code
checking (see https://docs.djangoproject.com/en/3.1/ref/checks/). To
start with the WARNING level but this could change in the future as we
gain experience with django.