### PR TITLE
BGDIINF_SB-1537: Harmonized Assets view with Item and Collections

### DIFF
--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -687,11 +687,14 @@ class ItemSerializer(NonNullModelSerializer):
     geometry = gis_serializers.GeometryField(required=True)
     links = ItemLinkSerializer(required=False, many=True)
     # read only fields
-    type = serializers.ReadOnlyField(default='Feature')
+    type = serializers.SerializerMethodField()
     bbox = BboxSerializer(source='*', read_only=True)
     assets = AssetSerializer(many=True, read_only=True)
     stac_extensions = serializers.SerializerMethodField()
     stac_version = serializers.SerializerMethodField()
+
+    def get_type(self, obj):
+        return 'Feature'
 
     def get_stac_extensions(self, obj):
         return list()

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -18,9 +18,9 @@ from . import views
 API_BASE = settings.API_BASE
 
 urlpatterns = [
+    path('checker', views.checker, name='checker'),
     path(f'{API_BASE}/', LandingPageDetail.as_view(), name='landing-page'),
     path(f'{API_BASE}/conformance', ConformancePageDetail.as_view(), name='conformance'),
-    path('checker/', views.checker, name='checker'),
     path(f"{API_BASE}/collections", CollectionList.as_view(), name='collection-list'),
     path(
         f"{API_BASE}/collections/<collection_name>",

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -640,7 +640,31 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
         else:
             serializer = self.get_serializer(queryset, many=True)
 
-        data = serializer.data
+        data = {
+            'assets': serializer.data,
+            'links': [
+                OrderedDict([
+                    ('rel', 'self'),
+                    ('href', request.build_absolute_uri()),
+                ]),
+                OrderedDict([
+                    ('rel', 'root'),
+                    ('href', request.build_absolute_uri(f'/{settings.API_BASE}/')),
+                ]),
+                OrderedDict([
+                    ('rel', 'parent'),
+                    ('href', request.build_absolute_uri('.').rstrip('/')),
+                ]),
+                OrderedDict([
+                    ('rel', 'item'),
+                    ('href', request.build_absolute_uri('.').rstrip('/')),
+                ]),
+                OrderedDict([
+                    ('rel', 'collection'),
+                    ('href', request.build_absolute_uri('../..').rstrip('/')),
+                ])
+            ]
+        }
 
         if page is not None:
             return self.get_paginated_response(data)

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -15,6 +15,9 @@ from tests.utils import get_http_error_description
 
 logger = logging.getLogger(__name__)
 
+TEST_LINK_ROOT_HREF = 'http://testserver/api/stac/v0.9'
+TEST_LINK_ROOT = {'rel': 'root', 'href': f'{TEST_LINK_ROOT_HREF}/'}
+
 
 class StacBaseTestCase(TestCase):
 
@@ -111,8 +114,35 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('collection', expected, current, ignore)
+        for key, value in [
+            ('stac_version', '0.9.0'),
+            ('crs', ['http://www.opengis.net/def/crs/OGC/1.3/CRS84']),
+            ('itemType', 'Feature')
+        ]:
+            self.assertIn(key, current)
+            self.assertEqual(value, current[key])
+        self.assertIn('extent', current, msg='Collection extent are missing')
+        self.assertIn('summaries', current, msg='Collection summaries are missing')
+        self.assertIn('links', current, msg='Collection links are missing')
+        name = current['id']
+        links = [
+            {
+                'rel': 'self',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{name}',
+            },
+            TEST_LINK_ROOT,
+            {
+                'rel': 'parent',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections',
+            },
+            {
+                'rel': 'items',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{name}/items',
+            },
+        ]
+        self._check_stac_links('item.links', links, current['links'])
 
-    def check_stac_item(self, expected, current, ignore=None):
+    def check_stac_item(self, expected, current, collection, ignore=None):
         '''Check a STAC Item data
 
         Check if the `current` Item data match the `expected`. This check is a subset check
@@ -131,8 +161,30 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('item', expected, current, ignore=ignore)
+        for key, value in [('stac_version', '0.9.0'), ('type', 'Feature')]:
+            self.assertIn(key, current)
+            self.assertEqual(value, current[key])
+        self.assertIn('bbox', current, msg='Item bbox are missing')
+        self.assertIn('links', current, msg='Item links are missing')
+        name = current['id']
+        links = [
+            {
+                'rel': 'self',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{name}',
+            },
+            TEST_LINK_ROOT,
+            {
+                'rel': 'parent',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items',
+            },
+            {
+                'rel': 'collection',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
+            },
+        ]
+        self._check_stac_links('item.links', links, current['links'])
 
-    def check_stac_asset(self, expected, current, ignore=None):
+    def check_stac_asset(self, expected, current, collection, item, ignore=None):
         '''Check a STAC Asset data
 
         Check if the `current` Asset data match the `expected`. This check is a subset check
@@ -151,6 +203,28 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('asset', expected, current, ignore=ignore)
+        self.assertIn('links', current, msg='Asset links are missing')
+        name = current['id']
+        links = [
+            {
+                'rel': 'self',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets/{name}'
+            },
+            TEST_LINK_ROOT,
+            {
+                'rel': 'parent',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets',
+            },
+            {
+                'rel': 'item',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}',
+            },
+            {
+                'rel': 'collection',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
+            },
+        ]
+        self._check_stac_links('asset.links', links, current['links'])
 
     def _check_stac_dictsubset(self, parent_path, expected, current, ignore=None):
         for key, value in expected.items():
@@ -193,7 +267,9 @@ class StacBaseTestCase(TestCase):
         for i, link in enumerate(expected):
             path = f'{parent_path}.{i}'
             current_link = get_link(current, link['rel'])
-            self.assertIsNotNone(current_link, msg=f'{path}: Link {link} is missing in current')
+            self.assertIsNotNone(
+                current_link, msg=f'{path}: Link {link} is missing in current links {current}'
+            )
             for key, value in link.items():
                 self.assertIn(
                     key, current_link, msg=f'key {key} is missing in current link {current_link}'

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -121,9 +121,13 @@ class StacBaseTestCase(TestCase):
         ]:
             self.assertIn(key, current)
             self.assertEqual(value, current[key])
-        self.assertIn('extent', current, msg='Collection extent are missing')
-        self.assertIn('summaries', current, msg='Collection summaries are missing')
-        self.assertIn('links', current, msg='Collection links are missing')
+        for key in ['extent', 'summaries', 'links', 'created', 'updated']:
+            self.assertIn(key, current, msg=f'Collection {key} is missing')
+        for date_field in ['created', 'updated']:
+            self.assertTrue(
+                fromisoformat(current[date_field]),
+                msg=f"The collection field {date_field} has an invalid date"
+            )
         name = current['id']
         links = [
             {
@@ -164,8 +168,16 @@ class StacBaseTestCase(TestCase):
         for key, value in [('stac_version', '0.9.0'), ('type', 'Feature')]:
             self.assertIn(key, current)
             self.assertEqual(value, current[key])
-        self.assertIn('bbox', current, msg='Item bbox are missing')
-        self.assertIn('links', current, msg='Item links are missing')
+        for key in ['bbox', 'links', 'properties']:
+            self.assertIn(key, current, msg=f'Item {key} is missing')
+        for key in ['created', 'updated']:
+            self.assertIn(key, current['properties'], msg=f'Item properties.{key} is missing')
+        for date_field in ['created', 'updated']:
+            self.assertTrue(
+                fromisoformat(current['properties'][date_field]),
+                msg=f"The item field {date_field} has an invalid date"
+            )
+
         name = current['id']
         links = [
             {
@@ -203,7 +215,13 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('asset', expected, current, ignore=ignore)
-        self.assertIn('links', current, msg='Asset links are missing')
+        for key in ['links', 'created', 'updated']:
+            self.assertIn(key, current, msg=f'Asset {key} is missing')
+        for date_field in ['created', 'updated']:
+            self.assertTrue(
+                fromisoformat(current[date_field]),
+                msg=f"The asset field {date_field} has an invalid date"
+            )
         name = current['id']
         links = [
             {

--- a/app/tests/data_factory.py
+++ b/app/tests/data_factory.py
@@ -81,7 +81,7 @@ or the `sample.get_json()` method or `sample.json` property (alias for
    stac_api.serializer.ItemSerializer(data=sample.get_json(method='deserialize'))
 
    response = client.get(path_to_item)
-   self.check_stac_item(sample.json, response.json())
+   self.check_stac_item(sample.json, response.json(), 'collection-1')
 
 '''
 # pylint: disable=too-many-lines, arguments-differ

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -80,14 +80,6 @@ class AssetsEndpointTestCase(StacBaseTestCase):
         # hash computation of the ETag
         self.check_header_etag(None, response)
 
-        # # created and updated must exist and be a valid date
-        # date_fields = ['created', 'updated']
-        # for date_field in date_fields:
-        #     self.assertTrue(
-        #         fromisoformat(json_data[date_field]),
-        #         msg=f"The field {date_field} has an invalid date"
-        #     )
-
 
 @requests_mock.Mocker(kw='requests_mocker')
 class AssetsWriteEndpointTestCase(StacBaseTestCase):

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -40,8 +40,8 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
 
         self.assertEqual(len(json_data['features']), 2, msg='Output should only have two features')
 
-        self.check_stac_item(self.items[0].json, json_data['features'][0])
-        self.check_stac_item(self.items[1].json, json_data['features'][1])
+        self.check_stac_item(self.items[0].json, json_data['features'][0], self.collection.name)
+        self.check_stac_item(self.items[1].json, json_data['features'][1], self.collection.name)
 
     def test_items_endpoint_with_limit(self):
         response = self.client.get(f"/{API_BASE}/collections/{self.collection.name}/items?limit=1")
@@ -53,7 +53,7 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
 
         self.assertEqual(len(json_data['features']), 1, msg='Output should only have one feature')
 
-        self.check_stac_item(self.items[0].json, json_data['features'][0])
+        self.check_stac_item(self.items[0].json, json_data['features'][0], self.collection.name)
 
     def test_single_item_endpoint(self):
         collection_name = self.collection.name
@@ -66,7 +66,7 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
         # hash computation of the ETag
         self.check_header_etag(None, response)
 
-        self.check_stac_item(self.items[0].json, json_data)
+        self.check_stac_item(self.items[0].json, json_data, self.collection.name)
 
         # created and updated must exist and be a valid date
         date_fields = ['created', 'updated']
@@ -430,13 +430,13 @@ class ItemsWriteEndpointTestCase(StacBaseTestCase):
         self.assertStatusCode(201, response)
         self.check_header_location(f'{path}/{sample.json["id"]}', response)
 
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
         # Check the data by reading it back
         response = self.client.get(response['Location'])
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
     def test_item_endpoint_post_extra_payload(self):
         data = self.factory.create_item_sample(self.collection, extra_payload=True).get_json('post')
@@ -461,13 +461,13 @@ class ItemsWriteEndpointTestCase(StacBaseTestCase):
         self.assertStatusCode(201, response)
         self.check_header_location(f'{path}/{sample.json["id"]}', response)
 
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
         # Check the data by reading it back
         response = self.client.get(response['Location'])
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
     def test_item_endpoint_post_invalid_data(self):
         data = self.factory.create_item_sample(self.collection,
@@ -522,13 +522,13 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
         # Check the data by reading it back
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
     def test_item_endpoint_put_extra_payload(self):
         sample = self.factory.create_item_sample(
@@ -564,13 +564,13 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
         # Check the data by reading it back
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
         self.assertNotIn('datetime', json_data['properties'].keys())
         self.assertNotIn('title', json_data['properties'].keys())
 
@@ -587,7 +587,7 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(sample.json['id'], json_data['id'])
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
         response = self.client.get(path)
         self.assertStatusCode(404, response, msg="Renamed item still available on old name")
@@ -598,7 +598,7 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(sample.json['id'], json_data['id'])
-        self.check_stac_item(sample.json, json_data)
+        self.check_stac_item(sample.json, json_data, self.collection.name)
 
     def test_item_endpoint_patch(self):
         data = {"properties": {"title": "patched title"}}
@@ -607,14 +607,14 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(self.item.name, json_data['id'])
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(data, json_data, self.collection.name)
 
         # Check the data by reading it back
         response = self.client.get(path)
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(self.item.name, json_data['id'])
-        self.check_stac_item(data, json_data)
+        self.check_stac_item(data, json_data, self.collection.name)
 
     def test_item_endpoint_patch_extra_payload(self):
         data = {"crazy:stuff": "not allowed"}
@@ -647,6 +647,7 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(data['id'], json_data['id'])
+        self.check_stac_item(data, json_data, self.collection.name)
 
         response = self.client.get(path)
         self.assertStatusCode(404, response, msg="Renamed item still available on old name")

--- a/app/tests/test_sampledata.py
+++ b/app/tests/test_sampledata.py
@@ -72,4 +72,4 @@ class SampleDataTestCase(StacBaseTestCase):
 
         # we ignore the created and updated attribute because they cannot match the one from the
         # samples as they are automatically generated with the time of creation/update.
-        self.check_stac_item(item_dict, payload, ignore=['created', 'updated'])
+        self.check_stac_item(item_dict, payload, collection_name, ignore=['created', 'updated'])

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -646,13 +646,13 @@ components:
             example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
             format: url
             type: string
-          roles:
-            description: Purposes of the asset
-            example:
-              - thumbnail
-            items:
-              type: string
-            type: array
+          # roles:
+          #   description: Purposes of the asset
+          #   example:
+          #     - thumbnail
+          #   items:
+          #     type: string
+          #   type: array
           title:
             description: Displayed title
             example: Thumbnail
@@ -675,7 +675,6 @@ components:
           - type
           - created
           - updated
-          - id
         type: object
       type: object
       readOnly: true

--- a/spec/static/openapi.yaml
+++ b/spec/static/openapi.yaml
@@ -992,13 +992,6 @@ components:
             example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
             format: url
             type: string
-          roles:
-            description: Purposes of the asset
-            example:
-            - thumbnail
-            items:
-              type: string
-            type: array
           title:
             description: Displayed title
             example: Thumbnail
@@ -1021,7 +1014,6 @@ components:
         - type
         - created
         - updated
-        - id
         type: object
       type: object
       readOnly: true

--- a/spec/static/openapitransactional.yaml
+++ b/spec/static/openapitransactional.yaml
@@ -508,7 +508,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/itemAssets"
+            $ref: "#/components/schemas/assets"
     Asset:
       description: >-
         The response is a document consisting of one asset of the feature.
@@ -1134,13 +1134,6 @@ components:
             example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
             format: url
             type: string
-          roles:
-            description: Purposes of the asset
-            example:
-            - thumbnail
-            items:
-              type: string
-            type: array
           title:
             description: Displayed title
             example: Thumbnail
@@ -1163,9 +1156,7 @@ components:
         - type
         - created
         - updated
-        - id
         type: object
-        $ref: "#/components/schemas/itemAsset"
       type: object
       readOnly: true
       example:
@@ -1756,12 +1747,36 @@ components:
         When the `id` doesn't match the parameter `assetId`, the asset is renamed,
         renaming also the object itself on S3.
       example: smr50-263-2016-2056-kgrs-2.5.tiff
+    assets:
+      type: object
+      properties:
+        assets:
+          items:
+            $ref: "#/components/schemas/itemAsset"
+          type: array
+        links:
+          items:
+            $ref: "#/components/schemas/link"
+          type: array
+          example:
+          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            rel: self
+          - href: https://data.geo.admin.ch/api/stac/v0.9/
+            rel: root
+          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            rel: parent
+          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            rel: item
+          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            rel: collection
     assetBase:
       type: object
       required:
       - created
       - updated
       properties:
+        id:
+          $ref: "#/components/schemas/assetId"
         title:
           $ref: "#/components/schemas/title"
         description:
@@ -1789,11 +1804,27 @@ components:
         - type
         - href
         - checksum:multihash
+        - links
         properties:
           checksum:multihash:
             $ref: "#/components/schemas/checksum:multihash"
           href:
             $ref: "#/components/schemas/href"
+          links:
+            items:
+              $ref: "#/components/schemas/link"
+            type: array
+            example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: item
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     itemAssetWrite:
       allOf:
       - $ref: "#/components/schemas/assetBase"
@@ -1802,8 +1833,6 @@ components:
         - id
         - type
         properties:
-          id:
-            $ref: "#/components/schemas/assetId"
           checksum:multihash:
             $ref: "#/components/schemas/writeChecksumMultihash"
     itemAssetUpdate:

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -662,16 +662,36 @@ components:
         filename. When the `id` doesn't match the parameter `assetId`, the asset is renamed,
         renaming also the object itself on S3.
       example: smr50-263-2016-2056-kgrs-2.5.tiff
-    itemAssets:
+    assets:
       type: object
-      additionalProperties:
-        $ref: "#/components/schemas/itemAsset"
+      properties:
+        assets:
+          items:
+            $ref: "#/components/schemas/itemAsset"
+          type: array
+        links:
+          items:
+            $ref: "#/components/schemas/link"
+          type: array
+          example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: item
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     assetBase:
       type: object
       required:
         - created
         - updated
       properties:
+        id:
+          $ref: "#/components/schemas/assetId"
         title:
           $ref: "#/components/schemas/title"
         description:
@@ -702,11 +722,27 @@ components:
             - type
             - href
             - checksum:multihash
+            - links
           properties:
             "checksum:multihash":
               $ref: "#/components/schemas/checksum:multihash"
             href:
               $ref: "#/components/schemas/href"
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+                  rel: item
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
     itemAssetWrite:
       allOf:
         - $ref: "#/components/schemas/assetBase"
@@ -715,8 +751,6 @@ components:
             - id
             - type
           properties:
-            id:
-              $ref: "#/components/schemas/assetId"
             "checksum:multihash":
               $ref: "#/components/schemas/writeChecksumMultihash"
             # href:
@@ -913,7 +947,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/itemAssets"
+            $ref: "#/components/schemas/assets"
     Asset:
       description: >-
         The response is a document consisting of one asset of the feature.


### PR DESCRIPTION
Now the Asset views have the same schema as the items and collections.
This adds the links attribute to the asset view.

Note the the assets that are nested in Item view, are not touched.

Also fixed a bug in the PATCH item answer were the 'type' attribute was missing.

This PR code is currently deployed on DEV and can be tested: https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk200.noscale/items/smr200-200-2-2016/assets