### PR TITLE
BGDIINF_SB-1402: Fixed link to api doc

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -70,7 +70,7 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'config.urls'
-API_BASE = 'api/stac/v0.9/'
+API_BASE = 'api/stac/v0.9'
 
 TEMPLATES = [
     {

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -120,7 +120,7 @@ class LandingPageSerializer(serializers.ModelSerializer):
         representation['links'][:0] = [
             OrderedDict([
                 ('rel', 'self'),
-                ('href', request.build_absolute_uri(f'/{api_base}')),
+                ('href', request.build_absolute_uri(f'/{api_base}/')),
                 ("type", "application/json"),
                 ("title", "This document"),
             ]),
@@ -138,18 +138,18 @@ class LandingPageSerializer(serializers.ModelSerializer):
             ]),
             OrderedDict([
                 ("rel", "conformance"),
-                ("href", request.build_absolute_uri(f'/{api_base}conformance')),
+                ("href", request.build_absolute_uri(f'/{api_base}/conformance')),
                 ("type", "application/json"),
                 ("title", "OGC API conformance classes implemented by this server"),
             ]),
             OrderedDict([
                 ('rel', 'data'),
-                ('href', request.build_absolute_uri(f'/{api_base}collections')),
+                ('href', request.build_absolute_uri(f'/{api_base}/collections')),
                 ("type", "application/json"),
                 ("title", "Information about the feature collections"),
             ]),
             OrderedDict([
-                ("href", request.build_absolute_uri(f"/{api_base}search")),
+                ("href", request.build_absolute_uri(f"/{api_base}/search")),
                 ("rel", "search"),
                 ("type", "application/json"),
                 ("title", "Search across feature collections"),
@@ -321,19 +321,19 @@ class CollectionSerializer(NonNullModelSerializer):
         representation['links'][:0] = [
             OrderedDict([
                 ('rel', 'self'),
-                ('href', request.build_absolute_uri(f'/{api_base}collections/{name}')),
+                ('href', request.build_absolute_uri(f'/{api_base}/collections/{name}')),
             ]),
             OrderedDict([
                 ('rel', 'root'),
-                ('href', request.build_absolute_uri(f'/{api_base}')),
+                ('href', request.build_absolute_uri(f'/{api_base}/')),
             ]),
             OrderedDict([
                 ('rel', 'parent'),
-                ('href', request.build_absolute_uri(f'/{api_base}collections')),
+                ('href', request.build_absolute_uri(f'/{api_base}/collections')),
             ]),
             OrderedDict([
                 ('rel', 'items'),
-                ('href', request.build_absolute_uri(f'/{api_base}collections/{name}/items')),
+                ('href', request.build_absolute_uri(f'/{api_base}/collections/{name}/items')),
             ])
         ]
         return representation
@@ -474,20 +474,20 @@ class ItemSerializer(NonNullModelSerializer):
                 ('rel', 'self'),
                 (
                     'href',
-                    request.build_absolute_uri(f'/{api}collections/{collection}/items/{name}')
+                    request.build_absolute_uri(f'/{api}/collections/{collection}/items/{name}')
                 ),
             ]),
             OrderedDict([
                 ('rel', 'root'),
-                ('href', request.build_absolute_uri(f'/{api}')),
+                ('href', request.build_absolute_uri(f'/{api}/')),
             ]),
             OrderedDict([
                 ('rel', 'parent'),
-                ('href', request.build_absolute_uri(f'/{api}collections/{collection}/items')),
+                ('href', request.build_absolute_uri(f'/{api}/collections/{collection}/items')),
             ]),
             OrderedDict([
                 ('rel', 'collection'),
-                ('href', request.build_absolute_uri(f'/{api}collections/{collection}')),
+                ('href', request.build_absolute_uri(f'/{api}/collections/{collection}')),
             ])
         ]
         return representation

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -14,27 +14,27 @@ from . import views
 API_BASE = settings.API_BASE
 
 urlpatterns = [
-    path(API_BASE, LandingPageDetail.as_view(), name='landing-page'),
+    path(f'{API_BASE}/', LandingPageDetail.as_view(), name='landing-page'),
     path('checker/', views.checker, name='checker'),
-    path(f"{API_BASE}collections", CollectionList.as_view(), name='collection-list'),
+    path(f"{API_BASE}/collections", CollectionList.as_view(), name='collection-list'),
     path(
-        f"{API_BASE}collections/<collection_name>",
+        f"{API_BASE}/collections/<collection_name>",
         CollectionDetail.as_view(),
         name='collection-detail'
     ),
-    path(f"{API_BASE}collections/<collection_name>/items", ItemsList.as_view(), name='items-list'),
+    path(f"{API_BASE}/collections/<collection_name>/items", ItemsList.as_view(), name='items-list'),
     path(
-        f"{API_BASE}collections/<collection_name>/items/<item_name>",
+        f"{API_BASE}/collections/<collection_name>/items/<item_name>",
         ItemDetail.as_view(),
         name='item-detail'
     ),
     path(
-        f"{API_BASE}collections/<collection_name>/items/<item_name>/assets",
+        f"{API_BASE}/collections/<collection_name>/items/<item_name>/assets",
         AssetsList.as_view(),
         name='assets-list'
     ),
     path(
-        f"{API_BASE}collections/<collection_name>/items/<item_name>/assets/<asset_name>",
+        f"{API_BASE}/collections/<collection_name>/items/<item_name>/assets/<asset_name>",
         AssetDetail.as_view(),
         name='asset-detail'
     ),

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -96,7 +96,7 @@ class CollectionList(generics.ListAPIView):
                 ]),
                 OrderedDict([
                     ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.API_BASE}')),
+                    ('href', request.build_absolute_uri(f'/{settings.API_BASE}/')),
                 ]),
                 OrderedDict([
                     ('rel', 'parent'),
@@ -205,7 +205,7 @@ class ItemsList(generics.ListAPIView):
                 ]),
                 OrderedDict([
                     ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.API_BASE}')),
+                    ('href', request.build_absolute_uri(f'/{settings.API_BASE}/')),
                 ]),
                 OrderedDict([
                     ('rel', 'parent'),

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -32,7 +32,7 @@ class AssetsEndpointTestCase(TestCase):
         collection_name = self.collections[0].name
         item_name = self.items[0][0].name
         response = self.client.get(
-            f"/{API_BASE}collections/{collection_name}/items/{item_name}/assets"
+            f"/{API_BASE}/collections/{collection_name}/items/{item_name}/assets"
         )
         json_data = response.json()
         self.assertEqual(200, response.status_code, msg=get_http_error_description(json_data))
@@ -53,7 +53,7 @@ class AssetsEndpointTestCase(TestCase):
         item_name = self.items[0][0].name
         asset_name = self.assets[0][0][0].name
         response = self.client.get(
-            f"/{API_BASE}collections/{collection_name}/items/{item_name}/assets/{asset_name}"
+            f"/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}"
         )
         json_data = response.json()
         self.assertEqual(200, response.status_code, msg=get_http_error_description(json_data))

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -27,7 +27,7 @@ class CollectionsEndpointTestCase(TestCase):
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_collections_endpoint(self):
-        response = self.client.get(f"/{API_BASE}collections")
+        response = self.client.get(f"/{API_BASE}/collections")
         response_json = response.json()
         self.assertEqual(200, response.status_code, msg=get_http_error_description(response_json))
 
@@ -47,7 +47,7 @@ class CollectionsEndpointTestCase(TestCase):
 
     def test_single_collection_endpoint(self):
         collection_name = self.collections[0].name
-        response = self.client.get(f"/{API_BASE}collections/{collection_name}")
+        response = self.client.get(f"/{API_BASE}/collections/{collection_name}")
         response_json = response.json()
         self.assertEqual(response.status_code, 200, msg=get_http_error_description(response_json))
 
@@ -61,18 +61,18 @@ class CollectionsEndpointTestCase(TestCase):
         )
 
     def test_collections_limit_query(self):
-        response = self.client.get(f"/{API_BASE}collections?limit=1")
+        response = self.client.get(f"/{API_BASE}/collections?limit=1")
         self.assertEqual(200, response.status_code)
         self.assertLessEqual(1, len(response.json()['collections']))
 
-        response = self.client.get(f"/{API_BASE}collections?limit=0")
+        response = self.client.get(f"/{API_BASE}/collections?limit=0")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=test")
+        response = self.client.get(f"/{API_BASE}/collections?limit=test")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=-1")
+        response = self.client.get(f"/{API_BASE}/collections?limit=-1")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=1000")
+        response = self.client.get(f"/{API_BASE}/collections?limit=1000")
         self.assertEqual(400, response.status_code)

--- a/app/tests/test_collections_model.py
+++ b/app/tests/test_collections_model.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 
-from django.conf import settings
 from django.test import TestCase
 
 from stac_api.models import Item
@@ -10,8 +9,6 @@ from stac_api.utils import utc_aware
 import tests.database as db
 
 logger = logging.getLogger(__name__)
-
-API_BASE = settings.API_BASE
 
 
 class CollectionsModelTestCase(TestCase):

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -12,25 +12,25 @@ API_BASE = settings.API_BASE
 class ApiGenericTestCase(APITestCase):
 
     def test_limit_query(self):
-        response = self.client.get(f"/{API_BASE}collections?limit=0")
+        response = self.client.get(f"/{API_BASE}/collections?limit=0")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=test")
+        response = self.client.get(f"/{API_BASE}/collections?limit=test")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=-1")
+        response = self.client.get(f"/{API_BASE}/collections?limit=-1")
         self.assertEqual(400, response.status_code)
 
-        response = self.client.get(f"/{API_BASE}collections?limit=1000")
+        response = self.client.get(f"/{API_BASE}/collections?limit=1000")
         self.assertEqual(400, response.status_code)
 
     def test_http_error_invalid_query_param(self):
-        response = self.client.get(f"/{API_BASE}collections?limit=0")
+        response = self.client.get(f"/{API_BASE}/collections?limit=0")
         self.assertEqual(400, response.status_code)
         self._check_http_error_msg(response.json())
 
     def test_http_error_collection_not_found(self):
-        response = self.client.get(f"/{API_BASE}collections/not-found")
+        response = self.client.get(f"/{API_BASE}/collections/not-found")
         self.assertEqual(404, response.status_code)
         self._check_http_error_msg(response.json())
 

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -73,7 +73,7 @@ class ItemsEndpointTestCase(TestCase):
 
     def test_items_endpoint_with_paging(self):
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items?limit=1"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items?limit=1"
         )
         json_data = response.json()
         logger.debug('Response (%s):\n%s', type(json_data), pformat(json_data))
@@ -117,7 +117,7 @@ class ItemsEndpointTestCase(TestCase):
         # here we set the limit to the number of items in DB plus one to make
         # sure that the items filtering based on the collection name from uri works
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items?"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items?"
             f"limit=100"
         )
         json_data = response.json()
@@ -134,7 +134,7 @@ class ItemsEndpointTestCase(TestCase):
     def test_single_item_endpoint(self):
         collection_name = self.collections[0].name
         item_name = self.items[0][0].name
-        response = self.client.get(f"/{API_BASE}collections/{collection_name}/items/{item_name}")
+        response = self.client.get(f"/{API_BASE}/collections/{collection_name}/items/{item_name}")
         json_data = response.json()
         logger.debug('Response (%s):\n%s', type(json_data), pformat(json_data))
         self.assertEqual(200, response.status_code, msg=get_http_error_description(json_data))
@@ -152,7 +152,7 @@ class ItemsEndpointTestCase(TestCase):
 
     def test_items_endpoint_datetime_query(self):
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime={isoformat(self.now)}&limit=10"
         )
         json_data = response.json()
@@ -162,7 +162,7 @@ class ItemsEndpointTestCase(TestCase):
 
     def test_items_endpoint_datetime_range_query(self):
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime={isoformat(self.yesterday)}/{isoformat(self.now)}&limit=100"
         )
         json_data = response.json()
@@ -174,7 +174,7 @@ class ItemsEndpointTestCase(TestCase):
     def test_items_endpoint_datetime_open_end_range_query(self):
         # test open end query
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime={isoformat(self.yesterday)}/..&limit=100"
         )
         json_data = response.json()
@@ -186,7 +186,7 @@ class ItemsEndpointTestCase(TestCase):
     def test_items_endpoint_datetime_open_start_range_query(self):
         # test open start query
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=../{isoformat(self.yesterday)}&limit=100"
         )
         json_data = response.json()
@@ -197,7 +197,7 @@ class ItemsEndpointTestCase(TestCase):
     def test_items_endpoint_datetime_invalid_range_query(self):
         # test open start and end query
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=../..&limit=100"
         )
         json_data = response.json()
@@ -205,7 +205,7 @@ class ItemsEndpointTestCase(TestCase):
 
         # invalid datetime
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=2019&limit=100"
         )
         json_data = response.json()
@@ -213,7 +213,7 @@ class ItemsEndpointTestCase(TestCase):
 
         # invalid start
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=2019/..&limit=100"
         )
         json_data = response.json()
@@ -221,7 +221,7 @@ class ItemsEndpointTestCase(TestCase):
 
         # invalid end
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=../2019&limit=100"
         )
         json_data = response.json()
@@ -229,7 +229,7 @@ class ItemsEndpointTestCase(TestCase):
 
         # invalid start and end
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?datetime=2019/2019&limit=100"
         )
         json_data = response.json()
@@ -238,7 +238,7 @@ class ItemsEndpointTestCase(TestCase):
     def test_items_endpoint_bbox_valid_query(self):
         # test bbox
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?bbox=5.96,45.82,10.49,47.81&limit=100"
         )
         json_data = response.json()
@@ -250,14 +250,14 @@ class ItemsEndpointTestCase(TestCase):
     def test_items_endpoint_bbox_invalid_query(self):
         # test invalid bbox
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?bbox=5.96,45.82,10.49,47.81,screw;&limit=100"
         )
         json_data = response.json()
         self.assertEqual(400, response.status_code, msg=get_http_error_description(json_data))
 
         response = self.client.get(
-            f"/{API_BASE}collections/{self.collections[0].name}/items"
+            f"/{API_BASE}/collections/{self.collections[0].name}/items"
             f"?bbox=5.96,45.82,10.49,47.81,42,42&limit=100"
         )
         json_data = response.json()

--- a/app/tests/test_landing_page.py
+++ b/app/tests/test_landing_page.py
@@ -12,7 +12,7 @@ class IndexTestCase(TestCase):
         self.client = Client()
 
     def test_landing_page(self):
-        response = self.client.get(f"/{API_BASE}")
+        response = self.client.get(f"/{API_BASE}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         required_keys = ['description', 'id', 'stac_version', 'links']

--- a/app/tests/test_sampledata.py
+++ b/app/tests/test_sampledata.py
@@ -40,7 +40,7 @@ class SampleDataTestCase(StacBaseTestCase):
         with open(collection_dir / 'collection.json') as fd:
             collection_dict = json.load(fd)
 
-        response = self.client.get(f"/{API_BASE}collections/{collection.name}")
+        response = self.client.get(f"/{API_BASE}/collections/{collection.name}")
         payload = response.json()
         logger.debug('Collection %s payload:\n%s', collection.name, pformat(payload))
         self.assertEqual(200, response.status_code, msg=get_http_error_description(payload))
@@ -62,7 +62,7 @@ class SampleDataTestCase(StacBaseTestCase):
             item_dict = json.load(fd)
 
         response = self.client.get(
-            f"/{API_BASE}collections/{collection_name}/items/{item_dict['id']}"
+            f"/{API_BASE}/collections/{collection_name}/items/{item_dict['id']}"
         )
         payload = response.json()
         logger.debug('Item %s.%s payload:\n%s', collection_name, item_dict['id'], pformat(payload))


### PR DESCRIPTION
The links to the API documentation (html and yaml) had a double // in
front of `static` which broke the link.

To fix it I removed the trailing slash in API_BASE settings, because it
make the code more explicit and is less prone to errors as it happened
with the static links of the api doc.