### PR TITLE
Updated yapf config to match guidelines

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -19,10 +19,15 @@ based_on_style=google
 dedent_closing_brackets=True
 coalesce_brackets=True
 
-# Split before arguments, but do not split all subexpressions recursively
+# This avoid issues with complex dictionary
+# see https://github.com/google/yapf/issues/392#issuecomment-407958737
+indent_dictionary_value=True
+allow_split_before_dict_value=False
+
+# Split before arguments, but do not split all sub expressions recursively
 # (unless needed).
 split_all_top_level_comma_separated_values=True
 
-# Split lines longuer than 100 characters (this only applies to code not to
+# Split lines longer than 100 characters (this only applies to code not to
 # comment and docstring)
 column_limit=100


### PR DESCRIPTION

Added two configuration to avoid issues with complex dictionary styling,
see https://github.com/geoadmin/doc-guidelines/pull/55