### PR TITLE
adding some debug packages to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN groupadd -r geoadmin && useradd -r -s /bin/false -g geoadmin geoadmin
 # install relevent packages
 RUN apt-get update \
     && apt-get install -y binutils libproj-dev gdal-bin \
+    # the following line contains debug tools that can be removed later
+    curl net-tools iputils-ping postgresql-client-common jq openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install pipenv \


### PR DESCRIPTION
The minimal image we're currently building doesn't offer tools for debugging networking issues in the container running on k8s. 

A slightly bigger image is built with this PR including some of the popular tools for debugging networking issues. Can be removed at a later stage once issue is found.