### PR TITLE
BGDIINF_SB-1469: Commented out link merge, body, headers, method and length attribute

### DIFF
--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -814,44 +814,42 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
+        # body:
+        #   description: For POST requests, the link can specify the HTTP body as a JSON object.
+        #   type: object
+        # headers:
+        #   description: Object key values pairs they map to headers
+        #   example:
+        #     Accept: application/json
+        #   type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
           type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
+        # length:
+        #   type: integer
+        # merge:
+        #   default: false
+        #   description: >-
+        #     This is only valid when the server is responding to POST request.
 
+        #     If merge is true, the client is expected to merge the body value
+        #     into the current request body before following the link.
+        #     This avoids passing large post bodies back and forth when following
+        #     links, particularly for navigating pages through the `POST /search`
+        #     endpoint.
 
-            If merge is true, the client is expected to merge the body value
-            into the current request body before following the link.
-            This avoids passing large post bodies back and forth when following
-            links, particularly for navigating pages through the `POST /search`
-            endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able
-            to merge in the key value pairs specified as JSON
-            `{"next": "token"}` will become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-            - GET
-            - POST
-          type: string
+        #     NOTE: To support form encoding it is expected that a client be able
+        #     to merge in the key value pairs specified as JSON
+        #     `{"next": "token"}` will become `&next=token`.
+        #   type: boolean
+        # method:
+        #   default: GET
+        #   description: Specifies the HTTP method that the link expects
+        #   enum:
+        #     - GET
+        #     - POST
+        #   type: string
         rel:
           description: >-
             Relationship between the current document and the linked document.

--- a/spec/static/openapi.yaml
+++ b/spec/static/openapi.yaml
@@ -1181,43 +1181,9 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a
-            JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
-          type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
-
-
-            If merge is true, the client is expected to merge the body value into
-            the current request body before following the link. This avoids passing
-            large post bodies back and forth when following links, particularly for
-            navigating pages through the `POST /search` endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able to
-            merge in the key value pairs specified as JSON `{"next": "token"}` will
-            become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-          - GET
-          - POST
           type: string
         rel:
           description: >-

--- a/spec/static/openapitransactional.yaml
+++ b/spec/static/openapitransactional.yaml
@@ -1250,43 +1250,9 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a
-            JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
-          type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
-
-
-            If merge is true, the client is expected to merge the body value into
-            the current request body before following the link. This avoids passing
-            large post bodies back and forth when following links, particularly for
-            navigating pages through the `POST /search` endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able to
-            merge in the key value pairs specified as JSON `{"next": "token"}` will
-            become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-          - GET
-          - POST
           type: string
         rel:
           description: >-


### PR DESCRIPTION
These attributes are currently not implemented. They might be required
to implement the pagination of the search endpoint but this still needs
to be verified (aka the django rest framework cursor pagination might
not need it)