### PR TITLE
BGDIINF_SB-1503 changing setting for SECURE_PROXY_SSL_HEADER

### DIFF
--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -20,10 +20,6 @@ loggers:
     level: DEBUG
     handlers:
       - console
-  default:
-    level: DEBUG
-    handlers:
-      - console
 
 filters:
   application:

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -39,7 +39,7 @@ SECRET_KEY = os.getenv('SECRET_KEY', None)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-# SECURITY: 
+# SECURITY:
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ('HTTP_CLOUDFRONT_FORWARDED_PROTO', 'https')
 

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -39,6 +39,10 @@ SECRET_KEY = os.getenv('SECRET_KEY', None)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
+# SECURITY: 
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = ('HTTP_CLOUDFRONT_FORWARDED_PROTO', 'https')
+
 ALLOWED_HOSTS = []
 ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')
 

--- a/app/tests/test_cf_forwarded_proto.py
+++ b/app/tests/test_cf_forwarded_proto.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.test import Client
+from django.test import TestCase
+
+API_BASE = settings.API_BASE
+
+
+class CFForwardedProtoTestCase(TestCase):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+
+    def test_http_access(self):
+        response = self.client.get(
+            f"/{API_BASE}", HTTP_ACCEPT='application/json', follow=True)
+        for link in response.json().get('links',[]):
+            self.assertTrue(link['href'].startswith('http'))
+
+    def test_https_access(self):
+        response = self.client.get(
+            f"/{API_BASE}", HTTP_CLOUDFRONT_FORWARDED_PROTO='https', HTTP_ACCEPT='application/json', follow=True)
+        for link in response.json().get('links', []):
+            self.assertTrue(link['href'].startswith('https'))

--- a/app/tests/test_cf_forwarded_proto.py
+++ b/app/tests/test_cf_forwarded_proto.py
@@ -11,13 +11,16 @@ class CFForwardedProtoTestCase(TestCase):
         self.client = Client()
 
     def test_http_access(self):
-        response = self.client.get(
-            f"/{API_BASE}", HTTP_ACCEPT='application/json', follow=True)
-        for link in response.json().get('links',[]):
+        response = self.client.get(f"/{API_BASE}", HTTP_ACCEPT='application/json', follow=True)
+        for link in response.json().get('links', []):
             self.assertTrue(link['href'].startswith('http'))
 
     def test_https_access(self):
         response = self.client.get(
-            f"/{API_BASE}", HTTP_CLOUDFRONT_FORWARDED_PROTO='https', HTTP_ACCEPT='application/json', follow=True)
+            f"/{API_BASE}",
+            HTTP_CLOUDFRONT_FORWARDED_PROTO='https',
+            HTTP_ACCEPT='application/json',
+            follow=True
+        )
         for link in response.json().get('links', []):
             self.assertTrue(link['href'].startswith('https'))


### PR DESCRIPTION
Django doesn't correctly determine if the original request was made using SSL with our Stack. Therefore we need to adapt the settings value SECURE_PROXY_SSL_HEADER