### PR TITLE
BGDIINF_SB-1510: fixed invalid datetime range | added unit tests

### DIFF
--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry
@@ -128,6 +129,20 @@ def validate_item_properties_datetimes_dependencies(
             raise ValidationError(_(message))
 
 
+def validate_datetime_string(datetime_string):
+    '''
+    Check if a given string is a datetime string in the expected format or
+    raise an error, if not.
+
+    Raises:
+        ValueError
+    '''
+    try:
+        datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ')
+    except:
+        raise ValueError(_('Invalid datetime string'))
+
+
 def validate_item_properties_datetimes(
     properties_datetime, properties_start_datetime, properties_end_datetime, partial=False
 ):
@@ -142,6 +157,16 @@ def validate_item_properties_datetimes(
             properties_start_datetime,
             properties_end_datetime,
         )
+
+        if properties_datetime is None:
+            if not isinstance(properties_start_datetime, datetime):
+                validate_datetime_string(properties_start_datetime)
+            if not isinstance(properties_end_datetime, datetime):
+                validate_datetime_string(properties_end_datetime)
+            if properties_end_datetime < properties_start_datetime:
+                message = "Property end_datetime can't refer to a date earlier than property "\
+                "start_datetime"
+                raise ValidationError(_(message))
 
 
 def get_conformance_default_links():

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -15,6 +15,7 @@ from solo.models import SingletonModel
 
 from stac_api.collection_summaries import update_summaries
 from stac_api.temporal_extent import update_temporal_extent
+from stac_api.utils import fromisoformat
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +113,21 @@ def validate_item_properties_datetimes_dependencies(
 	Raises:
 		django.core.exceptions.ValidationError
     '''
+    try:
+        if not isinstance(properties_datetime, datetime) and properties_datetime is not None:
+            properties_datetime = fromisoformat(properties_datetime)
+        if not isinstance(
+            properties_start_datetime, datetime
+        ) and properties_start_datetime is not None:
+            properties_start_datetime = fromisoformat(properties_start_datetime)
+        if not isinstance(
+            properties_end_datetime, datetime
+        ) and properties_end_datetime is not None:
+            properties_end_datetime = fromisoformat(properties_end_datetime)
+    except ValueError as error:
+        logger.error("Invalid datetime string %s", error)
+        raise ValidationError('Invalid datetime string %s' % (error))
+
     if properties_datetime is not None:
         if (properties_start_datetime is not None or properties_end_datetime is not None):
             message = 'Cannot provide together property datetime with datetime range ' \
@@ -128,19 +144,11 @@ def validate_item_properties_datetimes_dependencies(
             logger.error(message)
             raise ValidationError(_(message))
 
-
-def validate_datetime_string(datetime_string):
-    '''
-    Check if a given string is a datetime string in the expected format or
-    raise an error, if not.
-
-    Raises:
-        ValueError
-    '''
-    try:
-        datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ')
-    except:
-        raise ValueError(_('Invalid datetime string'))
+    if properties_datetime is None:
+        if properties_end_datetime < properties_start_datetime:
+            message = "Property end_datetime can't refer to a date earlier than property "\
+            "start_datetime"
+            raise ValidationError(_(message))
 
 
 def validate_item_properties_datetimes(
@@ -157,16 +165,6 @@ def validate_item_properties_datetimes(
             properties_start_datetime,
             properties_end_datetime,
         )
-
-        if properties_datetime is None:
-            if not isinstance(properties_start_datetime, datetime):
-                validate_datetime_string(properties_start_datetime)
-            if not isinstance(properties_end_datetime, datetime):
-                validate_datetime_string(properties_end_datetime)
-            if properties_end_datetime < properties_start_datetime:
-                message = "Property end_datetime can't refer to a date earlier than property "\
-                "start_datetime"
-                raise ValidationError(_(message))
 
 
 def get_conformance_default_links():
@@ -482,7 +480,6 @@ class Item(models.Model):
         # This is needed because save() is called during the Item.object.create() function without
         # calling clean() ! and our validation is done within clean() method.
         self.clean()
-
         if self.pk is None:
             action = "insert"
         else:

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -116,13 +116,15 @@ def validate_item_properties_datetimes_dependencies(
     try:
         if not isinstance(properties_datetime, datetime) and properties_datetime is not None:
             properties_datetime = fromisoformat(properties_datetime)
-        if not isinstance(
-            properties_start_datetime, datetime
-        ) and properties_start_datetime is not None:
+        if (
+            not isinstance(properties_start_datetime, datetime) and
+            properties_start_datetime is not None
+        ):
             properties_start_datetime = fromisoformat(properties_start_datetime)
-        if not isinstance(
-            properties_end_datetime, datetime
-        ) and properties_end_datetime is not None:
+        if (
+            not isinstance(properties_end_datetime, datetime) and
+            properties_end_datetime is not None
+        ):
             properties_end_datetime = fromisoformat(properties_end_datetime)
     except ValueError as error:
         logger.error("Invalid datetime string %s", error)

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -126,7 +126,7 @@ def validate_item_properties_datetimes_dependencies(
             properties_end_datetime = fromisoformat(properties_end_datetime)
     except ValueError as error:
         logger.error("Invalid datetime string %s", error)
-        raise ValidationError('Invalid datetime string %s' % (error))
+        raise ValidationError(f'Invalid datetime string {error}') from error
 
     if properties_datetime is not None:
         if (properties_start_datetime is not None or properties_end_datetime is not None):

--- a/app/tests/test_item_model.py
+++ b/app/tests/test_item_model.py
@@ -144,7 +144,7 @@ class ItemsModelTestCase(TestCase):
 class ValidateItemPropertiesDatetimeDependenciesFunctionTestCase(TestCase):
 
     def test_validate_function_invalid_datetime_string(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             properties_datetime = None
             properties_start_datetime = "2001-22-66T08:00:00+00:00"
             properties_end_datetime = "2001-11-11T08:00:00+00:00"

--- a/app/tests/test_item_model.py
+++ b/app/tests/test_item_model.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from stac_api.models import Item
+from stac_api.models import validate_item_properties_datetimes_dependencies
 from stac_api.utils import utc_aware
 
 import tests.database as db
@@ -138,3 +139,15 @@ class ItemsModelTestCase(TestCase):
                 geometry=None
             )
             item.full_clean()
+
+
+class ValidateItemPropertiesDatetimeDependenciesFunctionTestCase(TestCase):
+
+    def test_validate_function_invalid_datetime_string(self):
+        with self.assertRaises(ValueError):
+            properties_datetime = None
+            properties_start_datetime = "2001-22-66T08:00:00+00:00"
+            properties_end_datetime = "2001-11-11T08:00:00+00:00"
+            validate_item_properties_datetimes_dependencies(
+                properties_datetime, properties_start_datetime, properties_end_datetime
+            )

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -787,6 +787,28 @@ class ItemSerializationTestCase(StacBaseTestCase):
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
 
+    def test_item_deserialization_end_date_before_start_date(self):
+        today = datetime.utcnow()
+        yesterday = today - timedelta(days=1)
+        data = OrderedDict([
+            ("collection", self.collection.name),
+            ("id", "test/invalid name"),
+            ("geometry", geometry_json),
+            (
+                "properties",
+                OrderedDict([
+                    ("start_datetime", isoformat(utc_aware(today))),
+                    ("end_datetime", isoformat(utc_aware(yesterday))),
+                    ("title", "This is a title"),
+                ])
+            ),
+        ])
+
+        # translate to Python native:
+        serializer = ItemSerializer(data=data)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
     def test_item_deserialization_invalid_link(self):
         data = OrderedDict([
             ("collection", self.collection.name),


### PR DESCRIPTION
* now end_date cannot be before start_date in items datetime ranges
* added unit tests for item model and item serializer
* in case the item's (start_, end_)datetime property is not an instance of datetime, it is now checked, if it is a valid datetime string.