### PR TITLE
 BGDIINF_SB-1367: Finalize item deserialization and moved item created/updated props

### DIFF
--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -33,6 +33,15 @@ def create_or_update_str(created):
 
 
 def update_or_create_links(model, instance, instance_type, links_data):
+    '''Update or create links for a model
+
+    Update the given links list within a model instance or create them when they don't exists yet.
+    Args:
+        model: model class on which to update/create links (Collection or Item)
+        instance: model instance on which to update/create links
+        instance_type: (str) instance type name string to use for filtering ('collection' or 'item')
+        links_data: list of links dictionary to add/update
+    '''
     links_ids = []
     for link_data in links_data:
         link, created = model.objects.get_or_create(

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -32,6 +32,46 @@ def create_or_update_str(created):
     return 'update'
 
 
+def update_or_create_links(model, instance, instance_type, links_data):
+    links_ids = []
+    for link_data in links_data:
+        link, created = model.objects.get_or_create(
+            **{instance_type: instance},
+            rel=link_data["rel"],
+            defaults={
+                'href': link_data.get('href', None),
+                'link_type': link_data.get('link_type', None),
+                'title': link_data.get('title', None)
+            }
+        )
+        logger.debug(
+            '%s link %s',
+            create_or_update_str(created),
+            link.href,
+            extra={
+                instance_type: instance.name, "link": link_data
+            }
+        )
+        links_ids.append(link.id)
+        # the duplicate here is necessary to update the values in
+        # case the object already exists
+        link.link_type = link_data.get('link_type', link.link_type)
+        link.title = link_data.get('title', link.title)
+        link.href = link_data.get('href', link.rel)
+        link.full_clean()
+        link.save()
+
+    # Delete link that were not mentioned in the payload anymore
+    deleted = model.objects.filter(**{instance_type: instance},).exclude(id__in=links_ids).delete()
+    logger.info(
+        "deleted %d stale links for %s %s",
+        deleted[0],
+        instance_type,
+        instance.name,
+        extra={instance_type: instance}
+    )
+
+
 class NonNullModelSerializer(serializers.ModelSerializer):
     """Filter fields with null value
 
@@ -291,40 +331,6 @@ class CollectionSerializer(NonNullModelSerializer):
     def get_stac_version(self, obj):
         return STAC_VERSION
 
-    def _update_or_create_links(self, collection, links_data):
-        links_ids = []
-        for link_data in links_data:
-            link, created = CollectionLink.objects.get_or_create(
-                collection=collection,
-                rel=link_data["rel"],
-                defaults={
-                    'href': link_data.get('href', None),
-                    'link_type': link_data.get('link_type', None),
-                    'title': link_data.get('title', None)
-                }
-            )
-            logger.debug(
-                '%s link %s', create_or_update_str(created), link.href, extra={"link": link_data}
-            )
-            links_ids.append(link.id)
-            # the duplicate here is necessary to update the values in
-            # case the object already exists
-            link.link_type = link_data.get('link_type', link.link_type)
-            link.title = link_data.get('title', link.title)
-            link.href = link_data.get('href', link.rel)
-            link.full_clean()
-            link.save()
-
-        # Delete link that were not mentioned in the payload anymore
-        deleted = CollectionLink.objects.filter(collection=collection).exclude(id__in=links_ids
-                                                                              ).delete()
-        logger.info(
-            "deleted %d stale links for collection %s",
-            deleted[0],
-            collection.name,
-            extra={"collection": collection.name}
-        )
-
     def _update_or_create_providers(self, collection, providers_data):
         provider_ids = []
         for provider_data in providers_data:
@@ -370,7 +376,12 @@ class CollectionSerializer(NonNullModelSerializer):
         links_data = validated_data.pop('links', [])
         collection = Collection.objects.create(**validated_data)
         self._update_or_create_providers(collection=collection, providers_data=providers_data)
-        self._update_or_create_links(collection=collection, links_data=links_data)
+        update_or_create_links(
+            instance_type="collection",
+            model=CollectionLink,
+            instance=collection,
+            links_data=links_data
+        )
         return collection
 
     def update(self, instance, validated_data):
@@ -380,7 +391,12 @@ class CollectionSerializer(NonNullModelSerializer):
         providers_data = validated_data.pop('providers', [])
         links_data = validated_data.pop('links', [])
         self._update_or_create_providers(collection=instance, providers_data=providers_data)
-        self._update_or_create_links(collection=instance, links_data=links_data)
+        update_or_create_links(
+            instance_type="collection",
+            model=CollectionLink,
+            instance=instance,
+            links_data=links_data
+        )
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):
@@ -443,8 +459,10 @@ class ItemsPropertiesSerializer(serializers.Serializer):
         source='properties_end_datetime', allow_null=True, required=False
     )
     title = serializers.CharField(
-        required=False, allow_blank=True, source='properties_title', max_length=255
+        source='properties_title', required=False, allow_blank=True, max_length=255
     )
+    created = serializers.DateTimeField(read_only=True)
+    updated = serializers.DateTimeField(read_only=True)
 
 
 class BboxSerializer(gis_serializers.GeoFeatureModelSerializer):
@@ -534,31 +552,27 @@ class ItemSerializer(NonNullModelSerializer):
             'properties',
             'stac_extensions',
             'links',
-            'assets',
-            'created',
-            'updated',
+            'assets'
         ]
 
     # NOTE: when explicitely declaring fields, we need to add the validation as for the field
     # in model !
-    collection = serializers.StringRelatedField()
+    collection = serializers.SlugRelatedField(slug_field='name', queryset=Collection.objects.all())
     id = serializers.CharField(
         source='name',
         required=True,
         max_length=255,
         validators=[validate_name, UniqueValidator(queryset=Collection.objects.all())]
     )
-    properties = ItemsPropertiesSerializer(source='*')
-    geometry = gis_serializers.GeometryField()
+    properties = ItemsPropertiesSerializer(source='*', required=True)
+    geometry = gis_serializers.GeometryField(required=True)
+    links = ItemLinkSerializer(required=False, many=True)
     # read only fields
-    links = ItemLinkSerializer(many=True, read_only=True)
     type = serializers.ReadOnlyField(default='Feature')
     bbox = BboxSerializer(source='*', read_only=True)
     assets = AssetSerializer(many=True, read_only=True)
     stac_extensions = serializers.SerializerMethodField()
     stac_version = serializers.SerializerMethodField()
-    created = serializers.DateTimeField(read_only=True)
-    updated = serializers.DateTimeField(read_only=True)
 
     def get_stac_extensions(self, obj):
         return list()
@@ -598,3 +612,18 @@ class ItemSerializer(NonNullModelSerializer):
             ])
         ]
         return representation
+
+    def create(self, validated_data):
+        links_data = validated_data.pop('links', [])
+        item = Item.objects.create(**validated_data)
+        update_or_create_links(
+            instance_type="item", model=ItemLink, instance=item, links_data=links_data
+        )
+        return item
+
+    def update(self, instance, validated_data):
+        links_data = validated_data.pop('links', [])
+        update_or_create_links(
+            instance_type="item", model=ItemLink, instance=instance, links_data=links_data
+        )
+        return super().update(instance, validated_data)

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -151,7 +151,7 @@ class ItemsEndpointTestCase(TestCase):
         date_fields = ['created', 'updated']
         for date_field in date_fields:
             self.assertTrue(
-                fromisoformat(json_data[date_field]),
+                fromisoformat(json_data['properties'][date_field]),
                 msg=f"The field {date_field} has an invalid date"
             )
 

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -26,6 +26,20 @@ from tests.base_test import StacBaseTestCase
 logger = logging.getLogger(__name__)
 API_BASE = settings.API_BASE
 
+geometry_json = OrderedDict([
+    (
+        "coordinates",
+        [[
+            [5.644711, 46.775054],
+            [5.644711, 48.014995],
+            [6.602408, 48.014995],
+            [7.602408, 49.014995],
+            [5.644711, 46.775054],
+        ]]
+    ),
+    ("type", "Polygon"),
+])
+
 
 class SerializationTestCase(StacBaseTestCase):
 
@@ -421,17 +435,6 @@ class SerializationTestCase(StacBaseTestCase):
         }
         self.check_stac_item(expected, python_native)
 
-        # Make sure that back translation is possible and valid, though the write is not yet
-        # implemented.
-        # back-translate to Python native:
-        stream = io.BytesIO(json_string)
-        python_native_back = JSONParser().parse(stream)
-
-        # back-translate into fully populated Item instance:
-        back_serializer = ItemSerializer(data=python_native_back)
-        back_serializer.is_valid(raise_exception=True)
-        logger.debug('back validated data:\n%s', pformat(back_serializer.validated_data))
-
     def test_item_serialization_datetime_range(self):
         now = utc_aware(datetime.utcnow())
         yesterday = now - timedelta(days=1)
@@ -539,16 +542,209 @@ class SerializationTestCase(StacBaseTestCase):
         }
         self.check_stac_item(expected, python_native)
 
-        # Make sure that back translation is possible and valid, though the write is not yet
-        # implemented.
-        # back-translate to Python native:
-        stream = io.BytesIO(json_string)
-        python_native_back = JSONParser().parse(stream)
+    def test_item_deserialization_create_only_required(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+            ("geometry", geometry_json),
+            ("properties", OrderedDict([("datetime", isoformat(utc_aware(datetime.utcnow())))])),
+        ])
 
-        # back-translate into fully populated Item instance:
-        back_serializer = ItemSerializer(data=python_native_back)
-        back_serializer.is_valid(raise_exception=True)
-        logger.debug('back validated data:\n%s', pformat(back_serializer.validated_data))
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        item = serializer.save()
+
+        # serialize the object and test it against the one above
+        # mock a request needed for the serialization of links
+        request = self.factory.get(
+            f'{API_BASE}/collections/{self.collection.name}/items/{item.name}'
+        )
+        serializer = ItemSerializer(item, context={'request': request})
+        python_native = serializer.data
+        self.check_stac_item(data, python_native)
+
+    def test_item_deserialization_create_only_required_2(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+            ("geometry", geometry_json),
+            (
+                "properties",
+                OrderedDict([
+                    ("start_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("end_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                ])
+            ),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        item = serializer.save()
+
+        # serialize the object and test it against the one above
+        # mock a request needed for the serialization of links
+        request = self.factory.get(
+            f'{API_BASE}/collections/{self.collection.name}/items/{item.name}'
+        )
+        serializer = ItemSerializer(item, context={'request': request})
+        python_native = serializer.data
+        self.check_stac_item(data, python_native)
+
+    def test_item_deserialization_create_full(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+            ("geometry", geometry_json),
+            (
+                "properties",
+                OrderedDict([
+                    ("start_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("end_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("title", "This is a title"),
+                ])
+            ),
+            ("links", [OrderedDict([('href', 'http://www.example.com'), ('rel', 'example')])]),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        item = serializer.save()
+
+        # serialize the object and test it against the one above
+        # mock a request needed for the serialization of links
+        request = self.factory.get(
+            f'{API_BASE}/collections/{self.collection.name}/items/{item.name}'
+        )
+        serializer = ItemSerializer(item, context={'request': request})
+        python_native = serializer.data
+        self.check_stac_item(data, python_native)
+
+    def test_item_deserialization_update_link_required(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+            ("geometry", geometry_json),
+            (
+                "properties",
+                OrderedDict([
+                    ("start_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("end_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("title", "This is a title"),
+                ])
+            ),
+            ("links", [OrderedDict([('href', 'http://www.example.com'), ('rel', 'example')])]),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        item = serializer.save()
+
+        # Update some data
+        data['properties']['title'] = 'New Title'
+        data['geometry']['coordinates'] = [[[5.602407647225925, 48.01499501585063],
+                                            [8.175889890047533, 48.02711914887954],
+                                            [8.158929420648244, 46.78690091679339],
+                                            [5.644711296534027, 46.775053769032677],
+                                            [5.602407647225925, 48.01499501585063]]]
+        data['properties']['end_datetime'] = isoformat(utc_aware(datetime.utcnow()))
+        data['links'][0]['type'] = 'example'
+        serializer = ItemSerializer(item, data=data)
+        serializer.is_valid(raise_exception=True)
+        collection = serializer.save()
+
+        # serialize the object and test it against the one above
+        # mock a request needed for the serialization of links
+        request = self.factory.get(
+            f'{API_BASE}/collections/{self.collection.name}/items/{item.name}'
+        )
+        serializer = ItemSerializer(item, context={'request': request})
+        python_native = serializer.data
+        self.check_stac_item(data, python_native)
+
+    def test_item_deserialization_update_remove_link_update_datetime(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+            ("geometry", geometry_json),
+            (
+                "properties",
+                OrderedDict([
+                    ("start_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("end_datetime", isoformat(utc_aware(datetime.utcnow()))),
+                    ("title", "This is a title"),
+                ])
+            ),
+            ("links", [OrderedDict([('href', 'http://www.example.com'), ('rel', 'example')])]),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        item = serializer.save()
+
+        # Update some data
+        data['properties']['datetime'] = isoformat(utc_aware(datetime.utcnow()))
+        # To remove a property we have to set it to None otherwise the property
+        # is left unchanged
+        data['properties']['start_datetime'] = None
+        data['properties']['end_datetime'] = None
+        del data['links']
+        serializer = ItemSerializer(item, data=data)
+        serializer.is_valid(raise_exception=True)
+        collection = serializer.save()
+
+        # serialize the object and test it against the one above
+        # mock a request needed for the serialization of links
+        request = self.factory.get(
+            f'{API_BASE}/collections/{self.collection.name}/items/{item.name}'
+        )
+        serializer = ItemSerializer(item, context={'request': request})
+        python_native = serializer.data
+        # remove the properties that have been previously set to know for removal
+        del data['properties']['start_datetime']
+        del data['properties']['end_datetime']
+        self.check_stac_item(data, python_native)
+
+    def test_item_deserialization_missing_required(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test"),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_item_deserialization_invalid_data(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test/invalid name"),
+            ("geometry", geometry_json),
+            ("properties", OrderedDict([("datetime", 'test')])),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_item_deserialization_invalid_link(self):
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test/invalid name"),
+            ("geometry", geometry_json),
+            ("links", [OrderedDict([('href', 'www.example.com'), ('rel', 'example')])]),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
 
     def test_asset_serialization(self):
         collection_name = self.collection.name

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -41,7 +41,7 @@ geometry_json = OrderedDict([
 ])
 
 
-class SerializationTestCase(StacBaseTestCase):
+class CollectionSerializationTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         '''
@@ -328,6 +328,27 @@ class SerializationTestCase(StacBaseTestCase):
         serializer = CollectionSerializer(data=data)
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
+
+
+class ItemSerializationTestCase(StacBaseTestCase):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        '''
+        Prepare instances of keyword, link, provider and instance for testing.
+        Adding the relationships among those by populating the ManyToMany fields
+        '''
+        self.factory = APIRequestFactory()
+        self.collection_created = utc_aware(datetime.utcnow())
+        self.collection = db.create_collection('collection-1')
+        self.collection.full_clean()
+        self.collection.save()
+        self.item = db.create_item(self.collection, 'item-1')
+        self.item.full_clean()
+        self.item.save()
+        self.asset = db.create_asset(self.item, 'asset-1')
+        self.asset.full_clean()
+        self.asset.save()
+        self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_item_serialization(self):
         collection_name = self.collection.name
@@ -745,6 +766,27 @@ class SerializationTestCase(StacBaseTestCase):
         serializer = ItemSerializer(data=data)
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
+
+
+class AssetSerializationTestCase(StacBaseTestCase):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        '''
+        Prepare instances of keyword, link, provider and instance for testing.
+        Adding the relationships among those by populating the ManyToMany fields
+        '''
+        self.factory = APIRequestFactory()
+        self.collection_created = utc_aware(datetime.utcnow())
+        self.collection = db.create_collection('collection-1')
+        self.collection.full_clean()
+        self.collection.save()
+        self.item = db.create_item(self.collection, 'item-1')
+        self.item.full_clean()
+        self.item.save()
+        self.asset = db.create_asset(self.item, 'asset-1')
+        self.asset.full_clean()
+        self.asset.save()
+        self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_serialization(self):
         collection_name = self.collection.name


### PR DESCRIPTION
Now the Item serializer is complete with deserialization and with a good
test coverage.

Move the item properties "created" and "updated"  into "properties:
{created: , updated: }" to match the spec.