### PR TITLE
BGDIINF_SB-1260: Use UTC time format in logging

### DIFF
--- a/project/config/logging-cfg-dev.yml
+++ b/project/config/logging-cfg-dev.yml
@@ -27,7 +27,8 @@ filters:
     application: service-stac
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
 
 formatters:
   standard:
@@ -37,10 +38,10 @@ formatters:
     add_always_extra: False
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name

--- a/project/config/logging-cfg-local.yml
+++ b/project/config/logging-cfg-local.yml
@@ -27,7 +27,8 @@ filters:
     application: service-stac
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
 
 formatters:
   standard:
@@ -37,10 +38,10 @@ formatters:
     add_always_extra: False
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name

--- a/project/config/logging-cfg-prod.yml
+++ b/project/config/logging-cfg-prod.yml
@@ -25,7 +25,8 @@ filters:
     application: service-stac
   isotime:
     (): logging_utilities.filters.TimeAttribute
-    isotime: True
+    isotime: False
+    utc_isotime: True
 
 formatters:
   standard:
@@ -35,10 +36,10 @@ formatters:
     add_always_extra: False
     filter_attributes:
       - application
-      - isotime
+      - utc_isotime
     remove_empty: True
     fmt:
-      time: isotime
+      time: utc_isotime
       level: levelname
       app: application
       logger: name


### PR DESCRIPTION

UTC time format is a better choice for the ELK (Elastic Logstash
Kibana).

See comment in https://jira.swisstopo.ch/browse/BGDIINF_SB-1260