### PR TITLE
Moved collection and item links to be inlined in admin page

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -9,10 +9,7 @@ from .models import Item
 from .models import ItemLink
 from .models import Provider
 
-admin.site.register(Item)
 admin.site.register(Asset)
-admin.site.register(CollectionLink)
-admin.site.register(ItemLink)
 
 
 class ProviderInline(admin.TabularInline):
@@ -27,8 +24,21 @@ class ProviderInline(admin.TabularInline):
     }
 
 
+class CollectionLinkInline(admin.TabularInline):
+    model = CollectionLink
+    extra = 0
+
+
 @admin.register(Collection)
 class CollectionAdmin(admin.ModelAdmin):
-    inlines = [
-        ProviderInline,
-    ]
+    inlines = [ProviderInline, CollectionLinkInline]
+
+
+class ItemLinkInline(admin.TabularInline):
+    model = ItemLink
+    extra = 0
+
+
+@admin.register(Item)
+class ItemAdmin(admin.ModelAdmin):
+    inlines = [ItemLinkInline]


### PR DESCRIPTION
Now collection and item links are inlined in the admin page like the
providers. This way we have a consistent admin interface.