### PR TITLE
BGDIINF_SB-1401: Fixed DEBUG=True prod image and renamed docker target test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#############################################
+###########################################################
 # Base container with all necessary deps
 # Buster slim python 3.7 base image.
 FROM python:3.7-slim-buster as base
@@ -25,9 +25,9 @@ WORKDIR /app
 COPY --chown=geoadmin:geoadmin ./app /app/
 COPY --chown=geoadmin:geoadmin ./spec /spec/
 
-#############################################
-# Container to perform tests/management tasks
-FROM base as test
+###########################################################
+# Container to perform tests/management/dev tasks
+FROM base as debug
 
 RUN cd /tmp && \
     pipenv install --system --deploy --ignore-pipfile --dev
@@ -52,7 +52,7 @@ EXPOSE $HTTP_PORT
 ENTRYPOINT ["python3"]
 
 
-#############################################
+###########################################################
 # Container to use in production
 FROM base as production
 

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ SETTINGS_TIMESTAMP = $(TIMESTAMPS)/.settins.timestamp
 DOCKER_BUILD_TIMESTAMP = $(TIMESTAMPS)/.docker-test.timestamp
 
 # Docker variables
-DOCKER_IMG_LOCAL_TAG = swisstopo/$(SERVICE_NAME):latest
-DOCKER_IMG_LOCAL_TAG_TEST = swisstopo/$(SERVICE_NAME):latest-dev
+DOCKER_IMG_LOCAL_TAG = swisstopo/$(SERVICE_NAME):$(USER).latest
+DOCKER_IMG_LOCAL_TAG_TEST = swisstopo/$(SERVICE_NAME):$(USER).latest-dev
 
 # Find all python files that are not inside a hidden directory (directory starting with .)
 PYTHON_FILES := $(shell find $(APP_SRC_DIR) -type f -name "*.py" -print)
@@ -54,23 +54,23 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo -e " \033[1mLOCAL DEVELOPMENT TARGETS\033[0m "
-	@echo "- setup              Create the python virtual environment and install requirements"
-	@echo "- ci                 Create the python virtual environment and install requirements based on the Pipfile.lock"
+	@echo "- setup                    Create the python virtual environment and install requirements"
+	@echo "- ci                       Create the python virtual environment and install requirements based on the Pipfile.lock"
 	@echo -e " \033[1mFORMATING, LINTING AND TESTING TOOLS TARGETS\033[0m "
-	@echo "- format             Format the python source code"
-	@echo "- lint               Lint the python source code"
-	@echo "- test               Run the tests"
+	@echo "- format                   Format the python source code"
+	@echo "- lint                     Lint the python source code"
+	@echo "- test                     Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
-	@echo "- serve              Run the project using the django debug server. Port can be set by Env variable HTTP_PORT i(default: 8000)"
-	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8000)"
+	@echo "- serve                    Run the project using the django debug server. Port can be set by Env variable HTTP_PORT i(default: 8000)"
+	@echo "- gunicornserve            Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8000)"
 	@echo -e " \033[1mDOCKER TARGETS\033[0m "
-	@echo "- dockerbuild-(test|prod) Build the project locally (with tag := $(DOCKER_IMG_LOCAL_TAG))"
-	@echo "- dockerrun          Run the test container with default manage.py command 'runserver'. Note: ENV is populated from '.env.local'"
-	@echo "                     Other cmds can be invoked with 'make dockerrun CMD'."
-	@echo -e "                     \e[1mNote:\e[0m This will connect to your host Postgres DB. If you wanna test with a containerized DB, run 'docker-compose up'"
+	@echo "- dockerbuild-(debug|prod) Build the project locally (with tag := $(DOCKER_IMG_LOCAL_TAG))"
+	@echo "- dockerrun                Run the test container with default manage.py command 'runserver'. Note: ENV is populated from '.env.local'"
+	@echo "                           Other cmds can be invoked with 'make dockerrun CMD'."
+	@echo -e "                           \e[1mNote:\e[0m This will connect to your host Postgres DB. If you wanna test with a containerized DB, run 'docker-compose up'"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "
-	@echo "- clean              Clean genereated files"
-	@echo "- clean_venv         Clean python venv"
+	@echo "- clean                    Clean genereated files"
+	@echo "- clean_venv               Clean python venv"
 	@echo -e " \033[1mDJANGO TARGETS\033[0m "
 	@echo -e " invoke django targets such as \033[1mserve, test, migrate, ...\033[0m  directly by calling app/manage.py COMMAND. Useful COMMANDS"
 	@echo -e " > \033[1mhint:\033[0m source .venv/bin/activate to use the virualenv corresponding to this application before using app/manage.py"
@@ -159,17 +159,17 @@ serve-spec:
 # Note: the timestamp magic is ommitted here on purpose, we rely on docker's
 # change detection mgmt
 
-.PHONY: dockerbuild-test
-dockerbuild-test:
-	docker build -t $(DOCKER_IMG_LOCAL_TAG_TEST) --target test .
+.PHONY: dockerbuild-debug
+dockerbuild-debug:
+	docker build -t $(DOCKER_IMG_LOCAL_TAG_TEST) --target debug .
 
 .PHONY: dockerbuild-prod
 dockerbuild-prod:
 	docker build -t $(DOCKER_IMG_LOCAL_TAG) --target production .
 
 .PHONY: dockerrun
-dockerrun: dockerbuild-test
-	@echo "starting docker test container with populating ENV from .env.local"
+dockerrun: dockerbuild-debug
+	@echo "starting docker debug container with populating ENV from .env.local"
 	docker run -it --rm --env-file .env.local --net=host $(DOCKER_IMG_LOCAL_TAG_TEST) ./manage.py runserver
 
 

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from .settings_prod import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -35,7 +35,7 @@ if APP_ENV.lower() == 'local':
 SECRET_KEY = os.getenv('SECRET_KEY', None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
+DEBUG = False
 
 ALLOWED_HOSTS = []
 ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,7 +23,8 @@ phases:
   pre_build:
     commands:
       - echo "export of the image tag for build and push purposes"
-      # Reading git branch (the utility in the deploy script is unable to read it automatically on CodeBuild)
+      # Reading git branch (the utility in the deploy script is unable to read it automatically
+      # on CodeBuild)
       # see https://stackoverflow.com/questions/47657423/get-github-git-branch-for-aws-codebuild
       - export GITHUB_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
       - |-
@@ -47,15 +48,15 @@ phases:
       - export DOCKER_IMG_TAG_LATEST_DEV=${DOCKER_IMG_TAG_BASE}.latest-dev
       # Starting dev build for testing
       - echo "starting test build on $(date)"
-      - echo "Building docker image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST_DEV}"
-      - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST_DEV} --target test .
+      - echo "Building docker debug image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST_DEV}"
+      - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST_DEV} --target debug .
       # Running tests
       # Note: the app container will 'exit 0' once tests are completed, we need to
       # stop the db as well then
       - docker-compose up --abort-on-container-exit
       # Starting prod build
       - echo "starting production build on $(date)"
-      - echo "Building docker image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST}"
+      - echo "Building docker production image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST}"
       - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST} --target production .
 
   post_build:
@@ -65,6 +66,8 @@ phases:
         if [ "${GITHUB_BRANCH}" = "master" ]; then
           docker push ${DOCKER_IMG_TAG_HASH}
         elif [ "${GITHUB_BRANCH}" = "develop" ]; then
+          echo "Push production image ${DOCKER_IMG_TAG_LATEST}"
           docker push ${DOCKER_IMG_TAG_LATEST}
+          echo "Push debug image ${DOCKER_IMG_TAG_LATEST_DEV}"
           docker push ${DOCKER_IMG_TAG_LATEST_DEV}
         fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
   app:
     build:
       context: .
-      target: test
-    image: swisstopo/service-stac:latest-dev
+      target: debug
+    image: swisstopo/service-stac:ci.latest-dev
     # spinning up postgis container takes some time, app needs to wait
     # for it to be ready before connecting
     # see: https://docs.docker.com/compose/startup-order/


### PR DESCRIPTION
The docker production image could not be started with the DEBUG flag set
to true. This was due to the fact that the DEBUG=True required some
django app that were only configured in the settings_dev.py and not in
prod settings.

Now in the prod image the DEBUG flag is forced to false to avoid issue
when the flag is externally set (e.g. deploying a production image on
dev staging). Anyway we should never deploy an image on production with
django DEBUG enabled.

Also renamed the docker image target test to debug as this target is not
olny used for testing in the CI but also used on the k8s dev staging.