### PR TITLE
Corrected the SPEC and unit tests for the error description type

### DIFF
--- a/app/stac_api/apps.py
+++ b/app/stac_api/apps.py
@@ -91,10 +91,6 @@ def custom_exception_handler(exc, context):
     if isinstance(exc, APIException):
         status_code = exc.status_code
         description = exc.detail
-        if isinstance(description, (list)):
-            # Some APIException, like for instance the ValidationError wrap the detail into a list
-            # because the STAC API spec wants a string as description we join the list together here
-            description = '\n'.join(description)
     elif settings.DEBUG and not settings.DEBUG_PROPAGATE_API_EXCEPTIONS:
         # Other exceptions are left to Django to handle in DEBUG mode, this allow django
         # to set a nice HTML output with backtrace when DEBUG_PROPAGATE_EXCEPTIONS is false

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -24,6 +24,10 @@ class StacBaseTestCase(TestCase):
             self.assertIn(
                 'description', json_data.keys(), msg="'description' is missing from response"
             )
+            self.assertTrue(
+                isinstance(json_data['description'], (list, str, dict)),
+                msg=f"Description wrong type: {type(json_data['description'])}"
+            )
             self.assertEqual(code, json_data['code'], msg="invalid response code")
 
     def check_stac_collection(self, expected, current, ignore=None):

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -50,7 +50,9 @@ class ApiGenericTestCase(APITestCase):
                              sorted(list(json_msg.keys())),
                              msg="JSON response required keys missing")
         self.assertTrue(isinstance(json_msg['code'], int), msg="'code' is not an integer")
-        self.assertTrue(isinstance(json_msg['description'], str), msg="'code' is not an string")
+        self.assertTrue(
+            isinstance(json_msg['description'], (str, list, dict)), msg="'code' is not an string"
+        )
 
     def test_pagination(self):
         db.create_dummy_db_content(3)

--- a/spec/components/responses.yml
+++ b/spec/components/responses.yml
@@ -185,6 +185,3 @@ components:
           example:
             code: 500
             description: "Internal server error"
-        text/html:
-          schema:
-            type: string

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -357,7 +357,14 @@ components:
           type: int
           example: 500
         description:
-          type: string
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                anyOf:
+                  - type: string
+                  - type: object
+            - type: object
       required:
         - code
       type: object

--- a/spec/static/openapi.yaml
+++ b/spec/static/openapi.yaml
@@ -674,7 +674,15 @@ components:
           type: int
           example: 500
         description:
-          type: string
+          anyOf:
+          - type: string
+            example: "Error description"
+          - type: array
+            items:
+              anyOf:
+              - type: string
+              - type: object
+          - type: object
       required:
       - code
       type: object

--- a/spec/static/openapitransactional.yaml
+++ b/spec/static/openapitransactional.yaml
@@ -767,7 +767,15 @@ components:
           type: int
           example: 500
         description:
-          type: string
+          anyOf:
+          - type: string
+            example: "Error description"
+          - type: array
+            items:
+              anyOf:
+              - type: string
+              - type: object
+          - type: object
       required:
       - code
       type: object


### PR DESCRIPTION
Some django errors are encapsulated in object or list in order to
provide a good and detail error descrition in an organized structure. In
order not to loose this structure and organization we allow in the spec
to have the 'description' error field not only be string, but also array
and object.