### PR TITLE
Improved logging configuration for development

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -6,3 +6,5 @@ DB_HOST=localhost
 DB_PORT=5432
 LOGGING_CFG=app/config/logging-cfg-local.yml
 DEBUG=True
+DISABLE_LOGGING=False
+TEST_ENABLE_LOGGING=False

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Setup app](#setup-app)
   - [Starting dev server](#starting-dev-server)
   - [Running test](#running-test)
+  - [Using Django shell](#using-django-shell)
   - [Linting and formatting your work](#linting-and-formatting-your-work)
 - [Deploying the project and continuous integration](#deploying-the-project-and-continuous-integration)
 - [Deployment configuration](#deployment-configuration)
@@ -100,16 +101,15 @@ These steps you need to do once to setup the project.
 - creating a virtualenv and installing dependencies
 
   ```bash
-  python3 -m venv .venv
-  source .venv/bin/activate
-  pip install -r requirements_dev.txt
+  pipenv install
   ```
 
 ### Starting dev server
 
 ```bash
+# enable first your virtual environment and make sure that `APP_ENV=local` is set
+pipenv shell
 cd app
-# make sure you have the virtualenv activated and `APP_ENV=local` set
 ./manage.py runserver
 ```
 
@@ -130,6 +130,24 @@ you can choose to create a new test-db on every run or to keep the db, which spe
 ```bash
 TEST_ENABLE_LOGGING=1 ./manage.py test
 ```
+
+**NOTE:** the environment variable can also be set in the `.venv.local` file.
+
+### Using Django shell
+
+Django shell can be use for development purpose (see [Django: Playing with the API](https://docs.djangoproject.com/en/3.1/intro/tutorial02/#playing-with-the-api))
+
+```bash
+./manage.py shell
+```
+
+You can disable totally logging while playing with the shell as follow:
+
+```bash
+DISABLE_LOGGING=1 ./manage.py shell
+```
+
+**NOTE:** the environment variable can also be set in the `.venv.local` file.
 
 ### Linting and formatting your work
 

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -171,7 +171,10 @@ def get_logging_config():
     return log_config
 
 
-LOGGING = get_logging_config()
+if strtobool(os.getenv('DISABLE_LOGGING', 'False')):
+    LOGGING = None
+else:
+    LOGGING = get_logging_config()
 
 # Testing
 

--- a/app/tests/runner.py
+++ b/app/tests/runner.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from distutils.util import strtobool
 
 from django.test.runner import DiscoverRunner
 
@@ -19,7 +20,7 @@ class TestRunner(DiscoverRunner):
 
     def setup_test_environment(self, **kwargs):
         super().setup_test_environment(**kwargs)
-        if not os.getenv('TEST_ENABLE_LOGGING', None):
+        if not strtobool(os.getenv('TEST_ENABLE_LOGGING', 'False')):
             logger = logging.getLogger()
             for handler in logger.handlers:
                 if handler.get_name() == 'console':


### PR DESCRIPTION

Now you can completely disable logging via an simple boolean environment
variable `DISABLE_LOGGING`. This is usefull espacialy when working with
the django shell.

Also fixed the `TEST_ENABLE_LOGGING` which true when defined but didnot
checked the value correctly.

Updated the documentation accordingly and also removed old mention to
`pip` in docu while we are now using `pipenv`