### PR TITLE
BGDIINF_SB-1482: Fixed copy paste bug in Asset spec

### DIFF
--- a/spec/static/openapitransactional.yaml
+++ b/spec/static/openapitransactional.yaml
@@ -1647,7 +1647,7 @@ components:
           $ref: "#/components/schemas/updated"
     itemAsset:
       allOf:
-      - $ref: "#/components/schemas/itemBase"
+      - $ref: "#/components/schemas/assetBase"
       - type: object
         required:
         - href

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -673,7 +673,7 @@ components:
     # overwrites the STAC definition of itemAsset
     itemAsset:
       allOf:
-        - $ref: "#/components/schemas/itemBase"
+        - $ref: "#/components/schemas/assetBase"
         - type: object
           required:
             - href


### PR DESCRIPTION
With the SPEC rework for Transactional, a copy paste issue in the Asset
Spec has been introduced. The Asset returned the same response as the
Item.