### PR TITLE
 BGDIINF_SB-1571: Sets appropriate cache headers in GET and HEAD responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ lint:
 test:
 	# Collect static first to avoid warning in the test
 	$(PYTHON) $(DJANGO_MANAGER) collectstatic --noinput
-	$(PYTHON) $(DJANGO_MANAGER) test --verbosity=2 --parallel 8 $(TEST_DIR)
+	$(PYTHON) $(DJANGO_MANAGER) test --verbosity=2 --parallel 20 $(TEST_DIR)
 
 
 ###################

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [Linting and formatting your work](#linting-and-formatting-your-work)
 - [Deploying the project and continuous integration](#deploying-the-project-and-continuous-integration)
 - [Docker](#docker)
-- [Deployment configuration](#deployment-configuration)
+- [Configuration](#configuration)
 
 ## Summary of the project
 
@@ -39,7 +39,7 @@ The other services that are used (Postgres with PostGIS extension for metadata a
 
 Starting postgres and MinIO is done with a simple
 
-```
+```bash
 docker-compose up
 ```
 
@@ -51,7 +51,6 @@ If you want to use a local postgres instance instead of the dockerised one you n
 
 - a local postgres (>= 12.0) running
 - postgis extension installed (>= 3.0)
-
 
 Create a new superuser (required to create/destroy the test-databases) and a new database.
 
@@ -154,9 +153,11 @@ DISABLE_LOGGING=1 ./manage.py shell
 **NOTE:** the environment variable can also be set in the `.venv.local` file.
 
 #### Migrate DB with Django shell
+
 With the Django shell ist is possible to migrate the state of the database according to the code base. Please consider following principles:
 
 In general, the code base to setup the according state of the database ist stored here:
+
 ```bash
 stac_api/migrations/
 ├── 0001_initial.py
@@ -164,17 +165,22 @@ stac_api/migrations/
 ├── 0003_auto_20201022_1346.py
 ├── 0004_auto_20201028.py
 ```
+
 Please make sure, that per PR only one migrations script gets generated (_if possible_).
 
 **How to generate a db migrations script?**
+
 1. First of all this will only happen, when a model has changed
-2. Following command will generate a new migration script:
-   ```bash
-   ./manage.py makemigrations
-   ```
+1. Following command will generate a new migration script:
+
+    ```bash
+    ./manage.py makemigrations
+    ```
+
 **How to put the database to the state of a previous code base?**
 
 With the following command of the Django shell a specific state of the database can be achieved:
+
 ```bash
 .manage.py migrate stac_api 0003_auto_20201022_1346
 ```
@@ -183,6 +189,7 @@ With the following command of the Django shell a specific state of the database 
 
 Under a clean PR, we mean that only one migration script comes along a PR.
 This can be obtained with the following steps (_only if more than one migration script exist for this PR_):
+
 ```bash
 # 1. migrate back to the state before the PR
 ./manage.py migrate stac_api 0016_auto_20201022_1346
@@ -194,16 +201,19 @@ cd stac_api/migrations && rm 0017_har.py 0018_toto.py 0019_final.py
 # 3. add the generated migration script to git
 git add stac_api/migrations 0017_the_new_one.py
 ```
+
 **NOTE:** When going back to a certain migration step, you have to pay attention, that this also involves deleting fields, that have not been added yet.
 Which, of course, involves that its content will be purged as well.
 
 **How to get a working database when migrations scripts screw up?**
 
 With the following commands it is possible to get a proper state of the database:
+
 ```bash
 ./manage.py reset_db
 ./manage.py migrate
 ```
+
 **Warning:** ```reset_db``` a destructive command and will delete all structure and content of the database.
 
 ### Linting and formatting your work
@@ -251,7 +261,6 @@ setup the RDS database on int, run following command:
 
 **Note:** The script won't delete the existing database.
 
-
 ## Deploying the project and continuous integration
 
 When creating a PR, terraform should run a codebuild job to test and build automatically your PR as a tagged container. This container will only be pushed to dockerhub when the PR is accepted and merged.
@@ -292,12 +301,52 @@ You can also check these metadata on a running container as follow
 docker ps --format="table {{.ID}}\t{{.Image}}\t{{.Labels}}"d
 ```
 
-### Deployment configuration
+### Configuration
 
 The service is configured by Environment Variable:
 
+#### **General settings**
+
 | Env         | Default               | Description                            |
 |-------------|-----------------------|----------------------------------------|
-| LOGGING_CFG | logging-cfg-local.yml | Logging configuration file             |
-| HTTP_CACHE_SECONDS | 600 | Sets the `cache-control max-age` of the GET and HEAD requests |
-| HTTP_STATIC_CACHE_SECONDS | 3600 | Sets the `cache-control max-age` of static files GET, HEAD requests |
+| APP_ENV | `'local'` | Determine the application environment (local|dev|int|prod) |
+| LOGGING_CFG | `'logging-cfg-local.yml'` | Logging configuration file             |
+| SECRET_KEY | - | Secret key for django |
+| ALLOWED_HOSTS | `''` | See django ALLOWED_HOSTS. On local development and DEV staging this is overwritten with `'*'` |
+| HTTP_CACHE_SECONDS | `600` | Sets the `cache-control max-age` of the GET and HEAD requests |
+| HTTP_STATIC_CACHE_SECONDS | `3600` | Sets the `cache-control max-age` of static files GET, HEAD requests |
+| DJANGO_STATIC_HOST | `''` | See [Whitenoise use CDN](http://whitenoise.evans.io/en/stable/django.html#use-a-content-delivery-network). |
+| DISABLE_LOGGING | `False` | Disable all logging |
+| TEST_ENABLE_LOGGING | `False` | Enable logging in unittest |
+
+#### **Database settings**
+
+| Env         | Default               | Description                            |
+|-------------|-----------------------|----------------------------------------|
+| DB_NAME | service_stac | Database name |
+| DB_USER | service_stac | Database user (used by django for DB connection) |
+| DB_PW | service_stac | Database password (used by django for DB connection) |
+| DB_HOST | service_stac | Database host |
+| DB_PORT | 5432 | Database port |
+| DB_NAME_TEST | test_service_stac | Database name used for unittest |
+
+#### **Asset Storage settings (AWS S3)**
+
+| Env         | Default               | Description                            |
+|-------------|-----------------------|----------------------------------------|
+| AWS_ACCESS_KEY_ID | - | |
+| AWS_SECRET_ACCESS_KEY | - | |
+| AWS_STORAGE_BUCKET_NAME | - | |
+| AWS_S3_REGION_NAME | - | |
+| AWS_S3_ENDPOINT_URL | `None` | |
+| AWS_S3_CUSTOM_DOMAIN | `None` | |
+
+#### **Development settings (only for local environment and DEV staging)**
+
+These settings are read from `settings_dev.py`
+
+| Env         | Default               | Description                            |
+|-------------|-----------------------|----------------------------------------|
+| DEBUG | `False` | Set django DEBUG flag |
+| PAGE_SIZE | `2` | Default page size |
+| DEBUG_PROPAGATE_API_EXCEPTIONS | `False` | When `True` the API exception are treated as in production, using a JSON response. Otherwise in DEBUG mode the API exception returns an HTML response with backtrace. |

--- a/README.md
+++ b/README.md
@@ -299,3 +299,5 @@ The service is configured by Environment Variable:
 | Env         | Default               | Description                            |
 |-------------|-----------------------|----------------------------------------|
 | LOGGING_CFG | logging-cfg-local.yml | Logging configuration file             |
+| HTTP_CACHE_SECONDS | 600 | Sets the `cache-control max-age` of the GET and HEAD requests |
+| HTTP_STATIC_CACHE_SECONDS | 3600 | Sets the `cache-control max-age` of static files GET, HEAD requests |

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'middleware.cache_headers.CacheHeadersMiddleware',
     'middleware.logging.RequestResponseLoggingMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -84,6 +85,11 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'middleware.logging.ExceptionLoggingMiddleware',
 ]
+
+try:
+    CACHE_MIDDLEWARE_SECONDS = int(os.environ.get('HTTP_CACHE_SECONDS', '600'))
+except ValueError as error:
+    raise ValueError('Invalid HTTP_CACHE_SECONDS environment value: must be an integer')
 
 ROOT_URLCONF = 'config.urls'
 API_BASE = 'api/stac/v0.9'
@@ -164,6 +170,10 @@ STATIC_URL = STATIC_HOST + '/api/stac/v0.9/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'var/www/stac_api/static_files')
 STATICFILES_DIRS = [BASE_DIR / "spec/static", BASE_DIR / "app/stac_api/templates"]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+try:
+    WHITENOISE_MAX_AGE = int(os.environ.get('HTTP_STATIC_CACHE_SECONDS', '3600'))
+except ValueError as error:
+    raise ValueError('Invalid HTTP_STATIC_CACHE_SECONDS environment value: must be an integer')
 
 # Media files (i.e. uploaded content=assets in this project)
 UPLOAD_FILE_CHUNK_SIZE = 1024 * 1024  # Size in Bytes

--- a/app/middleware/cache_headers.py
+++ b/app/middleware/cache_headers.py
@@ -1,0 +1,42 @@
+import logging
+
+from django.conf import settings
+from django.utils.cache import add_never_cache_headers
+from django.utils.cache import patch_cache_control
+from django.utils.cache import patch_response_headers
+
+logger = logging.getLogger(__name__)
+
+
+class CacheHeadersMiddleware:
+    '''Middleware that adds appropriate cache headers to GET and HEAD methods.
+
+    NOTE: /checker and /get-token endpoints are marked as never cache.
+    '''
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        if request.path in ['/checker', '/get-token']:
+            # never cache the /checker and /get-token endpoints.
+            add_never_cache_headers(response)
+        elif request.method in ('GET', 'HEAD'):
+            logger.debug(
+                "Patching cache headers for request %s %s",
+                request.method,
+                request.path,
+                extra={"request": request}
+            )
+            patch_response_headers(response, settings.CACHE_MIDDLEWARE_SECONDS)
+            patch_cache_control(response, public=True)
+
+        return response

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -114,7 +114,7 @@ class ItemAdmin(admin.GeoModelAdmin):
             }
         ),
     )
-    # customisation of the geometry field
+    # customization of the geometry field
     map_template = finders.find('admin/ol_swisstopo.html')  # custom swisstopo
     wms_layer = 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale'
     wms_url = 'https://wms.geo.admin.ch/'

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -20,7 +20,9 @@ API_BASE = settings.API_BASE
 urlpatterns = [
     path('checker', views.checker, name='checker'),
     path(f'{API_BASE}/', LandingPageDetail.as_view(), name='landing-page'),
+    path(f"{API_BASE}/get-token", obtain_auth_token, name='get-token'),
     path(f'{API_BASE}/conformance', ConformancePageDetail.as_view(), name='conformance'),
+    path(f"{API_BASE}/search", SearchList.as_view(), name='search-list'),
     path(f"{API_BASE}/collections", CollectionList.as_view(), name='collection-list'),
     path(
         f"{API_BASE}/collections/<collection_name>",
@@ -33,7 +35,6 @@ urlpatterns = [
         ItemDetail.as_view(),
         name='item-detail'
     ),
-    path(f"{API_BASE}/search", SearchList.as_view(), name='search-list'),
     path(
         f"{API_BASE}/collections/<collection_name>/items/<item_name>/assets",
         AssetsList.as_view(),
@@ -44,5 +45,4 @@ urlpatterns = [
         AssetDetail.as_view(),
         name='asset-detail'
     ),
-    path(f"{API_BASE}/get-token", obtain_auth_token, name='get-token'),
 ]

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -69,6 +69,12 @@ def get_asset_etag(request, *args, **kwargs):
     return tag
 
 
+def checker(request):
+    data = {"success": True, "message": "OK"}
+
+    return JsonResponse(data)
+
+
 class LandingPageDetail(generics.RetrieveAPIView):
     serializer_class = LandingPageSerializer
     queryset = LandingPage.objects.all()
@@ -83,12 +89,6 @@ class ConformancePageDetail(generics.RetrieveAPIView):
 
     def get_object(self):
         return ConformancePage.get_solo()
-
-
-def checker(request):
-    data = {"success": True, "message": "OK"}
-
-    return JsonResponse(data)
 
 
 class CollectionList(generics.GenericAPIView, views_mixins.CreateModelMixin):


### PR DESCRIPTION
Adds the following headers to the django views:

- `Expires: DATE_600_SEC_AHEAD_FROM_NOW`
- `Cache-control: max-age=600, public`
- `Vary: Accept, Cookie` (Added automatically by Django)

The max-age and expire is configurable via `HTTP_CACHE_SECONDS`

For the static files the following headers are added (added automatically by Whitenoise):

- `cache-control: max-age=3600, public, immutable`
- `Expires: DATE_600_SEC_AHEAD_FROM_NOW`

The max-age and expire is configurable via `HTTP_STATIC_CACHE_SECONDS`

_NOTES:_
- it would be useful to have caching enabled in /search POST endpoint, however CloudFront apparently doesn't supports caching on POST requests.
- I did not use the Django CacheMiddleware, because it first install a default cache ([Local-memory caching](https://docs.djangoproject.com/en/3.1/topics/cache/#local-memory-caching) which is not a good choice for PROD) and because it has conflict with the ETag Precondition. If we want to also add caching in Django and make uses of CacheMiddleware we would need first to install a proper cache backend and then to move the ETag functionality in a Middleware as well (it is currently done per view using a decorator).
- Currently because we use the Django CSRF Middleware, the `Vary: Coockie` header is added to each responses. In my opinion this header for our caching is not required and depending on the CloudFront configuration, could even reduce the cache hit ratio of CloudFront. Once deployed on INT we will need to review the CloudFront configuration and do some testing.
- See https://github.com/geoadmin/infra-kubernetes/pull/42 for k8s configuration