### PR TITLE
BGDIINF_SB-1454: Remove assetQuery from doc

### DIFF
--- a/spec/components/parameters.yml
+++ b/spec/components/parameters.yml
@@ -1,14 +1,14 @@
 components:
   parameters:
-    assetQuery:
-      description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter
-        used in POST.
-      in: query
-      name: assetQuery
-      required: false
-      schema:
-        type: string
+    #assetQuery:
+    #  description: >-
+    #    Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter
+    #    used in POST.
+    #  in: query
+    #  name: assetQuery
+    #  required: false
+    #  schema:
+    #    type: string
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -1,74 +1,74 @@
 components:
   schemas:
-    assetQuery:
-      additionalProperties:
-        $ref: "#/components/schemas/assetQueryProp"
-      description: >-
-        Define which properties of the asset to query and the operations to apply.
-
-
-        The following properties can be queried:
-
-        - `type`: query for assets with this specific media type
-
-        - `proj:epsg`: query for assets with this specific epsg
-
-        - `eo:gsd`: query for assets with this specific gsd
-
-        - `geoadmin:variant`: query for assets with this specific variant
-      example:
-        type:
-          eq: image/tiff
-      type: object
-    assetQueryFilter:
-      description: Allows users to query asset properties for specific values
-      properties:
-        assetQuery:
-          $ref: "#/components/schemas/assetQuery"
-      type: object
-    assetQueryProp:
-      anyOf:
-        - description: >-
-            If the object doesn't contain any of the operators, it is equivalent to using the
-            equals operator
-        - description: Match using an operator
-          properties:
-            contains:
-              description: >-
-                Find items with a property that contains the specified
-                literal string, e.g., matches ".*<STRING>.*".
-                A case-insensitive comparison must be performed.
-              type: string
-            endsWith:
-              description: >-
-                Find items with a property that ends with the specified string. A case-insensitive
-                comparison must be performed.
-              type: string
-            eq:
-              description: >-
-                Find items with a property that is equal to the specified value. For strings, a
-                case-insensitive comparison must be performed.
-              nullable: true
-              oneOf:
-                - type: string
-                - type: number
-                - type: boolean
-            in:
-              description: >-
-                Find items with a property that equals at least one entry in the specified array.
-                A case-insensitive comparison must be performed.
-              items:
-                oneOf:
-                  - type: string
-                  - type: number
-              type: array
-            startsWith:
-              description: >-
-                Find items with a property that begins with the specified string. A case-insensitive
-                comparison must be performed.
-              type: string
-          type: object
-      description: Apply query operations to a specific property
+    #assetQuery:
+    #  additionalProperties:
+    #    $ref: "#/components/schemas/assetQueryProp"
+    #  description: >-
+    #    Define which properties of the asset to query and the operations to apply.
+    #
+    #
+    #    The following properties can be queried:
+    #
+    #    - `type`: query for assets with this specific media type
+    #
+    #    - `proj:epsg`: query for assets with this specific epsg
+    #
+    #    - `eo:gsd`: query for assets with this specific gsd
+    #
+    #    - `geoadmin:variant`: query for assets with this specific variant
+    #  example:
+    #    type:
+    #      eq: image/tiff
+    #  type: object
+    #assetQueryFilter:
+    #  description: Allows users to query asset properties for specific values
+    #  properties:
+    #    assetQuery:
+    #      $ref: "#/components/schemas/assetQuery"
+    #  type: object
+    #assetQueryProp:
+    #  anyOf:
+    #    - description: >-
+    #        If the object doesn't contain any of the operators, it is equivalent to using the
+    #        equals operator
+    #    - description: Match using an operator
+    #      properties:
+    #        contains:
+    #          description: >-
+    #            Find items with a property that contains the specified
+    #            literal string, e.g., matches ".*<STRING>.*".
+    #            A case-insensitive comparison must be performed.
+    #          type: string
+    #        endsWith:
+    #          description: >-
+    #            Find items with a property that ends with the specified string. A case-insensitive
+    #            comparison must be performed.
+    #          type: string
+    #        eq:
+    #          description: >-
+    #            Find items with a property that is equal to the specified value. For strings, a
+    #            case-insensitive comparison must be performed.
+    #          nullable: true
+    #          oneOf:
+    #            - type: string
+    #            - type: number
+    #            - type: boolean
+    #        in:
+    #          description: >-
+    #            Find items with a property that equals at least one entry in the specified array.
+    #            A case-insensitive comparison must be performed.
+    #          items:
+    #            oneOf:
+    #              - type: string
+    #              - type: number
+    #          type: array
+    #        startsWith:
+    #          description: >-
+    #            Find items with a property that begins with the specified string. A case-insensitive
+    #            comparison must be performed.
+    #          type: string
+    #      type: object
+    #  description: Apply query operations to a specific property
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -1168,7 +1168,7 @@ components:
       description: Apply query operations to a specific property
     searchBody:
       allOf:
-        - $ref: "#/components/schemas/assetQueryFilter"
+        #- $ref: "#/components/schemas/assetQueryFilter"
         - $ref: "#/components/schemas/queryFilter"
         - $ref: "#/components/schemas/bboxFilter"
         - $ref: "#/components/schemas/datetimeFilter"

--- a/spec/static/openapi.yaml
+++ b/spec/static/openapi.yaml
@@ -28,15 +28,6 @@ tags:
   name: STAC
 components:
   parameters:
-    assetQuery:
-      description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the
-        assetQueryFilter used in POST.
-      in: query
-      name: assetQuery
-      required: false
-      schema:
-        type: string
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -376,75 +367,6 @@ components:
             $ref: "#/components/schemas/exception"
       description: A server error occurred.
   schemas:
-    assetQuery:
-      additionalProperties:
-        $ref: "#/components/schemas/assetQueryProp"
-      description: >-
-        Define which properties of the asset to query and the operations to apply.
-
-
-        The following properties can be queried:
-
-        - `type`: query for assets with this specific media type
-
-        - `proj:epsg`: query for assets with this specific epsg
-
-        - `eo:gsd`: query for assets with this specific gsd
-
-        - `geoadmin:variant`: query for assets with this specific variant
-      example:
-        type:
-          eq: image/tiff
-      type: object
-    assetQueryFilter:
-      description: Allows users to query asset properties for specific values
-      properties:
-        assetQuery:
-          $ref: "#/components/schemas/assetQuery"
-      type: object
-    assetQueryProp:
-      anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
-              oneOf:
-              - type: string
-              - type: number
-            type: array
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
-      description: Apply query operations to a specific property
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -1512,7 +1434,6 @@ components:
       description: Apply query operations to a specific property
     searchBody:
       allOf:
-      - $ref: "#/components/schemas/assetQueryFilter"
       - $ref: "#/components/schemas/queryFilter"
       - $ref: "#/components/schemas/bboxFilter"
       - $ref: "#/components/schemas/datetimeFilter"
@@ -1679,7 +1600,7 @@ paths:
         in the link.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/assetQuery"
+      #- $ref: "#/components/parameters/assetQuery"
       - $ref: "#/components/parameters/query"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"

--- a/spec/static/openapitransactional.yaml
+++ b/spec/static/openapitransactional.yaml
@@ -28,15 +28,6 @@ tags:
   name: STAC
 components:
   parameters:
-    assetQuery:
-      description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the
-        assetQueryFilter used in POST.
-      in: query
-      name: assetQuery
-      required: false
-      schema:
-        type: string
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -444,75 +435,6 @@ components:
           schema:
             $ref: "#/components/schemas/exception"
   schemas:
-    assetQuery:
-      additionalProperties:
-        $ref: "#/components/schemas/assetQueryProp"
-      description: >-
-        Define which properties of the asset to query and the operations to apply.
-
-
-        The following properties can be queried:
-
-        - `type`: query for assets with this specific media type
-
-        - `proj:epsg`: query for assets with this specific epsg
-
-        - `eo:gsd`: query for assets with this specific gsd
-
-        - `geoadmin:variant`: query for assets with this specific variant
-      example:
-        type:
-          eq: image/tiff
-      type: object
-    assetQueryFilter:
-      description: Allows users to query asset properties for specific values
-      properties:
-        assetQuery:
-          $ref: "#/components/schemas/assetQuery"
-      type: object
-    assetQueryProp:
-      anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
-              oneOf:
-              - type: string
-              - type: number
-            type: array
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
-      description: Apply query operations to a specific property
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -1585,7 +1507,6 @@ components:
       description: Apply query operations to a specific property
     searchBody:
       allOf:
-      - $ref: "#/components/schemas/assetQueryFilter"
       - $ref: "#/components/schemas/queryFilter"
       - $ref: "#/components/schemas/bboxFilter"
       - $ref: "#/components/schemas/datetimeFilter"
@@ -2345,8 +2266,8 @@ paths:
         in the link.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/assetQuery"
-      - $ref: "#/components/parameters/query"
+      - #- $ref: "#/components/parameters/assetQuery"
+        $ref: "#/components/parameters/query"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"
       - $ref: "#/components/parameters/limit"


### PR DESCRIPTION
As this query is not implemented yet, it has been removed from the spec.

Removed means in this case, that it has been hidden as a comment #