### PR TITLE
BGDIINF_SB-1343: serve static assets using WhiteNoise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ FROM base as production
 RUN echo "from .settings_prod import *" > /app/config/settings.py \
     && chown geoadmin:geoadmin /app/config/settings.py
 
+# Collect static files
+RUN ./manage.py collectstatic --noinput
+
 # production container must not run as root
 USER geoadmin
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 
 # default configuration
 ENV ?= dev
-HTTP_PORT ?= 5000
+HTTP_PORT ?= 8000
 DEBUG ?= 1
 LOGGING_CFG ?= logging-cfg-local.yml
 LOGGING_CFG_PATH := $(DJANGO_CONFIG_DIR)/$(LOGGING_CFG)
@@ -70,8 +70,8 @@ help:
 	@echo "- lint               Lint the python source code"
 	@echo "- test               Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
-	@echo "- serve              Run the project using the django debug server. Port can be set by Env variable HTTP_PORT in .env.local file (default: 8000)"
-	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable DEBUG_HTTP_PORT (default: 5000)"
+	@echo "- serve              Run the project using the django debug server. Port can be set by Env variable HTTP_PORT i(default: 8000)"
+	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8000)"
 	@echo -e " \033[1mDOCKER TARGETS\033[0m "
 	@echo "- dockerbuild-(test|prod) Build the project locally (with tag := $(DOCKER_IMG_LOCAL_TAG))"
 	@echo "- dockerrun          Run the test container with default manage.py command 'runserver'. Note: ENV is populated from '.env.local'"
@@ -140,7 +140,7 @@ test: $(SETUP_TIMESTAMP)
 
 .PHONY: serve
 serve: $(SETUP_TIMESTAMP)
-	$(PYTHON) $(DJANGO_MANAGER) runserver
+	$(PYTHON) $(DJANGO_MANAGER) runserver $(HTTP_PORT)
 
 .PHONY: gunicornserve
 gunicornserve: $(SETUP_TIMESTAMP)

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ lint: $(SETUP_TIMESTAMP)
 # Running tests locally
 .PHONY: test
 test: $(SETUP_TIMESTAMP)
+	# Collect static first to avoid warning in the test
+	$(PYTHON) $(DJANGO_MANAGER) collectstatic --noinput
 	$(PYTHON) $(DJANGO_MANAGER) test --verbosity=2 $(TEST_DIR)
 
 

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -58,12 +58,14 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'django.contrib.gis'
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -152,7 +154,10 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_HOST = os.environ.get('DJANGO_STATIC_HOST', '')
+STATIC_URL = STATIC_HOST + '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'var/www/stac_api/static_files')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Logging
 # https://docs.djangoproject.com/en/3.1/topics/logging/

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -98,27 +98,19 @@ WSGI_APPLICATION = 'wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-try:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.contrib.gis.db.backends.postgis',
-            'NAME': os.environ.get('DB_NAME', 'service_stac_dev'),
-            'USER': os.environ['DB_USER'],
-            'PASSWORD': os.environ['DB_PW'],
-            'HOST': os.environ['DB_HOST'],
-            'PORT': os.environ.get('DB_PORT', 5432),
-            'TEST': {
-                'NAME': os.environ.get('DB_NAME_TEST', 'test_service_stac_dev'),
-            }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': os.environ.get('DB_NAME', 'service_stac'),
+        'USER': os.environ.get('DB_USER', 'service_stac'),
+        'PASSWORD': os.environ.get('DB_PW', 'service_stac'),
+        'HOST': os.environ.get('DB_HOST', 'service_stac'),
+        'PORT': os.environ.get('DB_PORT', 5432),
+        'TEST': {
+            'NAME': os.environ.get('DB_NAME_TEST', 'test_service_stac'),
         }
     }
-except KeyError as err:
-    if 'check' in sys.argv or 'help' in sys.argv:
-        # Do not raise an exception for django command that don't requires DB connection like
-        # for example the check and help command.
-        pass
-    else:
-        raise KeyError(f'Database environment variables {err} not configured') from err
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 import os
-import sys
 from distutils.util import strtobool
 from pathlib import Path
 

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -13,8 +13,6 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include
 from django.urls import path

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -23,8 +23,3 @@ urlpatterns = [
     path('', include('stac_api.urls')),
     path('admin/', admin.site.urls),
 ]
-
-# serve static files during local development as well
-# not suited for prod!
-if settings.DEBUG:
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -40,7 +40,7 @@ class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
 
 # We use the port 5000 as default, otherwise we set the HTTP_PORT env variable within the container.
 if __name__ == '__main__':
-    HTTP_PORT = str(os.environ.get('HTTP_PORT', "5000"))
+    HTTP_PORT = str(os.environ.get('HTTP_PORT', "8000"))
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ logging-utilities==1.1.0
 numpy==1.19.2
 python-dotenv==0.14.0
 djangorestframework==3.12.1
+whitenoise==5.2.0


### PR DESCRIPTION

WhiteNoise is used for production and development as server for static assets. Django itself is not appropriate to use for serving static asset on production. Gunicorn cannot directly serve static files as well.
Some good practice is to use NGINX to serve django static files which is also recommended to use as Reverse Proxy for gunicorn. However in our setup we don't uses nginx because we have a CDN on top of our architecture (CloudFront) which solves the problems that nginx is solving for gunicorn.
Therefore in order to avoid adding nginx to our container to serve static files, I used Whitenoise. Whitenoise is good solution when using with a CDN and for low traffic static files.

See also https://medium.com/technolingo/fastest-static-files-served-django-compressor-whitenoise-aws-cloudfront-ef777849090c and https://whitenoise.readthedocs.io/en/stable/index.html#isn-t-serving-static-files-from-python-horribly-inefficient