### PR TITLE
BGDIINF_SB-1568: Fixed serializer hide_fields and added asset mgmt tests

### DIFF
--- a/app/stac_api/collection_temporal_extent.py
+++ b/app/stac_api/collection_temporal_extent.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 
 
 def update_temporal_extent_on_item_insert(
-    collection, new_start_datetime, new_end_datetime, item_id
+    collection, new_start_datetime, new_end_datetime, item_name
 ):
     '''This function is called from within update_temporal_extent() when a new item is inserted to
     the collection.
@@ -16,8 +16,8 @@ def update_temporal_extent_on_item_insert(
             item's updated value for properties_start_datetime
         new_end_datetime: datetime
             item's updated value for properties_end_datetime
-        item_id: int
-            the id of the item being treated (pk)
+        item_name: string
+            the name of the item being treated
 
     Returns:
         bool: True if temporal extent has been updated, false otherwise
@@ -26,7 +26,7 @@ def update_temporal_extent_on_item_insert(
     logger.debug(
         "Inserting item %s (start_datetime: %s, end_datetime: %s) in "
         "collection %s and updating the collection's temporal extent.",
-        item_id,
+        item_name,
         new_start_datetime,
         new_end_datetime,
         collection.name,
@@ -410,7 +410,7 @@ def update_temporal_extent(
     # INSERT (as item_id is None)
     if action == "insert":
         updated = update_temporal_extent_on_item_insert(
-            collection, new_start_datetime, new_end_datetime, item.pk
+            collection, new_start_datetime, new_end_datetime, item.name
         )
 
     # UPDATE

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -396,12 +396,13 @@ class Collection(models.Model):
 
         logger.debug(
             'Collection update summaries: '
-            'trigger=%s, asset=%s, old_values=%s, current_summaries=%s',
+            'trigger=%s, asset=%s, old_values=%s, new_values=%s, current_summaries=%s',
             trigger,
             asset,
             old_values,
+            [asset.eo_gsd, asset.geoadmin_variant, asset.proj_epsg],
             self.summaries,
-            extra={'collection': self.name}
+            extra={'collection': self.name},
         )
 
         if trigger == 'delete':

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -161,3 +161,31 @@ def get_sha256_multihash(content):
     '''
     digest = hashlib.sha256(content).digest()
     return multihash.to_hex_string(multihash.encode(digest, 'sha2-256'))
+
+
+def create_multihash(digest, hash_type):
+    '''Returns a multihash from a digest
+
+    Args:
+        digest: string
+        hash_type: string
+            hash type (sha2-256, md5, ...)
+
+    Returns: multihash
+        multihash
+    '''
+    return multihash.decode(multihash.encode(multihash.from_hex_string(digest), hash_type))
+
+
+def create_multihash_string(digest, hash_code):
+    '''Returns a multihash string from a digest
+
+    Args:
+        digest: string
+        hash_code: string | int
+            hash code (sha2-256, md5, ...)
+
+    Returns: string
+        multihash string
+    '''
+    return multihash.to_hex_string(multihash.encode(digest, hash_code))

--- a/app/stac_api/views_mixins.py
+++ b/app/stac_api/views_mixins.py
@@ -59,9 +59,13 @@ class UpdateModelMixin:
 
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
+        hide_fields = kwargs.pop('hide_fields', [])
+        serializer_kwargs = {'partial': partial}
+        if hide_fields:
+            serializer_kwargs['hide_fields'] = hide_fields
         instance = self.get_object()
         data = self.get_write_request_data(request, partial=partial, *args, **kwargs)
-        serializer = self.get_serializer(instance, data=data, partial=partial)
+        serializer = self.get_serializer(instance, data=data, **serializer_kwargs)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 

--- a/app/tests/data_factory.py
+++ b/app/tests/data_factory.py
@@ -132,12 +132,14 @@ class SampleData:
         # Sets attributes from sample
         for key, value in sample.items():
             setattr(self, f'attr_{key}', value)
-        # overwrite sample data with kwargs
-        for key, value in kwargs.items():
-            setattr(self, f'attr_{key}', value)
 
         if required_only:
+            # remove optional fields
             self._filter_optional(self.optional_fields)
+
+        # overwrite/add sample data with kwargs
+        for key, value in kwargs.items():
+            setattr(self, f'attr_{key}', value)
 
         self.model_instance = None
 

--- a/app/tests/data_factory.py
+++ b/app/tests/data_factory.py
@@ -604,7 +604,14 @@ class AssetSample(SampleData):
         'checksum_multihash': 'checksum:multihash'
     }
     optional_fields = [
-        'title', 'description', 'eo_gsd', 'geoadmin_variant', 'geoadmin_lang', 'proj_epsg', 'file'
+        'title',
+        'description',
+        'eo_gsd',
+        'geoadmin_variant',
+        'geoadmin_lang',
+        'proj_epsg',
+        'file',
+        'checksum_multihash'
     ]
 
     def __init__(self, item, sample='asset-1', name=None, required_only=False, **kwargs):

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -112,7 +112,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(path, data=asset.json, content_type="application/json")
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(201, response)
         self.check_header_location(f"{path}/{asset['name']}", response)
@@ -131,7 +133,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(path, data=asset.json, content_type="application/json")
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(201, response)
         self.check_header_location(f"{path}/{asset['name']}", response)
@@ -150,7 +154,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(path, data=asset.json, content_type="application/json")
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         # Make sure that the asset is not found in DB
@@ -168,7 +174,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(path, data=asset.json, content_type="application/json")
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         # Make sure that the asset is not found in DB
@@ -184,7 +192,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(path, data=asset.json, content_type="application/json")
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         # Make sure that the asset is not found in DB
@@ -210,7 +220,8 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
     def test_asset_put_dont_exists(self, requests_mocker):
         collection_name = self.collection.name
         item_name = self.item.name
-        payload_json = self.factory.create_asset_sample(item=self.item, sample='asset-2').json
+        payload_json = self.factory.create_asset_sample(item=self.item,
+                                                        sample='asset-2').get_json('put')
 
         # the dataset to update does not exist yet
         path = \
@@ -231,7 +242,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.put(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.check_stac_asset(changed_asset.json, json_data, ignore=['item'])
@@ -256,7 +269,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.put(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_asset_endpoint_put_read_only_in_payload(self, requests_mocker):
@@ -273,7 +288,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.put(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_asset_endpoint_put_rename_asset(self, requests_mocker):
@@ -290,7 +307,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.put(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
         self.assertStatusCode(200, response)
         json_data = response.json()
         self.assertEqual(changed_asset.json['id'], json_data['id'])
@@ -315,7 +334,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.patch(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.patch(
+            path, data=changed_asset.get_json('patch'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(changed_asset.json['id'], json_data['id'])
@@ -340,7 +361,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.patch(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.patch(
+            path, data=changed_asset.get_json('patch'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_asset_endpoint_patch_read_only_in_payload(self, requests_mocker):
@@ -356,7 +379,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         mock_requests_asset_file(requests_mocker, changed_asset)
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.patch(path, data=changed_asset.json, content_type="application/json")
+        response = self.client.patch(
+            path, data=changed_asset.get_json('patch'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
 
@@ -419,7 +444,7 @@ class AssetsEndpointUnauthorizedTestCase(StacBaseTestCase):
         new_asset = self.factory.create_asset_sample(item=self.item).json
         updated_asset = self.factory.create_asset_sample(
             item=self.item, name=asset_name, sample='asset-1-updated'
-        ).json
+        ).get_json('post')
 
         # make sure POST fails for anonymous user:
         path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -4,6 +4,7 @@ from json import dumps
 from json import loads
 from pprint import pformat
 
+import requests
 import requests_mock
 
 from django.conf import settings
@@ -12,6 +13,7 @@ from django.test import Client
 from stac_api.models import Asset
 from stac_api.serializers import AssetSerializer
 from stac_api.utils import fromisoformat
+from stac_api.utils import get_sha256_multihash
 from stac_api.utils import utc_aware
 
 from tests.base_test import StacBaseTestCase
@@ -201,6 +203,194 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
         self.assertFalse(
             Asset.objects.filter(name=asset.json['id']).exists(),
             msg="Invalid asset has been created in DB"
+        )
+
+
+@requests_mock.Mocker(kw='requests_mocker')
+class AssetsWriteEndpointAssetFileTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.item = self.factory.create_item_sample(collection=self.collection).model
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_endpoint_post_asset_file_dont_exists(self, requests_mocker):
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset = self.factory.create_asset_sample(item=self.item)
+
+        mock_requests_asset_file(
+            requests_mocker, asset, headers={'x-amz-meta-sha256': None}, status_code=404
+        )
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Asset doesn't exists at href", description['href'][0], msg="Unexpected error message"
+        )
+
+        # Make sure that the asset is not found in DB
+        self.assertFalse(
+            Asset.objects.filter(name=asset.json['id']).exists(),
+            msg="Invalid asset has been created in DB"
+        )
+
+    def test_asset_endpoint_post_s3_not_answering(self, requests_mocker):
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset = self.factory.create_asset_sample(item=self.item)
+
+        mock_requests_asset_file(requests_mocker, asset, exc=requests.exceptions.ConnectTimeout)
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "href location not responding", description['href'][0], msg="Unexpected error message"
+        )
+
+        # Make sure that the asset is not found in DB
+        self.assertFalse(
+            Asset.objects.filter(name=asset.json['id']).exists(),
+            msg="Invalid asset has been created in DB"
+        )
+
+    def test_asset_endpoint_post_s3_without_sha256(self, requests_mocker):
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset = self.factory.create_asset_sample(item=self.item)
+
+        mock_requests_asset_file(requests_mocker, asset, headers={'x-amz-meta-sha256': None})
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
+        self.assertStatusCode(500, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Asset at href http://testserver/collection-1/item-1/asset-1 doesn't provide a valid "
+            "checksum header (ETag or x-amz-meta-sha256) for validation",
+            description['href'],
+            msg="Unexpected error message"
+        )
+
+        # Make sure that the asset is not found in DB
+        self.assertFalse(
+            Asset.objects.filter(name=asset.json['id']).exists(),
+            msg="Invalid asset has been created in DB"
+        )
+
+    def test_asset_endpoint_post_wrong_checksum(self, requests_mocker):
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset = self.factory.create_asset_sample(item=self.item)
+
+        mock_requests_asset_file(
+            requests_mocker, asset, headers={'x-amz-meta-sha256': get_sha256_multihash(b'')[4:]}
+        )
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets'
+        response = self.client.post(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('non_field_errors', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Asset at href http://testserver/collection-1/item-1/asset-1 with sha2-256 hash "
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 don't match expected "
+            "hash a7f5e7ca03b0f80a2fcfe5142642377e7654df2dfa736fe4d925322d8a651efe",
+            description['non_field_errors'][0],
+            msg="Unexpected error message"
+        )
+
+        # Make sure that the asset is not found in DB
+        self.assertFalse(
+            Asset.objects.filter(name=asset.json['id']).exists(),
+            msg="Invalid asset has been created in DB"
+        )
+
+
+@requests_mock.Mocker(kw='requests_mocker')
+class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.item = self.factory.create_item_sample(collection=self.collection).model
+        self.asset = self.factory.create_asset_sample(item=self.item).model
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_endpoint_patch_checksum(self, requests_mocker):
+        new_multihash = get_sha256_multihash(b'New file content')
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset_name = self.asset.name
+        asset_sample = self.factory.create_asset_sample(
+            item=self.item, name=asset_name, required_only=True, checksum_multihash=new_multihash
+        )
+
+        patch_payload = {'checksum:multihash': new_multihash}
+
+        mock_requests_asset_file(requests_mocker, asset_sample)
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
+        response = self.client.patch(path, data=patch_payload, content_type="application/json")
+        self.assertStatusCode(200, response)
+        json_data = response.json()
+        self.check_stac_asset(asset_sample.json, json_data, ignore=['item'])
+
+        # Check the data by reading it back
+        response = self.client.get(path)
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        self.check_stac_asset(asset_sample.json, json_data, ignore=['item'])
+
+    def test_asset_endpoint_patch_put_href(self, requests_mocker):
+        collection_name = self.collection.name
+        item_name = self.item.name
+        asset_name = self.asset.name
+        asset_sample = self.factory.create_asset_sample(
+            item=self.item, name=asset_name, required_only=True, href='https://www.google.com'
+        )
+
+        patch_payload = {'href': 'https://www.google.com'}
+
+        mock_requests_asset_file(requests_mocker, asset_sample)
+        path = f'/{API_BASE}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
+        response = self.client.patch(path, data=patch_payload, content_type="application/json")
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Unexpected property in payload",
+            description['href'][0],
+            msg="Unexpected error message"
+        )
+
+        response = self.client.put(
+            path, data=asset_sample.get_json('put'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Unexpected property in payload",
+            description['href'][0],
+            msg="Unexpected error message"
         )
 
 

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -252,51 +252,57 @@ class ItemsWriteEndpointTestCase(StacBaseTestCase):
         client_login(self.client)
 
     def test_item_endpoint_post_only_required(self):
-        data = self.factory.create_item_sample(self.collection, required_only=True).json
+        sample = self.factory.create_item_sample(self.collection, required_only=True)
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
-        response = self.client.post(path, data=data, content_type="application/json")
+        response = self.client.post(
+            path, data=sample.get_json('post'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(201, response)
-        self.check_header_location(f'{path}/{data["id"]}', response)
+        self.check_header_location(f'{path}/{sample.json["id"]}', response)
 
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
         # Check the data by reading it back
         response = self.client.get(response['Location'])
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
     def test_item_endpoint_post_extra_payload(self):
-        data = self.factory.create_item_sample(self.collection, extra_payload=True).json
+        data = self.factory.create_item_sample(self.collection, extra_payload=True).get_json('post')
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_post_read_only_in_payload(self):
-        data = self.factory.create_item_sample(self.collection, created=datetime.today()).json
+        data = self.factory.create_item_sample(self.collection,
+                                               created=datetime.today()).get_json('post')
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_post_full(self):
-        data = self.factory.create_item_sample(self.collection).json
+        sample = self.factory.create_item_sample(self.collection)
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
-        response = self.client.post(path, data=data, content_type="application/json")
+        response = self.client.post(
+            path, data=sample.get_json('post'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(201, response)
-        self.check_header_location(f'{path}/{data["id"]}', response)
+        self.check_header_location(f'{path}/{sample.json["id"]}', response)
 
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
         # Check the data by reading it back
         response = self.client.get(response['Location'])
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
     def test_item_endpoint_post_invalid_data(self):
-        data = self.factory.create_item_sample(self.collection, sample='item-invalid').json
+        data = self.factory.create_item_sample(self.collection,
+                                               sample='item-invalid').get_json('post')
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
@@ -313,7 +319,7 @@ class ItemsWriteEndpointTestCase(StacBaseTestCase):
             properties_datetime=None,
             properties_start_datetime=None,
             properties_end_datetime=None
-        ).json
+        ).get_json('post')
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
         response = self.client.post(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
@@ -338,39 +344,43 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         client_login(self.client)
 
     def test_item_endpoint_put(self):
-        data = self.factory.create_item_sample(
+        sample = self.factory.create_item_sample(
             self.collection, sample='item-2', name=self.item.name
-        ).json
+        )
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path, data=sample.get_json('put'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
         # Check the data by reading it back
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
     def test_item_endpoint_put_extra_payload(self):
-        data = self.factory.create_item_sample(
+        sample = self.factory.create_item_sample(
             self.collection, sample='item-2', name=self.item.name, extra_payload='invalid'
-        ).json
+        )
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path, data=sample.get_json('put'), content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_put_read_only_in_payload(self):
         data = self.factory.create_item_sample(
             self.collection, sample='item-2', name=self.item.name, created=datetime.now()
-        ).json
+        ).get_json('put')
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
         response = self.client.put(path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_put_update_to_datetime_range(self):
-        data = self.factory.create_item_sample(
+        sample = self.factory.create_item_sample(
             self.collection,
             sample='item-2',
             name=self.item.name,
@@ -378,44 +388,48 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
                 "start_datetime": "2020-10-18T00:00:00Z",
                 "end_datetime": "2020-10-19T00:00:00Z",
             }
-        ).json
+        )
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path, data=sample.get_json('put'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
 
         # Check the data by reading it back
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(sample.json, json_data)
         self.assertNotIn('datetime', json_data['properties'].keys())
         self.assertNotIn('title', json_data['properties'].keys())
 
     def test_item_endpoint_put_rename_item(self):
-        data = self.factory.create_item_sample(
+        sample = self.factory.create_item_sample(
             self.collection,
             sample='item-2',
             name=f'new-{self.item.name}',
-        ).json
+        )
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path, data=sample.get_json('put'), content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.assertEqual(data['id'], json_data['id'])
-        self.check_stac_item(data, json_data)
+        self.assertEqual(sample.json['id'], json_data['id'])
+        self.check_stac_item(sample.json, json_data)
 
         response = self.client.get(path)
         self.assertStatusCode(404, response, msg="Renamed item still available on old name")
 
         # Check the data by reading it back
-        path = f'/{API_BASE}/collections/{self.collection.name}/items/{data["id"]}'
+        path = f'/{API_BASE}/collections/{self.collection.name}/items/{sample.json["id"]}'
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.assertEqual(data['id'], json_data['id'])
-        self.check_stac_item(data, json_data)
+        self.assertEqual(sample.json['id'], json_data['id'])
+        self.check_stac_item(sample.json, json_data)
 
     def test_item_endpoint_patch(self):
         data = {"properties": {"title": "patched title"}}
@@ -521,15 +535,19 @@ class ItemsUnauthorizeEndpointTestCase(StacBaseTestCase):
 
     def test_unauthorized_item_post_put_patch_delete(self):
         # make sure POST fails for anonymous user:
-        data = self.factory.create_item_sample(self.collection).json
+        sample = self.factory.create_item_sample(self.collection)
         path = f'/{API_BASE}/collections/{self.collection.name}/items'
-        response = self.client.post(path, data=data, content_type="application/json")
+        response = self.client.post(
+            path, data=sample.get_json('post'), content_type="application/json"
+        )
         self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
 
         # make sure PUT fails for anonymous user:
-        data = self.factory.create_item_sample(self.collection, name=self.item.name).json
+        sample = self.factory.create_item_sample(self.collection, name=self.item.name)
         path = f'/{API_BASE}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path, data=sample.get_json('put'), content_type="application/json"
+        )
         self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
 
         # make sure PATCH fails for anonymous user:

--- a/app/tests/utils.py
+++ b/app/tests/utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from stac_api.utils import get_s3_resource
+from stac_api.utils import get_sha256_multihash
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +109,9 @@ def mock_requests_asset_file(mocker, asset):
     '''
     mocker.head(
         f'http://{settings.AWS_S3_CUSTOM_DOMAIN}/{asset["item"].collection.name}/{asset["item"].name}/{asset["name"]}',
-        headers={'x-amz-meta-sha256': asset.get("checksum_multihash", '0000')[4:]}
+        headers={
+            'x-amz-meta-sha256': asset.get("checksum_multihash", get_sha256_multihash(b''))[4:]
+        }
     )
 
 


### PR DESCRIPTION
The serializer hide_fields did not work for the asset put/patch
endpoints because the parameter was not passed in the view mixins. This
has been fixed.

In data_factory, allow to use extra attribute with the
required_only=True. This way we can retrieve the minimal attributes plus
an extra.

Completed the asset endpoint unittest to test the asset management. What
still missing is testing the asset managment on S3 (uploading/moving/deleting
asset) because S3 is currently mocked in unittest.