### PR TITLE
BGDIINF_SB-1291: Added django request info to log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Summary of the project
 
-`service-stac` provides and manages access to packaged geospatial data and their metadata. It implements and extends the **STAC API** specification version 0.9.0 [radiantearth/stac-spec/tree/v0.9.0/api-spec](https://github.com/radiantearth/stac-spec/tree/v0.9.0/api-spec). Currently the **STAC API** has been splitted from the main **STAC SPEC** repository into [radiantearth/stac-api-spec](https://github.com/radiantearth/stac-api-spec), which is under active development until the release 1.0-beta.
+`service-stac` provides and manages access to packaged geospatial data and their metadata. It implements and extends the **STAC API** specification version 0.9.0 [radiantearth/stac-spec/tree/v0.9.0/api-spec](https://github.com/radiantearth/stac-spec/tree/v0.9.0/api-spec). Currently the **STAC API** has been split from the main **STAC SPEC** repository into [radiantearth/stac-api-spec](https://github.com/radiantearth/stac-api-spec), which is under active development until the release 1.0-beta.
 
 ## Links
 

--- a/app/config/logging-cfg-dev.yml
+++ b/app/config/logging-cfg-dev.yml
@@ -29,13 +29,22 @@ filters:
     (): logging_utilities.filters.TimeAttribute
     isotime: False
     utc_isotime: True
+  django:
+    (): logging_utilities.filters.django_request.JsonDjangoRequest
+    include_keys:
+      - request.path
+      - request.method
+      - request.headers
+    exclude_keys:
+      - request.headers.Authorization
+      - request.headers.Proxy-Authorization
 
 formatters:
   standard:
     format: "[%(asctime)s] %(levelname)-8s - %(name)-26s : %(message)s"
   json:
     (): logging_utilities.formatters.json_formatter.JsonFormatter
-    add_always_extra: False
+    add_always_extra: True
     filter_attributes:
       - application
       - utc_isotime
@@ -60,3 +69,4 @@ handlers:
     filters:
       - application
       - isotime
+      - django

--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -33,13 +33,22 @@ filters:
     (): logging_utilities.filters.TimeAttribute
     isotime: False
     utc_isotime: True
+  django:
+    (): logging_utilities.filters.django_request.JsonDjangoRequest
+    include_keys:
+      - request.path
+      - request.method
+      - request.headers
+    exclude_keys:
+      - request.headers.Authorization
+      - request.headers.Proxy-Authorization
 
 formatters:
   standard:
     format: "[%(asctime)s] %(levelname)-8s - %(name)-26s : %(message)s"
   json:
     (): logging_utilities.formatters.json_formatter.JsonFormatter
-    add_always_extra: False
+    add_always_extra: True
     filter_attributes:
       - application
       - utc_isotime
@@ -64,3 +73,4 @@ handlers:
     filters:
       - application
       - isotime
+      - django

--- a/app/config/logging-cfg-prod.yml
+++ b/app/config/logging-cfg-prod.yml
@@ -27,13 +27,22 @@ filters:
     (): logging_utilities.filters.TimeAttribute
     isotime: False
     utc_isotime: True
+  django:
+    (): logging_utilities.filters.django_request.JsonDjangoRequest
+    include_keys:
+      - request.path
+      - request.method
+      - request.headers
+    exclude_keys:
+      - request.headers.Authorization
+      - request.headers.Proxy-Authorization
 
 formatters:
   standard:
     format: "[%(asctime)s] %(levelname)-8s - %(name)-26s : %(message)s"
   json:
     (): logging_utilities.formatters.json_formatter.JsonFormatter
-    add_always_extra: False
+    add_always_extra: True
     filter_attributes:
       - application
       - utc_isotime
@@ -58,3 +67,4 @@ handlers:
     filters:
       - application
       - isotime
+      - django

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -45,7 +45,7 @@ def landing_page(request):
     }
     # yapf: enable
 
-    logger.debug('Landing page: %s', data)
+    logger.debug('Landing page', extra={'request': request, 'response': data})
 
     return JsonResponse(data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ gevent==20.6.2
 gunicorn==19.9.0
 psycopg2-binary==2.8.5
 pyyaml==5.3.1
-logging-utilities==1.1.0a0
+logging-utilities==1.1.0
 numpy
 python-dotenv==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ gevent==20.6.2
 gunicorn==19.9.0
 psycopg2-binary==2.8.5
 pyyaml==5.3.1
-logging-utilities==1.0.0
+logging-utilities==1.1.0a0
 numpy
 python-dotenv==0.14.0


### PR DESCRIPTION
Add the Django HttpRequest info to the log ouptut of the landing page.

This requires the new upcoming logging-utilities 1.1.0, currently it uses the alpha version which will be updated as soon the PR https://github.com/geoadmin/lib-py-logging-utilities/pull/3 is accepted and merged.