### PR TITLE
BGDIINF_SB-1534: avoid duplicate validation in items

### DIFF
--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -514,11 +514,6 @@ class Item(models.Model):
         # parameters
         collection_updated = False
 
-        # Make sure that the properties datetime are valid before updating the temporal extent
-        # This is needed because save() is called during the Item.object.create() function without
-        # calling clean() ! and our validation is done within clean() method.
-        self.clean()
-
         self.update_etag()
 
         trigger = get_save_trigger(self)

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -735,12 +735,21 @@ class ItemSerializer(NonNullModelSerializer):
         return super().update(instance, validated_data)
 
     def validate(self, attrs):
-        validate_item_properties_datetimes(
-            attrs.get('properties_datetime', None),
-            attrs.get('properties_start_datetime', None),
-            attrs.get('properties_end_datetime', None),
-            partial=self.partial
-        )
+        if (
+            not self.partial or \
+            'properties_datetime' in attrs or \
+            'properties_start_datetime' in attrs or \
+            'properties_end_datetime' in attrs
+        ):
+            validate_item_properties_datetimes(
+                attrs.get('properties_datetime', None),
+                attrs.get('properties_start_datetime', None),
+                attrs.get('properties_end_datetime', None)
+            )
+        else:
+            logger.info(
+                'Skip validation of item properties datetimes; partial update without datetimes'
+            )
 
         validate_json_payload(self)
 

--- a/app/stac_api/validators.py
+++ b/app/stac_api/validators.py
@@ -183,19 +183,16 @@ def validate_item_properties_datetimes_dependencies(
 
 
 def validate_item_properties_datetimes(
-    properties_datetime, properties_start_datetime, properties_end_datetime, partial=False
+    properties_datetime, properties_start_datetime, properties_end_datetime
 ):
     '''
     Validate datetime values in the properties Item attributes
     '''
-    if not partial:
-        # Do not validate dependencies in partial update, leave it to the validation to the model
-        # instance.
-        validate_item_properties_datetimes_dependencies(
-            properties_datetime,
-            properties_start_datetime,
-            properties_end_datetime,
-        )
+    validate_item_properties_datetimes_dependencies(
+        properties_datetime,
+        properties_start_datetime,
+        properties_end_datetime,
+    )
 
 
 def validate_asset_multihash(value):

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -5,8 +5,6 @@ import requests_mock
 from django.conf import settings
 from django.test import Client
 
-from stac_api.models import Collection
-from stac_api.models import Item
 from stac_api.utils import get_link
 
 from tests.base_test import StacBaseTestCase
@@ -132,13 +130,9 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
     def setUpTestData(cls):
         mock_s3_bucket()
         cls.factory = Factory()
-        cls.collection = cls.factory.create_collection_sample().model
-        cls.item = cls.factory.create_item_sample(collection=cls.collection).model
-        cls.asset = cls.factory.create_asset_sample(item=cls.item).model
-
-    def setUp(self):
-        self.collection = Collection.objects.get(name='collection-1')
-        self.item = Item.objects.get(name='item-1')
+        cls.collection = cls.factory.create_collection_sample(name='collection-1').model
+        cls.item = cls.factory.create_item_sample(collection=cls.collection, name='item-1').model
+        cls.asset = cls.factory.create_asset_sample(item=cls.item, name='asset-1').model
 
     def test_get_precondition(self):
         for endpoint in [

--- a/app/tests/test_item_model.py
+++ b/app/tests/test_item_model.py
@@ -25,37 +25,41 @@ class ItemsModelTestCase(TestCase):
         self.collection = Collection.objects.get(name='collection-1')
 
     def test_item_create_model(self):
-        item = Item.objects.create(
+        item = Item(
             collection=self.collection,
             name='item-1',
             properties_datetime=utc_aware(datetime.utcnow())
         )
         item.full_clean()
+        item.save()
         self.assertEqual('item-1', item.name)
 
     def test_item_create_model_invalid_datetime(self):
         with self.assertRaises(ValidationError, msg="no datetime is invalid"):
-            item = Item.objects.create(collection=self.collection, name='item-1')
-            item.clean()
+            item = Item(collection=self.collection, name='item-1')
+            item.full_clean()
+            item.save()
 
         with self.assertRaises(ValidationError, msg="only start_datetime is invalid"):
-            item = Item.objects.create(
+            item = Item(
                 collection=self.collection,
                 name='item-2',
                 properties_start_datetime=utc_aware(datetime.utcnow())
             )
             item.full_clean()
+            item.save()
 
         with self.assertRaises(ValidationError, msg="only end_datetime is invalid"):
-            item = Item.objects.create(
+            item = Item(
                 collection=self.collection,
                 name='item-3',
                 properties_end_datetime=utc_aware(datetime.utcnow())
             )
             item.full_clean()
+            item.save()
 
         with self.assertRaises(ValidationError, msg="datetime is not allowed with start_datetime"):
-            item = Item.objects.create(
+            item = Item(
                 collection=self.collection,
                 name='item-4',
                 properties_datetime=utc_aware(datetime.utcnow()),
@@ -63,36 +67,36 @@ class ItemsModelTestCase(TestCase):
                 properties_end_datetime=utc_aware(datetime.utcnow())
             )
             item.full_clean()
+            item.save()
 
         with self.assertRaises(ValidationError):
-            item = Item.objects.create(
-                collection=self.collection, name='item-1', properties_datetime='asd'
-            )
-
-        with self.assertRaises(ValidationError):
-            item = Item.objects.create(
-                collection=self.collection, name='item-4', properties_start_datetime='asd'
-            )
+            item = Item(collection=self.collection, name='item-1', properties_datetime='asd')
             item.full_clean()
+            item.save()
 
         with self.assertRaises(ValidationError):
-            item = Item.objects.create(
-                collection=self.collection, name='item-1', properties_end_datetime='asd'
-            )
+            item = Item(collection=self.collection, name='item-4', properties_start_datetime='asd')
             item.full_clean()
+            item.save()
+
+        with self.assertRaises(ValidationError):
+            item = Item(collection=self.collection, name='item-1', properties_end_datetime='asd')
+            item.full_clean()
+            item.save()
 
         with self.assertRaises(
             ValidationError, msg="end_datetime must not be earlier than start_datetime"
         ):
             today = datetime.utcnow()
             yesterday = today - timedelta(days=1)
-            item = Item.objects.create(
+            item = Item(
                 collection=self.collection,
                 name='item-5',
                 properties_start_datetime=utc_aware(today),
                 properties_end_datetime=utc_aware(yesterday)
             )
             item.full_clean()
+            item.save()
 
     def test_item_create_model_valid_geometry(self):
         # a correct geometry should not pose any problems
@@ -106,6 +110,7 @@ class ItemsModelTestCase(TestCase):
             )
         )
         item.full_clean()
+        item.save()
 
     def test_item_create_model_invalid_geometry(self):
         # a geometry with self-intersection should not be allowed
@@ -120,6 +125,7 @@ class ItemsModelTestCase(TestCase):
                 )
             )
             item.full_clean()
+            item.save()
 
     def test_item_create_model_empty_geometry(self):
         # empty geometry should not be allowed
@@ -131,6 +137,7 @@ class ItemsModelTestCase(TestCase):
                 geometry=GEOSGeometry('POLYGON EMPTY')
             )
             item.full_clean()
+            item.save()
 
     def test_item_create_model_none_geometry(self):
         # None geometry should not be allowed
@@ -142,3 +149,4 @@ class ItemsModelTestCase(TestCase):
                 geometry=None
             )
             item.full_clean()
+            item.save()


### PR DESCRIPTION
The item properties datetimes were validated twice in a row. This was
unecessary and due to a wrong uses of the django/rest_framework in
unittest. Creating an object with
ModelClass.objects.create(**validated_data) should
only be done with validated data, like for example in the serializer.
This method doesn't do any validation. If we don't have validated data,
then we need to use ModelClass(**unvalidated_data).full_clean().save()

So the item model unittest has been corrected in order to remove the
self.clean() in the item.save() method. This introduce a sligthly
performance improvement, but more important it makes the code cleaner.