### PR TITLE
BGDIINF_SB-1401: Read the SECRET_KEY from env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ COPY ./wait-for-it.sh /app/
 RUN echo "from .settings_dev import *" > /app/config/settings.py \
     && chown geoadmin:geoadmin /app/config/settings.py
 
-RUN ./manage.py collectstatic --noinput
+# NOTE: uses a dummy secret_key to avoid django raising settings error
+RUN SECRET_KEY=dummy ./manage.py collectstatic --noinput
 
 USER geoadmin
 
@@ -59,8 +60,8 @@ FROM base as production
 RUN echo "from .settings_prod import *" > /app/config/settings.py \
     && chown geoadmin:geoadmin /app/config/settings.py
 
-# Collect static files
-RUN ./manage.py collectstatic --noinput
+# Collect static files, uses a dummy secret_key to avoid django raising settings error
+RUN SECRET_KEY=dummy ./manage.py collectstatic --noinput
 
 # production container must not run as root
 USER geoadmin

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -12,6 +12,15 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from .settings_prod import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# NOTE: this key here if for development convenience and should not be used
+# on deployment.
+if SECRET_KEY is None:
+    SECRET_KEY = '%5+eq2851!d7qi^sze(nv2g#kt8v$7)4ck3cq*e!5c2rx%13p+'
+
 ALLOWED_HOSTS = ['*']
 
 # django-extensions

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -31,11 +31,8 @@ if APP_ENV.lower() == 'local':
     os.environ['APP_ENV'] = 'local'
     load_dotenv(BASE_DIR / f'.env.{APP_ENV}')
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
-
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '%5+eq2851!d7qi^sze(nv2g#kt8v$7)4ck3cq*e!5c2rx%13p+'
+SECRET_KEY = os.getenv('SECRET_KEY', None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))


### PR DESCRIPTION
The secret key is now read from environment variable. The old key is kept only for local development purpose and has been moved out fo settings_prod.py.
This PR is required for https://github.com/geoadmin/infra-kubernetes/pull/29