### PR TITLE
Add metadata to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,21 @@ WORKDIR /app
 COPY --chown=geoadmin:geoadmin ./app /app/
 COPY --chown=geoadmin:geoadmin ./spec /spec/
 
+ARG GIT_HASH=unknown
+ARG GIT_BRANCH=unknown
+ARG GIT_DIRTY=""
+ARG AUTHOR=unknonw
+ARG TARGET=
+LABEL git.hash=$GIT_HASH
+LABEL git.branch=$GIT_BRANCH
+LABEL git.dirty="$GIT_DIRTY"
+LABEL author=$AUTHOR
+
 ###########################################################
 # Container to perform tests/management/dev tasks
 FROM base as debug
+
+LABEL target=debug
 
 RUN cd /tmp && \
     pipenv install --system --deploy --ignore-pipfile --dev
@@ -55,6 +67,8 @@ ENTRYPOINT ["python3"]
 ###########################################################
 # Container to use in production
 FROM base as production
+
+LABEL target=production
 
 # on prod, settings.py just import settings_prod
 RUN echo "from .settings_prod import *" > /app/config/settings.py \

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ PYLINT := $(PIPENV_RUN) pylint
 # that don't use it like for CodeBuild env
 SUMMON ?= summon --up -p gopass -e service-stac-$(ENV)
 
+GIT_HASH := `git rev-parse HEAD`
+GIT_BRANCH := `git symbolic-ref HEAD --short 2>/dev/null`
+GIT_DIRTY := `git status --porcelain`
+AUTHOR := $(USER)
 
 all: help
 
@@ -161,11 +165,19 @@ serve-spec:
 
 .PHONY: dockerbuild-debug
 dockerbuild-debug:
-	docker build -t $(DOCKER_IMG_LOCAL_TAG_TEST) --target debug .
+	docker build \
+		--build-arg GIT_HASH="$(GIT_HASH)" \
+		--build-arg GIT_BRANCH="$(GIT_BRANCH)" \
+		--build-arg GIT_DIRTY="$(GIT_DIRTY)" \
+		--build-arg AUTHOR="$(AUTHOR)" -t $(DOCKER_IMG_LOCAL_TAG_TEST) --target debug .
 
 .PHONY: dockerbuild-prod
 dockerbuild-prod:
-	docker build -t $(DOCKER_IMG_LOCAL_TAG) --target production .
+	docker build \
+		--build-arg GIT_HASH="$(GIT_HASH)" \
+		--build-arg GIT_BRANCH="$(GIT_BRANCH)" \
+		--build-arg GIT_DIRTY="$(GIT_DIRTY)" \
+		--build-arg AUTHOR="$(AUTHOR)" -t $(DOCKER_IMG_LOCAL_TAG) --target production .
 
 .PHONY: dockerrun
 dockerrun: dockerbuild-debug

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,7 +32,7 @@ phases:
           GITHUB_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }')";
           export GITHUB_BRANCH=${GITHUB_BRANCH#remotes/origin/};
         fi
-      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - export IMAGE_TAG="${GITHUB_BRANCH}.${COMMIT_HASH}"
       - echo "GITHUB_BRANCH=${GITHUB_BRANCH} COMMIT_HASH=${COMMIT_HASH} IMAGE_TAG=${IMAGE_TAG}"
       - echo "creating a clean environment"
@@ -47,9 +47,14 @@ phases:
       - export DOCKER_IMG_TAG_LATEST=${DOCKER_IMG_TAG_BASE}.latest
       - export DOCKER_IMG_TAG_LATEST_DEV=${DOCKER_IMG_TAG_BASE}.latest-dev
       # Starting dev build for testing
-      - echo "starting test build on $(date)"
+      - echo "starting debug build on $(date)"
       - echo "Building docker debug image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST_DEV}"
-      - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST_DEV} --target debug .
+      - >
+        docker build
+        --build-arg GIT_HASH="${COMMIT_HASH}"
+        --build-arg GIT_BRANCH="${GITHUB_BRANCH}"
+        --build-arg AUTHOR="CI"
+        -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST_DEV} --target debug .
       # Running tests
       # Note: the app container will 'exit 0' once tests are completed, we need to
       # stop the db as well then
@@ -57,7 +62,12 @@ phases:
       # Starting prod build
       - echo "starting production build on $(date)"
       - echo "Building docker production image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST}"
-      - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST} --target production .
+      - >
+        docker build
+        --build-arg GIT_HASH="${COMMIT_HASH}"
+        --build-arg GIT_BRANCH="${GITHUB_BRANCH}"
+        --build-arg AUTHOR="CI"
+        -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST} --target production .
 
   post_build:
     commands:


### PR DESCRIPTION
I added some metadata to a docker image:

- git commit hash
- git branch
- git dirty => '' or the output of "git status --porcelain" if the repo is dirty
- author
- target

These metadata can be easily seen on dockerhub, see https://hub.docker.com/layers/swisstopo/service-stac/ltshb.latest-dev/images/sha256-e9ca799a1a8d1621f37e203b809cf8f4fbb9d643c84b2abde9f9231f96ded899?context=explore as example and seek for `LABEL`

You can also check the metadata as follow:
```
docker image inspect --format='{{json .Config.Labels}}' swisstopo/service-stac:ltshb.latest-dev | jq
{
  "author": "ltshb",
  "git.branch": "feature_docker_image_metadata",
  "git.dirty": "",
  "git.hash": "47545796f9418ccdb9769d87c6e691248992b4d1",
  "target": "debug"
}
```

Or from running container with:

```
docker ps --format="table {{.ID}}\t{{.Image}}\t{{.Labels}}" 
CONTAINER ID        IMAGE                                     LABELS
549134d998a3        swisstopo/service-stac:ltshb.latest-dev   author=ltshb,git.branch=feature_docker_image_metadata,git.dirty=,git.hash=47545796f9418ccdb9769d87c6e691248992b4d1,target=debug
```

What do you think about adding these metadata to all our docker images ? These metadata are automatically added by the CI or by `make dockerbuild`. In future we could also add a `LABEL version=1.0.0` for example.