### PR TITLE
#patch prod logging settings

### DIFF
--- a/app/config/logging-cfg-prod.yml
+++ b/app/config/logging-cfg-prod.yml
@@ -4,10 +4,14 @@ disable_existing_loggers: False # this allow to get logger at module level
 root:
   handlers:
     - console
-  level: INFO
+  level: WARNING
   propagate: True
 
 loggers:
+  stac_api:
+    level: DEBUG
+  middleware:
+    level: DEBUG
   django:
     level: INFO
   gunicorn.error:


### PR DESCRIPTION
logging settings changed for prod: DEBUG logs from app should be printed as well, WARNING for all other loggers

Note: this is done as a `hotfix` (branched off `master`) to check if hotfix versioning (patch position in semver) is working correctly. A hotfix branch has to be merged back in both, `develop` and `master`