### PR TITLE
BGDIINF_SB-1491: authentication

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -80,7 +80,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'config.urls'
 API_BASE = 'api/stac/v0.9'
-LOGIN_URL = f"/{API_BASE}/api-auth/login/"
+LOGIN_URL = f"/{API_BASE}/login/"
 
 TEMPLATES = [
     {

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -80,7 +80,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'config.urls'
 API_BASE = 'api/stac/v0.9'
-LOGIN_URL = f"/{API_BASE}/login/"
+LOGIN_URL = "/api/stac/admin/login/"
 
 TEMPLATES = [
     {

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -51,6 +51,9 @@ ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')
 INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_gis',
+    'rest_framework.authtoken',
+    #  Note: If you use TokenAuthentication in production you must ensure
+    #  that your API is only available over https.
     'stac_api.apps.StacApiConfig',
     'config.apps.StacAdminConfig',
     'django.contrib.auth',
@@ -77,6 +80,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'config.urls'
 API_BASE = 'api/stac/v0.9'
+LOGIN_URL = f"/{API_BASE}/api-auth/login/"
 
 TEMPLATES = [
     {
@@ -181,11 +185,21 @@ else:
 TEST_RUNNER = 'tests.runner.TestRunner'
 
 # set default pagination configuration
+# set authentication schemes
+
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ],
     'DEFAULT_PAGINATION_CLASS': 'stac_api.apps.CursorPagination',
     'PAGE_SIZE': 100,
     'PAGE_SIZE_LIMIT': 100,
-    'EXCEPTION_HANDLER': 'stac_api.apps.custom_exception_handler'
+    'EXCEPTION_HANDLER': 'stac_api.apps.custom_exception_handler',
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+    ]
 }
 
 # Exception handling

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -1,5 +1,8 @@
 from django.conf import settings
+from django.urls import include
 from django.urls import path
+
+from rest_framework.authtoken.views import obtain_auth_token
 
 from stac_api.views import AssetDetail
 from stac_api.views import AssetsList
@@ -40,4 +43,7 @@ urlpatterns = [
         AssetDetail.as_view(),
         name='asset-detail'
     ),
+    # https://www.django-rest-framework.org/tutorial/quickstart/#urls
+    path(f"{API_BASE}/api-auth/", include('rest_framework.urls', namespace='rest_framework')),
+    path('api-token-auth/', obtain_auth_token, name='api-token-auth'),
 ]

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.urls import include
 from django.urls import path
 
 from rest_framework.authtoken.views import obtain_auth_token
@@ -43,7 +42,5 @@ urlpatterns = [
         AssetDetail.as_view(),
         name='asset-detail'
     ),
-    # https://www.django-rest-framework.org/tutorial/quickstart/#urls
-    path(f"{API_BASE}/", include('rest_framework.urls', namespace='rest_framework')),
     path(f"{API_BASE}/get_token", obtain_auth_token, name='get_token'),
 ]

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -44,6 +44,6 @@ urlpatterns = [
         name='asset-detail'
     ),
     # https://www.django-rest-framework.org/tutorial/quickstart/#urls
-    path(f"{API_BASE}/api-auth/", include('rest_framework.urls', namespace='rest_framework')),
-    path('api-token-auth/', obtain_auth_token, name='api-token-auth'),
+    path(f"{API_BASE}/", include('rest_framework.urls', namespace='rest_framework')),
+    path(F"{API_BASE}/get_token/", obtain_auth_token, name='api-token-auth'),
 ]

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -45,5 +45,5 @@ urlpatterns = [
     ),
     # https://www.django-rest-framework.org/tutorial/quickstart/#urls
     path(f"{API_BASE}/", include('rest_framework.urls', namespace='rest_framework')),
-    path(F"{API_BASE}/get_token/", obtain_auth_token, name='api-token-auth'),
+    path(f"{API_BASE}/get_token", obtain_auth_token, name='get_token'),
 ]

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -42,5 +42,5 @@ urlpatterns = [
         AssetDetail.as_view(),
         name='asset-detail'
     ),
-    path(f"{API_BASE}/get_token", obtain_auth_token, name='get_token'),
+    path(f"{API_BASE}/get-token", obtain_auth_token, name='get-token'),
 ]

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -1,16 +1,10 @@
-import json
 import logging
 from pprint import pformat
 
-from django.apps import apps
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
+from django.test import Client
 from django.test import TestCase
 
-from rest_framework.authtoken.models import Token
-from rest_framework.test import APIClient
 from rest_framework.test import APIRequestFactory
 
 from stac_api.serializers import CollectionSerializer
@@ -26,26 +20,6 @@ logger = logging.getLogger(__name__)
 API_BASE = settings.API_BASE
 
 
-def grant_permissions(model_name, user):
-    '''
-    grant the required permissions to a test user in order to
-    perform e.g. POST or PUT on the specified view
-    :param model_name: name of model, for which the permissions are granted
-    :param user: user, to whom the permissions are granted
-    '''
-    model_dict = apps.all_models['stac_api']
-    # grant permissions needed for specified view
-    for perm in ['add_', 'change_', 'delete_', 'view_']:
-        content_type = ContentType.objects.get_for_model(model_dict[model_name.lower()])
-        permission = Permission.objects.get(
-            codename=perm + model_name.lower(),
-            content_type=content_type,
-        )
-        user.user_permissions.add(permission)
-    user.save()
-    user.refresh_from_db()
-
-
 class CollectionsEndpointTestCase(TestCase):
 
 <<<<<<< HEAD
@@ -53,8 +27,12 @@ class CollectionsEndpointTestCase(TestCase):
         self.client = Client()
 =======
     def setUp(self):
+<<<<<<< HEAD
         self.client = APIClient()
 >>>>>>> BGDIINF_SB-1491: added basic, token and session authentication
+=======
+        self.client = Client()
+>>>>>>> BGDIINF_SB-1491: adapted urls.py
         self.factory = APIRequestFactory()
         self.collections, self.items, self.assets = db.create_dummy_db_content(4, 4, 4)
         self.maxDiff = None  # pylint: disable=invalid-name

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -182,7 +182,6 @@ class CollectionsEndpointTestCase(TestCase):
         self.assertEqual(response_json['title'], payload_json['title'])
         self.assertIn('providers', response_json.keys())  # optional value, should exist
 
-
         # is it persistent?
         response = self.client.get(
             f"/{API_BASE}/collections/{payload_json['id']}",

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -1,10 +1,16 @@
+import json
 import logging
 from pprint import pformat
 
+from django.apps import apps
 from django.conf import settings
-from django.test import Client
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
 from rest_framework.test import APIRequestFactory
 
 from stac_api.serializers import CollectionSerializer
@@ -20,10 +26,35 @@ logger = logging.getLogger(__name__)
 API_BASE = settings.API_BASE
 
 
+def grant_permissions(model_name, user):
+    '''
+    grant the required permissions to a test user in order to
+    perform e.g. POST or PUT on the specified view
+    :param model_name: name of model, for which the permissions are granted
+    :param user: user, to whom the permissions are granted
+    '''
+    model_dict = apps.all_models['stac_api']
+    # grant permissions needed for specified view
+    for perm in ['add_', 'change_', 'delete_', 'view_']:
+        content_type = ContentType.objects.get_for_model(model_dict[model_name.lower()])
+        permission = Permission.objects.get(
+            codename=perm + model_name.lower(),
+            content_type=content_type,
+        )
+        user.user_permissions.add(permission)
+    user.save()
+    user.refresh_from_db()
+
+
 class CollectionsEndpointTestCase(TestCase):
 
+<<<<<<< HEAD
     def setUp(self): # pylint: disable=invalid-name
         self.client = Client()
+=======
+    def setUp(self):
+        self.client = APIClient()
+>>>>>>> BGDIINF_SB-1491: added basic, token and session authentication
         self.factory = APIRequestFactory()
         self.collections, self.items, self.assets = db.create_dummy_db_content(4, 4, 4)
         self.maxDiff = None  # pylint: disable=invalid-name

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -291,3 +291,28 @@ class CollectionsEndpointTestCase(TestCase):
             content_type='application/json'
         )
         self.assertEqual(401, response.status_code, msg="Unauthorized patch was permitted.")
+
+    def test_unauthorized_collection_delete(self):
+        path = f'/{API_BASE}/collections/{self.collections[0].name}'
+        response = self.client.delete(path)
+        # Collection delete is not implemented (and currently not foreseen).
+        # Status code here is 401, as user is unauthorized for write requests.
+        # If logged-in, it should be 405, as DELETE for collections is not
+        # implemented.
+        self.assertEqual(
+            401,
+            response.status_code,
+            msg="unauthorized and unimplemented "
+            "collection delete was permitted."
+        )
+
+    def test_authorized_collection_delete(self):
+        path = f'/{API_BASE}/collections/{self.collections[0].name}'
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.delete(path)
+        # Collection delete is not implemented (and currently not foreseen), hence
+        # the status code should be 405. If it should get implemented in future
+        # an unauthorized delete should get a status code of 401 (see test above).
+        self.assertEqual(
+            405, response.status_code, msg="unimplemented collection delete was permitted."
+        )

--- a/app/tests/test_get_token_endpoint.py
+++ b/app/tests/test_get_token_endpoint.py
@@ -7,6 +7,8 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from rest_framework.test import APIRequestFactory
 
+from tests.utils import get_http_error_description
+
 API_BASE = settings.API_BASE
 
 
@@ -25,11 +27,18 @@ class GetTokenEndpointTestCase(TestCase):
     def test_get_token_with_valid_credentials(self):
         url = reverse('get_token')
         response = self.client.post(url, {'username': self.username, 'password': self.password})
-        self.assertEqual(200, response.status_code, msg="User request for token failed.")
+        self.assertEqual(200, response.status_code, msg=get_http_error_description(response.json()))
         generated_token = response.data["token"]
         token_from_db = Token.objects.get(user=self.user)
         self.assertEqual(
             generated_token,
             token_from_db.key,
             msg="Generated token and token stored in DB do not match."
+        )
+
+    def test_get_token_with_invalid_credentials(self):
+        url = reverse('get_token')
+        response = self.client.post(url, {'username': self.username, 'password': 'wrong_password'})
+        self.assertEqual(
+            400, response.status_code, msg="Token for unauthorized user has been created."
         )

--- a/app/tests/test_get_token_endpoint.py
+++ b/app/tests/test_get_token_endpoint.py
@@ -25,7 +25,7 @@ class GetTokenEndpointTestCase(TestCase):
         self.user.save()
 
     def test_get_token_with_valid_credentials(self):
-        url = reverse('get_token')
+        url = reverse('get-token')
         response = self.client.post(url, {'username': self.username, 'password': self.password})
         self.assertEqual(200, response.status_code, msg=get_http_error_description(response.json()))
         generated_token = response.data["token"]
@@ -37,7 +37,7 @@ class GetTokenEndpointTestCase(TestCase):
         )
 
     def test_get_token_with_invalid_credentials(self):
-        url = reverse('get_token')
+        url = reverse('get-token')
         response = self.client.post(url, {'username': self.username, 'password': 'wrong_password'})
         self.assertEqual(
             400, response.status_code, msg="Token for unauthorized user has been created."

--- a/app/tests/test_get_token_endpoint.py
+++ b/app/tests/test_get_token_endpoint.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+from rest_framework.test import APIRequestFactory
+
+API_BASE = settings.API_BASE
+
+
+class GetTokenEndpointTestCase(TestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+        self.factory = APIRequestFactory()
+        self.username = 'SherlockHolmes'
+        self.password = '221B_BakerStreet'
+        self.user = get_user_model().objects.create_user(
+            self.username, 'top@secret.co.uk', self.password
+        )
+        self.user.save()
+
+    def test_get_token_with_valid_credentials(self):
+        url = reverse('get_token')
+        response = self.client.post(url, {'username': self.username, 'password': self.password})
+        self.assertEqual(200, response.status_code, msg="User request for token failed.")
+        generated_token = response.data["token"]
+        token_from_db = Token.objects.get(user=self.user)
+        self.assertEqual(
+            generated_token,
+            token_from_db.key,
+            msg="Generated token and token stored in DB do not match."
+        )

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -7,6 +7,7 @@ from pprint import pformat
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import Client
 
 from rest_framework.test import APIRequestFactory
@@ -42,7 +43,7 @@ def to_dict(input_ordered_dict):
 
 class ItemsEndpointTestCase(StacBaseTestCase):
 
-    def setUp(self): # pylint: disable=invalid-name
+    def setUp(self):  # pylint: disable=invalid-name
         self.factory = APIRequestFactory()
         self.client = Client()
         self.collections, self.items, self.assets = db.create_dummy_db_content(4, 4, 4)
@@ -78,6 +79,11 @@ class ItemsEndpointTestCase(StacBaseTestCase):
         item_range.save()
         self.collections[0].save()
         self.maxDiff = None  # pylint: disable=invalid-name
+        self.username = 'SherlockHolmes'
+        self.password = '221B_BakerStreet'
+        self.superuser = get_user_model().objects.create_superuser(
+            self.username, 'test_e_mail1234@some_fantasy_domainname.com', self.password
+        )
 
 
 class ItemsReadEndpointTestCase(ItemsEndpointTestCase):
@@ -286,6 +292,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.post(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(201, response)
@@ -310,6 +317,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.post(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(201, response)
@@ -334,6 +342,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
@@ -346,6 +355,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
     def test_item_endpoint_post_invalid_datetime(self):
         data = {"id": "test", "geometry": TEST_VALID_GEOMETRY, "properties": {"title": "My title"}}
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
@@ -365,6 +375,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.put(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -386,6 +397,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.put(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -406,6 +418,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.put(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -432,6 +445,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             }
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.put(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -455,6 +469,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
     def test_item_endpoint_patch(self):
         data = {"geometry": TEST_VALID_GEOMETRY, "properties": {"title": "patched title",}}
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.patch(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -471,6 +486,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
     def test_item_endpoint_patch_invalid_datetimes(self):
         data = {"properties": {"datetime": "patched title",}}
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.patch(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
@@ -483,6 +499,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
             "id": f'new-{self.items[0][0].name}',
         }
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.patch(path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -500,6 +517,7 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
 
     def test_item_endpoint_delete_item(self):
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.delete(path)
         self.assertStatusCode(200, response)
 
@@ -515,5 +533,43 @@ class ItemsWriteEndpointTestCase(ItemsEndpointTestCase):
 
     def test_item_endpoint_delete_item_invalid_name(self):
         path = f'/{API_BASE}/collections/{self.collections[0].name}/items/non-existant-item'
+        self.client.login(username=self.username, password=self.password)
         response = self.client.delete(path)
         self.assertStatusCode(404, response)
+
+    def test_unauthorized_item_post_put_patch_delete(self):
+        # make sure POST fails for anonymous user:
+        data = {
+            "id": "test",
+            "geometry": TEST_VALID_GEOMETRY,
+            "properties": {
+                "datetime": "2020-10-18T00:00:00Z"
+            }
+        }
+        path = f'/{API_BASE}/collections/{self.collections[0].name}/items'
+        response = self.client.post(path, data=data, content_type="application/json")
+        self.assertEqual(401, response.status_code, msg="Unauthorized post was permitted.")
+
+        # make sure PUT fails for anonymous user:
+        data = {
+            "id": self.items[0][0].name,
+            "geometry": TEST_VALID_GEOMETRY,
+            "properties": {
+                "datetime": "2020-10-18T00:00:00Z",
+                "title": "My title",
+            }
+        }
+        path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        response = self.client.put(path, data=data, content_type="application/json")
+        self.assertEqual(401, response.status_code, msg="Unauthorized put was permitted.")
+
+        # make sure PATCH fails for anonymous user:
+        data = {"geometry": TEST_VALID_GEOMETRY, "properties": {"title": "patched title",}}
+        path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        response = self.client.patch(path, data=data, content_type="application/json")
+        self.assertEqual(401, response.status_code, msg="Unauthorized patch was permitted.")
+
+        # make sure DELETE fails for anonymous user:
+        path = f'/{API_BASE}/collections/{self.collections[0].name}/items/{self.items[0][0].name}'
+        response = self.client.delete(path)
+        self.assertEqual(401, response.status_code, msg="Unauthorized delete was permitted.")


### PR DESCRIPTION
* added token, basic and session authentication
* set `DjangoModelPermissionsOrAnonReadOnly` as default (non-logged in, anonymous users have read-only access, logged-in users can take actions according to their individual permissions)
* added POST endpoint for users to request a token based on their username and password
(e.g. as follows: `curl -d "username=testuser&password=test12345" http://127.0.0.1:8000/api-token-auth/`)
* added unit tests for authorized POSTs as well as unauthorized POSTs or requets with wrong credentials

The POST/PUT endpoints for collections as well as a lot of the unit tests and test data for the collections_endpoint were borrowed from https://github.com/geoadmin/service-stac/pull/132, thanks @rebert :smiley: 
