### PR TITLE
BGDIINF_SB-1395: Changed HTTP error message to json format

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -6,5 +6,6 @@ DB_HOST=localhost
 DB_PORT=5432
 LOGGING_CFG=app/config/logging-cfg-local.yml
 DEBUG=True
+DEBUG_PROPAGATE_API_EXCEPTIONS=False
 DISABLE_LOGGING=False
 TEST_ENABLE_LOGGING=False

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -12,9 +12,6 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from .settings_prod import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
 ALLOWED_HOSTS = ['*']
 
 # django-extensions

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -36,3 +36,7 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 if DEBUG:
     REST_FRAMEWORK['PAGE_SIZE'] = os.environ.get('PAGE_SIZE', 2)
+
+    DEBUG_PROPAGATE_API_EXCEPTIONS = bool(
+        strtobool(os.getenv('DEBUG_PROPAGATE_API_EXCEPTIONS', 'False'))
+    )

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -41,9 +41,6 @@ SECRET_KEY = '%5+eq2851!d7qi^sze(nv2g#kt8v$7)4ck3cq*e!5c2rx%13p+'
 DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
 
 ALLOWED_HOSTS = []
-if DEBUG:
-    # When the debug flag is set allow local host
-    ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
 ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')
 
 # Application definition

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -183,5 +183,14 @@ TEST_RUNNER = 'tests.runner.TestRunner'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'stac_api.apps.CursorPagination',
     'PAGE_SIZE': 100,
-    'PAGE_SIZE_LIMIT': 100
+    'PAGE_SIZE_LIMIT': 100,
+    'EXCEPTION_HANDLER': 'stac_api.apps.custom_exception_handler'
 }
+
+# Exception handling
+
+# When DEBUG is true the uncaught exceptions are handle by django a returns a detail exception
+# backtrace as HTML, we can force to give a JSON message as in prod by settings this variable,
+# this is usefull for unittest when we want to test exception handling. This settings can be set
+# via environment variable in settings_dev.py when DEBUG=True
+DEBUG_PROPAGATE_API_EXCEPTIONS = False

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -25,6 +25,9 @@ urlpatterns = [
 
 if settings.DEBUG:
     import debug_toolbar
+    from stac_api.views import TestHttp500
+
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),
+        path('tests/test_http_500', TestHttp500.as_view()),
     ] + urlpatterns

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -180,3 +180,11 @@ class AssetDetail(generics.RetrieveAPIView):
         queryset = self.get_queryset().filter(asset_name=asset_name)
         obj = get_object_or_404(queryset)
         return obj
+
+
+class TestHttp500(AssetDetail):
+
+    def get(self, request, *args, **kwargs):
+        logger.debug('Test request that raises an exception')
+
+        raise AttributeError('test exception')

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.conf import settings
+
+from rest_framework.test import APITestCase
+
+logger = logging.getLogger(__name__)
+
+API_BASE = settings.API_BASE
+
+
+class ApiGenericTestCase(APITestCase):
+
+    def test_limit_query(self):
+        response = self.client.get(f"/{API_BASE}collections?limit=0")
+        self.assertEqual(400, response.status_code)
+
+        response = self.client.get(f"/{API_BASE}collections?limit=test")
+        self.assertEqual(400, response.status_code)
+
+        response = self.client.get(f"/{API_BASE}collections?limit=-1")
+        self.assertEqual(400, response.status_code)
+
+        response = self.client.get(f"/{API_BASE}collections?limit=1000")
+        self.assertEqual(400, response.status_code)
+
+    def test_http_error_invalid_query_param(self):
+        response = self.client.get(f"/{API_BASE}collections?limit=0")
+        self.assertEqual(400, response.status_code)
+        self._check_http_error_msg(response.json())
+
+    def test_http_error_collection_not_found(self):
+        response = self.client.get(f"/{API_BASE}collections/not-found")
+        self.assertEqual(404, response.status_code)
+        self._check_http_error_msg(response.json())
+
+    def test_http_error_500_exception(self):
+        with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True):
+            response = self.client.get("/tests/test_http_500")
+            self.assertEqual(500, response.status_code)
+            self._check_http_error_msg(response.json())
+
+    def _check_http_error_msg(self, json_msg):
+        self.assertListEqual(['code', 'description'],
+                             sorted(list(json_msg.keys())),
+                             msg="JSON response required keys missing")
+        self.assertTrue(isinstance(json_msg['code'], int), msg="'code' is not an integer")
+        self.assertTrue(isinstance(json_msg['description'], str), msg="'code' is not an string")


### PR DESCRIPTION
Now all Rest API HTTP error message follow the API spec and are json  format:
    
`{"code": int, "description": str}`
    
Exception are 404 NOT FOUND when given an invalid URL, e.g. http://data.geoadmin.ch/unknown-url => gives an HTML 404 response.