### PR TITLE
BGDIINF_SB-1546: Improvements of collections update logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - [Setting up the local database](#setting-up-the-local-database)
   - [Using a local PostGres database instead of a container](#using-a-local-postgres-database-instead-of-a-container)
   - [Starting dev server](#starting-dev-server)
-  - [Running test](#running-test)
+  - [Running tests](#running-tests)
   - [Using Django shell](#using-django-shell)
   - [Linting and formatting your work](#linting-and-formatting-your-work)
 - [Deploying the project and continuous integration](#deploying-the-project-and-continuous-integration)
@@ -36,7 +36,7 @@ Prerequisites on host for development and build:
 - pipenv
 - `docker` and `docker-compose`
 
-If you wish to use a local postgres instance rather than the dockerised one, you'll also need the following : 
+If you wish to use a local postgres instance rather than the dockerised one, you'll also need the following :
 
 - a local postgres (>= 12.0) running
 - postgis extension installed (>= 3.0)
@@ -75,25 +75,25 @@ These steps will ensure you have everything needed to start working locally.
   ```bash
   pipenv install
   ```
-  
-An alternative to ```pipenv install``` is to use the ```make setup``` command, which will install the environment, 
+
+An alternative to ```pipenv install``` is to use the ```make setup``` command, which will install the environment,
 apply a patch to the multihash package to support md5, create the volumes needed by the Postgres and MinIO containers
 and run those containers. ```Make setup``` assume a standard local installation with a dev environment.
-  
+
 ### Setting up the local database
 
-The service use two other services to run, Posgres with a PostGIS extension and S3. 
-For local development, we recommend using the services given through the [docker-compose.yml](docker-compose.yml) file, which will 
+The service use two other services to run, Posgres with a PostGIS extension and S3.
+For local development, we recommend using the services given through the [docker-compose.yml](docker-compose.yml) file, which will
 instantiate a Postgres container and a [MinIO](https://www.min.io/) container which act as a local S3 replacement.
 
-If you used the ```make setup``` command during the local environment creation, those two services 
-should be already be up. You can check with 
+If you used the ```make setup``` command during the local environment creation, those two services
+should be already be up. You can check with
 
   ```bash
   docker ps -a
   ```
 
-which should give you a result like this : 
+which should give you a result like this :
   ```
   CONTAINER ID   IMAGE                  COMMAND                   CREATED        STATUS                      PORTS                     NAMES
   a63582388800   minio/mc               "/bin/sh -c '\n  set …"   39 hours ago   Exited (0) 40 seconds ago                             service-stac_s3-client_1
@@ -101,10 +101,10 @@ which should give you a result like this :
   d158be863ac1   kartoza/postgis:12.0   "/bin/sh -c /docker-…"    39 hours ago   Up 41 seconds               0.0.0.0:15432->5432/tcp   service-stac_db_1
   ```
 
-As you can see, MinIO is using two containers, one is the local S3 server, the other is a S3 client used to set the 
+As you can see, MinIO is using two containers, one is the local S3 server, the other is a S3 client used to set the
 download policy of the bucket which allows anonymous downloads, and exits once its job is done. You should also have a postGIS container.
 
-`make setup` also creates some necessary directories : `.volumes/minio` and `.volumes/postgresql`, which are mounted to the 
+`make setup` also creates some necessary directories : `.volumes/minio` and `.volumes/postgresql`, which are mounted to the
 corresponding containers in order to allow data persistency.
 
 Another way to start these containers (if, for example, they stopped) is with a simple
@@ -115,7 +115,7 @@ Another way to start these containers (if, for example, they stopped) is with a 
 
 Lastly, once your databases have been set up, it is time to apply migrations (to have the latest model) and fill it with
 some default values to be able to start working with it. (From the root)
-  ```bash 
+  ```bash
   pipenv shell
   ./app/manage.py migrate
   ./app/manage.py populate_testdb
@@ -124,7 +124,7 @@ some default values to be able to start working with it. (From the root)
 the ```pipenv shell``` command activate the virtual environment provided by pipenv.
 ### Using a local PostGres database instead of a container
 
-To use a local postgres instance rather than a container, once you've ensured you've the needed dependencies, you should : 
+To use a local postgres instance rather than a container, once you've ensured you've the needed dependencies, you should :
 
 - Create a new superuser (required to create/destroy the test-databases) and a new database.
 
@@ -163,11 +163,15 @@ cd app
 ./manage.py test
 ```
 
-you can choose to create a new test-db on every run or to keep the db, which speeds testing up:
+You can choose to create a new test-db on every run or to keep the db, which speeds testing up:
 
 ```bash
 ./manage.py test --keepdb
 ```
+
+You can uses `--parallel=20` which also speed up tests.
+
+You can use `--failfast` to stop at the first error.
 
 **NOTE:** by default logging is disabled during tests, you can enable it by setting the `TEST_ENABLE_LOGGING=1` environment variable:
 
@@ -175,7 +179,22 @@ you can choose to create a new test-db on every run or to keep the db, which spe
 TEST_ENABLE_LOGGING=1 ./manage.py test
 ```
 
-**NOTE:** the environment variable can also be set in the `.venv.local` file.
+or set the environment variable directly in the `.venv.local` file.
+
+Alternatively you can use `make` to run the tests which will run all tests in parallel.
+
+```bash
+make test
+```
+
+or use the container environment like on the CI.
+
+```bash
+docker-compose -f docker-compose-ci.yml up --build --abort-on-container-exit
+```
+
+**NOTE:** the `--build` option is important otherwise the container will not be rebuild and you don't have the latest modification
+of the code.
 
 ### Using Django shell
 

--- a/app/stac_api/collection_spatial_extent.py
+++ b/app/stac_api/collection_spatial_extent.py
@@ -126,7 +126,7 @@ class CollectionSpatialExtentMixin():
                     self.extent_geometry = None
                 logger.info(
                     'Collection extent_geometry updated to %s in %ss, after item deletion',
-                    union_geometry.extent,
+                    union_geometry.extent if self.extent_geometry else None,
                     time.time() - start,
                     extra={
                         'collection': self.name, 'item': item.name, 'trigger': 'item-delete'

--- a/app/stac_api/collection_spatial_extent.py
+++ b/app/stac_api/collection_spatial_extent.py
@@ -1,0 +1,155 @@
+import logging
+import time
+
+from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import Polygon
+from django.contrib.gis.geos.error import GEOSException
+
+logger = logging.getLogger(__name__)
+
+
+class CollectionSpatialExtentMixin():
+
+    def update_bbox_extent(self, trigger, geometry, original_geometry, item):
+        '''Updates the collection's spatial extent if needed when an item is updated.
+
+        This function generates a new extent regarding all the items with the same
+        collection foreign key. If there is no spatial bbox yet, the one of the geometry of the
+        item is being used.
+
+        Args:
+            trigger: str
+                Item trigger event, one of 'insert', 'update' or 'delete'
+            geometry: GeometryField
+                the geometry of the item
+            original_geometry:
+                the original geometry during an updated or None
+            item: Item
+                the item being treated
+
+        Returns:
+            bool: True if the collection temporal extent has been updated, false otherwise
+        '''
+        updated = False
+        try:
+            # insert (as item_id is None)
+            if trigger == 'insert':
+                # the first item of this collection
+                if self.extent_geometry is None:
+                    logger.info(
+                        'Set collections extent_geometry with geometry %s, '
+                        'triggered by the first item insertion',
+                        GEOSGeometry(geometry).extent,
+                        extra={
+                            'collection': self.name, 'item': item.name, 'trigger': 'item-insert'
+                        },
+                    )
+                    self.extent_geometry = Polygon.from_bbox(GEOSGeometry(geometry).extent)
+                # there is already a geometry in the collection a union of the geometries
+                else:
+                    logger.info(
+                        'Updating collections extent_geometry with geometry %s, '
+                        'triggered by an item insertion',
+                        GEOSGeometry(geometry).extent,
+                        extra={
+                            'collection': self.name, 'item': item.name, 'trigger': 'item-insert'
+                        },
+                    )
+                    self.extent_geometry = Polygon.from_bbox(
+                        GEOSGeometry(self.extent_geometry).union(GEOSGeometry(geometry)).extent
+                    )
+                updated |= True
+
+            # update
+            if trigger == 'update' and geometry != original_geometry:
+                # is the new bbox larger than (and covering) the existing
+                if Polygon.from_bbox(GEOSGeometry(geometry).extent).covers(self.extent_geometry):
+                    # pylint: disable=fixme
+                    # TODO: cover this code by a unittest, remove this comment when BGDIINF_SB-1595
+                    # is implemented
+                    logger.info(
+                        'Updating collections extent_geometry with item geometry changed '
+                        'from %s to %s, (larger and covering bbox)',
+                        GEOSGeometry(original_geometry).extent,
+                        GEOSGeometry(geometry).extent,
+                        extra={
+                            'collection': self.name, 'item': item.name, 'trigger': 'item-update'
+                        },
+                    )
+                    self.extent_geometry = Polygon.from_bbox(GEOSGeometry(geometry).extent)
+                # we need to iterate trough the items
+                else:
+                    logger.warning(
+                        'Updating collections extent_geometry with item geometry changed '
+                        'from %s to %s. We need to loop over all items of the collection, '
+                        'this may take a while !',
+                        GEOSGeometry(original_geometry).extent,
+                        GEOSGeometry(geometry).extent,
+                        extra={
+                            'collection': self.name, 'item': item.name, 'trigger': 'item-update'
+                        },
+                    )
+                    start = time.time()
+                    qs = type(item).objects.filter(collection_id=self.pk).exclude(id=item.pk)
+                    union_geometry = GEOSGeometry(geometry)
+                    for _item in qs:
+                        union_geometry = union_geometry.union(_item.geometry)
+                    self.extent_geometry = Polygon.from_bbox(union_geometry.extent)
+                    logger.info(
+                        'Collection extent_geometry updated to %s in %ss, after item update',
+                        union_geometry.extent,
+                        time.time() - start,
+                        extra={
+                            'collection': self.name, 'item': item.name, 'trigger': 'item-update'
+                        },
+                    )
+                updated |= True
+
+            # delete, we need to iterate trough the items
+            if trigger == 'delete':
+                logger.warning(
+                    'Updating collections extent_geometry with removal of item geometry %s. '
+                    'We need to loop over all items of the collection, this may take a while !',
+                    GEOSGeometry(geometry).extent,
+                    extra={
+                        'collection': self.name, 'item': item.name, 'trigger': 'item-delete'
+                    },
+                )
+                start = time.time()
+                qs = type(item).objects.filter(collection_id=self.pk).exclude(id=item.pk)
+                union_geometry = GEOSGeometry('Polygon EMPTY')
+                if bool(qs):
+                    for _item in qs:
+                        union_geometry = union_geometry.union(_item.geometry)
+                    self.extent_geometry = Polygon.from_bbox(union_geometry.extent)
+                else:
+                    self.extent_geometry = None
+                logger.info(
+                    'Collection extent_geometry updated to %s in %ss, after item deletion',
+                    union_geometry.extent,
+                    time.time() - start,
+                    extra={
+                        'collection': self.name, 'item': item.name, 'trigger': 'item-delete'
+                    },
+                )
+                updated |= True
+        except GEOSException as error:
+            logger.error(
+                'Failed to update spatial extend in collection %s with item %s, trigger=%s, '
+                'current-extent=%s, new-geometry=%s, old-geometry=%s: %s',
+                self.name,
+                item.name,
+                trigger,
+                self.extent_geometry,
+                GEOSGeometry(geometry).extent,
+                GEOSGeometry(original_geometry).extent,
+                error,
+                extra={
+                    'collection': self.name, 'item': item.name, 'trigger': f'item-{trigger}'
+                },
+            )
+            raise GEOSException(
+                f'Failed to update spatial extend in colletion {self.name} with item '
+                f'{item.name}: {error}'
+            )
+        return updated

--- a/app/stac_api/collection_summaries.py
+++ b/app/stac_api/collection_summaries.py
@@ -14,344 +14,372 @@ def float_in(flt, floats, **kwargs):
     return np.any(np.isclose(flt, floats, **kwargs))
 
 
-def update_summaries_on_asset_delete(collection, asset):
-    '''Updates the collection's summaries if needed  on an asset's deletion
+class CollectionSummariesMixin():
 
-    Args:
-        collection: collection, for which the summaries probably need an update
-        asset: asset thats being deleted
+    def update_summaries(self, asset, trigger, old_values=None):
+        '''Updates the collection's summaries if needed when assets are updated or deleted.
+
+        For all the given parameters this function checks, if the corresponding parameters of the
+        collection need to be updated. If so, they will be updated.
+
+        Args:
+            asset:
+                Asset thats being inserted/updated or deleted
+            trigger:
+                Asset trigger event, one of 'insert', 'update' or 'delete'
+            old_values: (optional)
+                List with the original values of asset's [eo_gsd, geoadmin_variant, proj_epsg].
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+
+        logger.debug(
+            'Collection update summaries: '
+            'trigger=%s, asset=%s, old_values=%s, new_values=%s, current_summaries=%s',
+            trigger,
+            asset,
+            old_values,
+            [asset.eo_gsd, asset.geoadmin_variant, asset.proj_epsg],
+            self.summaries,
+            extra={
+                'collection': self.name,
+                'item': asset.item.name,
+                'asset': asset.name,
+            },
+        )
+
+        if trigger == 'delete':
+            return self._update_summaries_on_asset_delete(asset)
+        if trigger == 'update':
+            return self._update_summaries_on_asset_update(asset, old_values)
+        if trigger == 'insert':
+            return self._update_summaries_on_asset_insert(asset)
+        raise ValueError(f'Invalid trigger parameter: {trigger}')
+
+    def _update_summaries_on_asset_delete(self, asset):
+        '''Updates the collection's summaries if needed  on an asset's deletion
+
+        Args:
+            asset: asset thats being deleted
+
+            For all the given parameters this function checks, if the corresponding
+            parameters of the collection need to be updated. If so, they will be either
+            updated or an error will be raised, if updating fails.
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+        assets = type(asset).objects.filter(item__collection_id=self.pk).exclude(id=asset.id)
+
+        if assets.exists():
+            for key, attribute in [('geoadmin:variant', 'geoadmin_variant'),
+                                   ('proj:epsg', 'proj_epsg'),
+                                   ('eo:gsd', 'eo_gsd')]:
+                attribute_value = getattr(asset, attribute)
+                if not assets.filter(**{attribute: attribute_value}).exists():
+                    logger.info(
+                        'Removing %s %s from collection summaries',
+                        key,
+                        attribute_value,
+                        extra={
+                            'collection': self.name,
+                            'item': asset.item.name,
+                            'asset': asset.name,
+                            'trigger': 'asset-delete'
+                        }
+                    )
+                    self.summaries[key].remove(attribute_value)
+                    updated |= True
+        else:
+            logger.info(
+                'Clearing the collection summaries',
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-delete'
+                }
+            )
+            # asset was the last item in the collection
+            self.summaries["geoadmin:variant"] = []
+            self.summaries["proj:epsg"] = []
+            self.summaries["eo:gsd"] = []
+            updated |= True
+
+        return updated
+
+    def _update_summaries_on_asset_insert(self, asset):
+        '''Updates the collection's summaries if needed on an asset's insertion
+
+        Args:
+            asset: asset thats being inserted
+            For all the given parameters this function checks, if the corresponding
+            parameters of the collection need to be updated. If so, they will be either
+            updated or an error will be raised, if updating fails.
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+        if (
+            asset.geoadmin_variant and
+            asset.geoadmin_variant not in self.summaries["geoadmin:variant"]
+        ):
+            logger.info(
+                'Adds geoadmin:variant %s to collection summaries',
+                asset.geoadmin_variant,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-insert'
+                }
+            )
+            self.summaries["geoadmin:variant"].append(asset.geoadmin_variant)
+            self.summaries["geoadmin:variant"].sort()
+            updated |= True
+
+        if asset.proj_epsg and asset.proj_epsg not in self.summaries["proj:epsg"]:
+            logger.info(
+                'Adds proj:epsg %s to collection summaries',
+                asset.proj_epsg,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-insert'
+                }
+            )
+            self.summaries["proj:epsg"].append(asset.proj_epsg)
+            self.summaries["proj:epsg"].sort()
+            updated |= True
+
+        if asset.eo_gsd and not float_in(asset.eo_gsd, self.summaries["eo:gsd"]):
+            logger.info(
+                'Adds eo:gsd %s to collection summaries',
+                asset.proj_epsg,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-insert'
+                }
+            )
+            self.summaries["eo:gsd"].append(asset.eo_gsd)
+            self.summaries["eo:gsd"].sort()
+            updated |= True
+
+        return updated
+
+    def _update_summaries_geoadmin_variant_on_update(
+        self, assets, asset, geoadmin_variant, original_geoadmin_variant
+    ):
+        '''Updates the collection's geoadmin:variant summary if needed on an asset's update
+
+        For the given geoadmin:variant parameter this function checks, if the collection's
+        geoadmin:variant summary needs to be updated. If so, it will be updated.
+
+        Args:
+            assets: QuerySet
+                Assets queryset of all other collection's assets (excluding the one that trigger
+                this update)
+            asset: Asset
+                asset thats being updated
+            geoadmin_variant: int
+                New asset's geoadmin:variant value
+            original_geoadmin_variant: int
+                Original asset's geoadmin:variant value
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+
+        if geoadmin_variant and geoadmin_variant not in self.summaries["geoadmin:variant"]:
+            logger.info(
+                'Adds geoadmin:variant %s to collection summaries',
+                geoadmin_variant,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["geoadmin:variant"].append(geoadmin_variant)
+            updated |= True
+
+        # check if the asset's original value is still present in other
+        # assets and can remain in the summaries or has to be deleted:
+        if (
+            not assets.exists() or
+            not assets.filter(geoadmin_variant=original_geoadmin_variant).exists()
+        ):
+            logger.info(
+                'Removes original geoadmin:variant value %s from collection summaries',
+                original_geoadmin_variant,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["geoadmin:variant"].remove(original_geoadmin_variant)
+            updated |= True
+
+        if updated:
+            self.summaries["geoadmin:variant"].sort()
+
+        return updated
+
+    def _update_summaries_proj_epsg_on_update(self, assets, asset, proj_epsg, original_proj_epsg):
+        '''Updates the collection's proj:epsg summary if needed on an asset's update
+
+        For the given proj:epsg parameter this function checks, if the collection's proj:epsg
+        summary needs to be updated. If so, it will be updated.
+
+        Args:
+            assets: QuerySet
+                Assets queryset of all other collection's assets (excluding the one that trigger
+                this update)
+            asset: Asset
+                asset thats being updated
+            proj_epsg: int
+                New asset's proj:epsg value
+            original_proj_epsg: int
+                Original asset's proj:epsg value
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+
+        if proj_epsg and proj_epsg not in self.summaries["proj:epsg"]:
+            logger.info(
+                'Adds proj:epsg value %s from collection summaries',
+                proj_epsg,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["proj:epsg"].append(proj_epsg)
+            updated |= True
+
+        if not assets.exists() or not assets.filter(proj_epsg=original_proj_epsg).exists():
+            logger.info(
+                'Removes original proj:epsg value %s from collection summaries',
+                original_proj_epsg,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["proj:epsg"].remove(original_proj_epsg)
+            updated |= True
+
+        if updated:
+            self.summaries["proj:epsg"].sort()
+
+        return updated
+
+    def _update_summaries_eo_gsd_on_update(self, assets, asset, eo_gsd, original_eo_gsd):
+        '''Updates the collection's eo:gsd summary if needed on an asset's update
+
+        For the given eo:gsd parameter this function checks, if the collection's eo:gsd summary
+        needs to be updated. If so, it will be updated.
+
+        Args:
+            assets: QuerySet
+                Assets queryset of all other collection's assets (excluding the one that trigger
+                this update)
+            asset: Asset
+                asset thats being updated
+            eo_gsd: int
+                New asset's eo:gsd value
+            original_eo_gsd: int
+                Original asset's eo:gsd value
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+
+        if eo_gsd and not float_in(eo_gsd, self.summaries["eo:gsd"]):
+            logger.info(
+                'Adds eo:gsd value %s from collection summaries',
+                eo_gsd,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["eo:gsd"].append(eo_gsd)
+            updated |= True
+
+        if not assets.exists() or not assets.filter(eo_gsd=original_eo_gsd).exists():
+            logger.info(
+                'Removes original eo:gsd value %s from collection summaries',
+                original_eo_gsd,
+                extra={
+                    'collection': self.name,
+                    'item': asset.item.name,
+                    'asset': asset.name,
+                    'trigger': 'asset-update'
+                }
+            )
+            self.summaries["eo:gsd"].remove(original_eo_gsd)
+            updated |= True
+
+        if updated:
+            self.summaries["eo:gsd"].sort()
+
+        return updated
+
+    def _update_summaries_on_asset_update(self, asset, old_values):
+        '''Updates the collection's summaries if needed on an asset's update
 
         For all the given parameters this function checks, if the corresponding
-        parameters of the collection need to be updated. If so, they will be either
-        updated or an error will be raised, if updating fails.
+        parameters of the collection need to be updated. If so, they will be updated.
 
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-    assets = type(asset).objects.filter(item__collection_id=collection.pk).exclude(id=asset.id)
+        Args:
+            asset: Asset
+                asset thats being updated
+            old_values: list (optional)
+                list with the original values of asset's; [eo_gsd, geoadmin_variant, proj_epsg].
 
-    if assets.exists():
-        for key, attribute in [('geoadmin:variant', 'geoadmin_variant'),
-                               ('proj:epsg', 'proj_epsg'),
-                               ('eo:gsd', 'eo_gsd')]:
-            attribute_value = getattr(asset, attribute)
-            if not assets.filter(**{attribute: attribute_value}).exists():
-                logger.info(
-                    'Removing %s %s from collection summaries',
-                    key,
-                    attribute_value,
-                    extra={
-                        'collection': collection.name,
-                        'item': asset.item.name,
-                        'asset': asset.name,
-                        'trigger': 'asset-delete'
-                    }
-                )
-                collection.summaries[key].remove(attribute_value)
-                updated |= True
-    else:
-        logger.info(
-            'Clearing the collection summaries',
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-delete'
-            }
-        )
-        # asset was the last item in the collection
-        collection.summaries["geoadmin:variant"] = []
-        collection.summaries["proj:epsg"] = []
-        collection.summaries["eo:gsd"] = []
-        updated |= True
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+        original_eo_gsd = old_values[0]
+        original_geoadmin_variant = old_values[1]
+        original_proj_epsg = old_values[2]
 
-    return updated
+        assets = type(asset).objects.filter(item__collection_id=self.pk).exclude(id=asset.id)
 
+        if original_geoadmin_variant != asset.geoadmin_variant:
+            updated |= self._update_summaries_geoadmin_variant_on_update(
+                assets, asset, asset.geoadmin_variant, original_geoadmin_variant
+            )
 
-def update_summaries_on_asset_insert(collection, asset):
-    '''Updates the collection's summaries if needed on an asset's insertion
+        if original_proj_epsg != asset.proj_epsg:
+            updated |= self._update_summaries_proj_epsg_on_update(
+                assets, asset, asset.proj_epsg, original_proj_epsg
+            )
 
-    Args:
-        collection: collection, for which the summaries probably need an update
-        asset: asset thats being inserted
-        For all the given parameters this function checks, if the corresponding
-        parameters of the collection need to be updated. If so, they will be either
-        updated or an error will be raised, if updating fails.
+        if original_eo_gsd != asset.eo_gsd:
+            updated |= self._update_summaries_eo_gsd_on_update(
+                assets, asset, asset.eo_gsd, original_eo_gsd
+            )
 
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-    if (
-        asset.geoadmin_variant and
-        asset.geoadmin_variant not in collection.summaries["geoadmin:variant"]
-    ):
-        logger.info(
-            'Adds geoadmin:variant %s to collection summaries',
-            asset.geoadmin_variant,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-insert'
-            }
-        )
-        collection.summaries["geoadmin:variant"].append(asset.geoadmin_variant)
-        collection.summaries["geoadmin:variant"].sort()
-        updated |= True
-
-    if asset.proj_epsg and asset.proj_epsg not in collection.summaries["proj:epsg"]:
-        logger.info(
-            'Adds proj:epsg %s to collection summaries',
-            asset.proj_epsg,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-insert'
-            }
-        )
-        collection.summaries["proj:epsg"].append(asset.proj_epsg)
-        collection.summaries["proj:epsg"].sort()
-        updated |= True
-
-    if asset.eo_gsd and not float_in(asset.eo_gsd, collection.summaries["eo:gsd"]):
-        logger.info(
-            'Adds eo:gsd %s to collection summaries',
-            asset.proj_epsg,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-insert'
-            }
-        )
-        collection.summaries["eo:gsd"].append(asset.eo_gsd)
-        collection.summaries["eo:gsd"].sort()
-        updated |= True
-
-    return updated
-
-
-def update_summaries_geoadmin_variant_on_update(
-    collection, assets, asset, geoadmin_variant, original_geoadmin_variant
-):
-    '''Updates the collection's geoadmin:variant summary if needed on an asset's update
-
-    For the given geoadmin:variant parameter this function checks, if the collection's
-    geoadmin:variant summary needs to be updated. If so, it will be updated.
-
-    Args:
-        collection: Collection
-            Asset's collection, for which the summaries might need an update
-        assets: QuerySet
-            Assets queryset of all other collection's assets (excluding the one that trigger this
-            update)
-        asset: Asset
-            asset thats being updated
-        geoadmin_variant: int
-            New asset's geoadmin:variant value
-        original_geoadmin_variant: int
-            Original asset's geoadmin:variant value
-
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-
-    if geoadmin_variant and geoadmin_variant not in collection.summaries["geoadmin:variant"]:
-        logger.info(
-            'Adds geoadmin:variant %s to collection summaries',
-            geoadmin_variant,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["geoadmin:variant"].append(geoadmin_variant)
-        updated |= True
-
-    # check if the asset's original value is still present in other
-    # assets and can remain in the summaries or has to be deleted:
-    if (
-        not assets.exists() or
-        not assets.filter(geoadmin_variant=original_geoadmin_variant).exists()
-    ):
-        logger.info(
-            'Removes original geoadmin:variant value %s from collection summaries',
-            original_geoadmin_variant,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["geoadmin:variant"].remove(original_geoadmin_variant)
-        updated |= True
-
-    if updated:
-        collection.summaries["geoadmin:variant"].sort()
-
-    return updated
-
-
-def update_summaries_proj_epsg_on_update(collection, assets, asset, proj_epsg, original_proj_epsg):
-    '''Updates the collection's proj:epsg summary if needed on an asset's update
-
-    For the given proj:epsg parameter this function checks, if the collection's proj:epsg summary
-    needs to be updated. If so, it will be updated.
-
-    Args:
-        collection: Collection
-            Asset's collection, for which the summaries might need an update
-        assets: QuerySet
-            Assets queryset of all other collection's assets (excluding the one that trigger this
-            update)
-        asset: Asset
-            asset thats being updated
-        proj_epsg: int
-            New asset's proj:epsg value
-        original_proj_epsg: int
-            Original asset's proj:epsg value
-
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-
-    if proj_epsg and proj_epsg not in collection.summaries["proj:epsg"]:
-        logger.info(
-            'Adds proj:epsg value %s from collection summaries',
-            proj_epsg,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["proj:epsg"].append(proj_epsg)
-        updated |= True
-
-    if not assets.exists() or not assets.filter(proj_epsg=original_proj_epsg).exists():
-        logger.info(
-            'Removes original proj:epsg value %s from collection summaries',
-            original_proj_epsg,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["proj:epsg"].remove(original_proj_epsg)
-        updated |= True
-
-    if updated:
-        collection.summaries["proj:epsg"].sort()
-
-    return updated
-
-
-def update_summaries_eo_gsd_on_update(collection, assets, asset, eo_gsd, original_eo_gsd):
-    '''Updates the collection's eo:gsd summary if needed on an asset's update
-
-    For the given eo:gsd parameter this function checks, if the collection's eo:gsd summary needs
-    to be updated. If so, it will be updated.
-
-    Args:
-        collection: Collection
-            Asset's collection, for which the summaries might need an update
-        assets: QuerySet
-            Assets queryset of all other collection's assets (excluding the one that trigger this
-            update)
-        asset: Asset
-            asset thats being updated
-        eo_gsd: int
-            New asset's eo:gsd value
-        original_eo_gsd: int
-            Original asset's eo:gsd value
-
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-
-    if eo_gsd and not float_in(eo_gsd, collection.summaries["eo:gsd"]):
-        logger.info(
-            'Adds eo:gsd value %s from collection summaries',
-            eo_gsd,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["eo:gsd"].append(eo_gsd)
-        updated |= True
-
-    if not assets.exists() or not assets.filter(eo_gsd=original_eo_gsd).exists():
-        logger.info(
-            'Removes original eo:gsd value %s from collection summaries',
-            original_eo_gsd,
-            extra={
-                'collection': collection.name,
-                'item': asset.item.name,
-                'asset': asset.name,
-                'trigger': 'asset-update'
-            }
-        )
-        collection.summaries["eo:gsd"].remove(original_eo_gsd)
-        updated |= True
-
-    if updated:
-        collection.summaries["eo:gsd"].sort()
-
-    return updated
-
-
-def update_summaries_on_asset_update(collection, asset, old_values):
-    '''Updates the collection's summaries if needed on an asset's update
-
-    For all the given parameters this function checks, if the corresponding
-    parameters of the collection need to be updated. If so, they will be updated.
-
-    Args:
-        collection: Collection
-            collection, for which the summaries probably need an update
-        asset: Asset
-            asset thats being updated
-        old_values: list (optional)
-            list with the original values of asset's; [eo_gsd, geoadmin_variant, proj_epsg].
-
-    Returns:
-        bool: True if the collection summaries has been updated, false otherwise
-    '''
-    updated = False
-    original_eo_gsd = old_values[0]
-    original_geoadmin_variant = old_values[1]
-    original_proj_epsg = old_values[2]
-
-    assets = type(asset).objects.filter(item__collection_id=collection.pk).exclude(id=asset.id)
-
-    if original_geoadmin_variant != asset.geoadmin_variant:
-        updated |= update_summaries_geoadmin_variant_on_update(
-            collection, assets, asset, asset.geoadmin_variant, original_geoadmin_variant
-        )
-
-    if original_proj_epsg != asset.proj_epsg:
-        updated |= update_summaries_proj_epsg_on_update(
-            collection, assets, asset, asset.proj_epsg, original_proj_epsg
-        )
-
-    if original_eo_gsd != asset.eo_gsd:
-        updated |= update_summaries_eo_gsd_on_update(
-            collection, assets, asset, asset.eo_gsd, original_eo_gsd
-        )
-
-    return updated
+        return updated

--- a/app/stac_api/collection_temporal_extent.py
+++ b/app/stac_api/collection_temporal_extent.py
@@ -4,822 +4,872 @@ import time
 logger = logging.getLogger(__name__)
 
 
-def update_temporal_extent_on_item_insert(
-    collection, new_start_datetime, new_end_datetime, item_name
-):
-    '''This function is called from within update_temporal_extent() when a new item is inserted to
-    the collection.
+class CollectionTemporalExtentMixin():
 
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        new_start_datetime: datetime
-            item's updated value for properties_start_datetime
-        new_end_datetime: datetime
-            item's updated value for properties_end_datetime
-        item_name: string
-            the name of the item being treated
+    def update_temporal_extent(self, item, trigger, original_item_values):
+        '''Updates the collection's temporal extent if needed when items are inserted, updated or
+        deleted.
 
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-    '''
-    updated = False
-    if (
-        collection.extent_start_datetime is None or
-        collection.extent_start_datetime > new_start_datetime
+        For all the given parameters this function checks, if the corresponding parameters of the
+        collection need to be updated. If so, they will be updated.
+
+        Args:
+            item:
+                Item thats being inserted/updated or deleted
+            trigger:
+                Item trigger event, one of 'insert', 'update' or 'delete'
+            original_item_values: (optional)
+                Dictionary with the original values of item's ['properties_datetime',
+                'properties_start_datetime', 'properties_end_datetime'].
+
+        Returns:
+            bool: True if the collection summaries has been updated, false otherwise
+        '''
+        updated = False
+
+        # Get the start end datetimes independently if we have a range or not, when there is no
+        # range then we use the same start and end datetime
+        start_datetime = item.properties_start_datetime
+        end_datetime = item.properties_end_datetime
+        if start_datetime is None or end_datetime is None:
+            start_datetime = item.properties_datetime
+            end_datetime = item.properties_datetime
+
+        # Get the original start end datetimes independently if we have a range or not, when there
+        # is no range then we use the same start and end datetime
+        old_start_datetime = original_item_values.get('properties_start_datetime', None)
+        old_end_datetime = original_item_values.get('properties_end_datetime', None)
+        if old_start_datetime is None or old_end_datetime is None:
+            old_start_datetime = original_item_values.get('properties_datetime', None)
+            old_end_datetime = original_item_values.get('properties_datetime', None)
+
+        if trigger == 'insert':
+            updated |= self._update_temporal_extent(
+                item, trigger, None, start_datetime, None, end_datetime
+            )
+        elif trigger in ['update', 'delete']:
+            updated |= self._update_temporal_extent(
+                item, trigger, old_start_datetime, start_datetime, old_end_datetime, end_datetime
+            )
+        else:
+            logger.critical(
+                'Failed to update collection temporal extent; invalid trigger parameter %s',
+                trigger,
+                extra={'collection', self.name, 'item', item.name}
+            )
+            raise ValueError(f'Invalid trigger parameter; {trigger}')
+
+        return updated
+
+    def _update_temporal_extent_on_item_insert(
+        self, new_start_datetime, new_end_datetime, item_name
     ):
-        logger.info(
-            "Collection temporal extent start_datetime=%s updated to the item start_datetime=%s",
-            collection.extent_start_datetime,
-            new_start_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-insert'
-            }
-        )
-        updated |= True
-        # first item in collection, as extent_start_datetime is None:
-        # or
-        # new item starts earlier that current collection range starts
-        collection.extent_start_datetime = new_start_datetime
+        '''This function is called from within update_temporal_extent() when a new item is inserted
+        to the collection.
 
-    if collection.extent_end_datetime is None or collection.extent_end_datetime < new_end_datetime:
-        logger.info(
-            "Collection temporal extent end_datetime=%s updated to item end_datetime=%s",
-            collection.extent_end_datetime,
-            new_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-insert'
-            }
-        )
-        updated |= True
-        # first item in collection, as extent_start_datetime is None
-        # or
-        # new item starts after current collection's range ends
-        collection.extent_end_datetime = new_end_datetime
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            new_start_datetime: datetime
+                item's updated value for properties_start_datetime
+            new_end_datetime: datetime
+                item's updated value for properties_end_datetime
+            item_name: string
+                the name of the item being treated
 
-    return updated
-
-
-def update_start_temporal_extent_on_item_update(
-    collection, old_start_datetime, new_start_datetime, item_name, qs_other_items=None
-):
-    '''This function is called from within update_temporal_extent() when the
-    start_datetime of an item in the collection is updated to check if the
-    collection's start_datetime needs to be updated.
-
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        old_start_datetime: datetime
-            item's old value for properties_start_datetime
-        new_start_datetime: datetime
-            item's updated value for properties_start_datetime
-        item_name: str
-            the name of the item being treated
-        qs_other_items: QuerySet | None
-            queryset with all items of the collection excluding the one being updated. (optional)
-
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-        return_qs: QuerySet | None
-            Queryset containing all items (but the one currently updated) that have
-            non-null properties_datetime values. This queryset might be used in
-            update_end_temporal_extent_on_item_update() and can be passed in already
-            evaluated state to save one DB hit.
-    '''
-    updated = False
-    return_qs = None
-    logger.debug(
-        "Updating collection extent start datetime %s with item (old start: %s, new start: %s)",
-        collection.extent_start_datetime,
-        old_start_datetime,
-        new_start_datetime,
-        extra={
-            'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-        }
-    )
-
-    if old_start_datetime == collection.extent_start_datetime:
-        # item's old start_datetime was defining left bound of the temporal
-        # extent interval of collection before update
-        if new_start_datetime < old_start_datetime:
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+        '''
+        updated = False
+        if (self.extent_start_datetime is None or self.extent_start_datetime > new_start_datetime):
             logger.info(
-                "Collection temporal extent start_datetime=%s updated to item start_datetime=%s",
-                collection.extent_start_datetime,
+                "Collection temporal extent start_datetime=%s updated to the "
+                "item start_datetime=%s",
+                self.extent_start_datetime,
                 new_start_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-insert'
                 }
             )
             updated |= True
-            # item's start_datetime was shifted to the left (earlier)
-            collection.extent_start_datetime = new_start_datetime
-        else:
-            # item's start_datetime was shifted to the right (later)
-            # but was defining the left bound of the temporal extent
-            # of the collection before
-            # --> hence the new start_datetime of the collection
-            # needs to be determined:
-            # set earliest start_datetime to min(earliest_start_datetime
-            # of all items but the one currently updated and
-            # new_start_datetime).
+            # first item in collection, as extent_start_datetime is None:
+            # or
+            # new item starts earlier that current collection range starts
+            self.extent_start_datetime = new_start_datetime
+
+        if self.extent_end_datetime is None or self.extent_end_datetime < new_end_datetime:
+            logger.info(
+                "Collection temporal extent end_datetime=%s updated to item end_datetime=%s",
+                self.extent_end_datetime,
+                new_end_datetime,
+                extra={
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-insert'
+                }
+            )
+            updated |= True
+            # first item in collection, as extent_start_datetime is None
+            # or
+            # new item starts after current collection's range ends
+            self.extent_end_datetime = new_end_datetime
+
+        return updated
+
+    def _update_start_temporal_extent_on_item_update(
+        self, old_start_datetime, new_start_datetime, item_name, qs_other_items=None
+    ):
+        '''This function is called from within update_temporal_extent() when the
+        start_datetime of an item in the collection is updated to check if the
+        collection's start_datetime needs to be updated.
+
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            old_start_datetime: datetime
+                item's old value for properties_start_datetime
+            new_start_datetime: datetime
+                item's updated value for properties_start_datetime
+            item_name: str
+                the name of the item being treated
+            qs_other_items: QuerySet | None
+                queryset with all items of the collection excluding the one being updated.
+                (optional)
+
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+            return_qs: QuerySet | None
+                Queryset containing all items (but the one currently updated) that have
+                non-null properties_datetime values. This queryset might be used in
+                update_end_temporal_extent_on_item_update() and can be passed in already
+                evaluated state to save one DB hit.
+        '''
+        updated = False
+        return_qs = None
+        logger.debug(
+            "Updating collection extent start datetime %s with item (old start: %s, new start: %s)",
+            self.extent_start_datetime,
+            old_start_datetime,
+            new_start_datetime,
+            extra={
+                'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+            }
+        )
+
+        if old_start_datetime == self.extent_start_datetime:
+            # item's old start_datetime was defining left bound of the temporal
+            # extent interval of collection before update
+            if new_start_datetime < old_start_datetime:
+                logger.info(
+                    "Collection temporal extent start_datetime=%s updated "
+                    "to item start_datetime=%s",
+                    self.extent_start_datetime,
+                    new_start_datetime,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                updated |= True
+                # item's start_datetime was shifted to the left (earlier)
+                self.extent_start_datetime = new_start_datetime
+            else:
+                # item's start_datetime was shifted to the right (later)
+                # but was defining the left bound of the temporal extent
+                # of the collection before
+                # --> hence the new start_datetime of the collection
+                # needs to be determined:
+                # set earliest start_datetime to min(earliest_start_datetime
+                # of all items but the one currently updated and
+                # new_start_datetime).
+                logger.warning(
+                    'Item was defining the start extent and its new start is more recent; '
+                    'Looping over all items of the collection in order to find the new '
+                    'start extent, this may take a while !',
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                start = time.time()
+                qs_other_items_with_properties_start_datetime = qs_other_items.filter(
+                    properties_start_datetime__isnull=False
+                )
+                if qs_other_items_with_properties_start_datetime.exists():
+                    earliest_properties_start_datetime = (
+                        qs_other_items_with_properties_start_datetime.
+                        earliest('properties_start_datetime').properties_start_datetime
+                    )
+                    earliest_start_datetime = min(
+                        new_start_datetime, earliest_properties_start_datetime
+                    )
+                else:
+                    earliest_start_datetime = new_start_datetime
+                logger.info(
+                    'Found the item with the earliest start_datetime properties %s in %ss',
+                    earliest_start_datetime,
+                    time.time() - start,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+
+                start = time.time()
+                # set earliest datetime to min(earliest_datetime of all items
+                # but the one currently updated and new_start_datetime)
+                qs_other_items_with_properties_datetime = qs_other_items.filter(
+                    properties_datetime__isnull=False
+                )
+                if qs_other_items_with_properties_datetime.exists():
+                    other_items_earliest_properties_datetime = (
+                        qs_other_items_with_properties_datetime.earliest('properties_datetime'
+                                                                        ).properties_datetime
+                    )
+                    earliest_datetime = min(
+                        new_start_datetime, other_items_earliest_properties_datetime
+                    )
+                    return_qs = qs_other_items_with_properties_datetime
+                else:
+                    earliest_datetime = new_start_datetime
+                logger.info(
+                    'Found the item with the earliest datetime properties %s in %ss',
+                    earliest_datetime,
+                    time.time() - start,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+
+                updated |= True
+                new_extent_start = min(earliest_start_datetime, earliest_datetime)
+                logger.info(
+                    "Collection temporal extent start_datetime updated from %s to %s",
+                    self.extent_start_datetime,
+                    new_extent_start,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                self.extent_start_datetime = new_extent_start
+        elif new_start_datetime < self.extent_start_datetime:
+            # item's start_datetime did not define the left bound of the
+            # collection's temporal extent before update, which does not
+            # matter anyways, as it defines the new left bound after update
+            # and collection's start_datetime can be simply adjusted
+            logger.info(
+                "Collection temporal extent start_datetime=%s updated to item start_datetime=%s",
+                self.extent_start_datetime,
+                new_start_datetime,
+                extra={
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                }
+            )
+            updated |= True
+            self.extent_start_datetime = new_start_datetime
+
+        return updated, return_qs
+
+    def _update_end_temporal_extent_on_item_update(
+        self,
+        old_end_datetime,
+        new_end_datetime,
+        item_name,
+        qs_other_items=None,
+        qs_other_items_with_properties_datetime=None
+    ):
+        '''This function is called from within update_temporal_extent() when an
+        item in the collection is updated to check if the collection's
+        end_datetime needs to be updated.
+
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            old_end_datetime: datetime
+                item's old value for properties_end_datetime
+            new_end_datetime: datetime
+                item's updated value for properties_end_datetime
+            item_name: str
+                the name of the item being treated
+            qs_other_items: QuerySet | None
+                queryset with all items of the collection excluding the one being updated.
+                (optional)
+            qs_other_items_with_properties_datetimes: QuerySet | None
+                Already evaluated queryset with all items (but the one currently updated) that have
+                non-null properties_datetime values (optional).
+
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+        '''
+        updated = False
+        logger.debug(
+            "Updating collection extent_end_datetime %s with item "
+            "(old end_datetime: %s, new end_datetime: %s)",
+            self.extent_end_datetime,
+            old_end_datetime,
+            new_end_datetime,
+            extra={
+                'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+            }
+        )
+
+        if old_end_datetime == self.extent_end_datetime:
+            # item's old end_datetime was defining the right bound of
+            # the collection's temporal extent interval before update
+            if new_end_datetime > old_end_datetime:
+                logger.info(
+                    "Collection temporal extent_end_datetime %s updated to item end_datetime %s",
+                    self.extent_end_datetime,
+                    new_end_datetime,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                # item's end_datetime was shifted to the right (later)
+                updated |= True
+                self.extent_end_datetime = new_end_datetime
+            else:
+                # item's end_datetime was shifted to the left (earlier)
+                # but was defining the right bound of the collection's
+                # temporal extent.
+                # --> hence the new end_datetime of the collection needs
+                # to be determined:
+                # set latest end_datetime to max(new_end_datetime and
+                # end_datetime of all items but the one currently updated).
+                logger.warning(
+                    'Item was defining the end extent and its new end is less recent; '
+                    'Looping over all items of the collection in order to find the new end extent,'
+                    'this may take a while !',
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                start = time.time()
+                qs_other_items_with_properties_end_datetime = qs_other_items.filter(
+                    properties_end_datetime__isnull=False
+                )
+                if qs_other_items_with_properties_end_datetime.exists():
+                    item_latest_end_datetime = (
+                        qs_other_items_with_properties_end_datetime.
+                        latest('properties_end_datetime')
+                    )
+                    logger.info(
+                        'Found the item %s with the latest end_datetime properties %s',
+                        item_latest_end_datetime,
+                        item_latest_end_datetime.properties_end_datetime,
+                        extra={
+                            'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                        }
+                    )
+                    latest_end_datetime = max(
+                        new_end_datetime, item_latest_end_datetime.properties_end_datetime
+                    )
+                else:
+                    logger.info(
+                        'No item with end_datetime found, use the updated item end_datetime '
+                        '%s as end extent',
+                        new_end_datetime,
+                        extra={
+                            'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                        }
+                    )
+                    latest_end_datetime = new_end_datetime
+                logger.info(
+                    'Search for the item\'s latest_end_datetime took %ss',
+                    time.time() - start,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+
+                start = time.time()
+                # set latest datetime to max(new_end_datetime and
+                # end end_datetime of all items but the one currently updated)
+                # get latest datetime, or none in case none exists and
+                # use the already evaluated qs_other_items_with_properties_datetime, if it has
+                # been passed to this function to save a DB hit.
+                if qs_other_items_with_properties_datetime is None:
+                    qs_other_items_with_properties_datetime = qs_other_items.filter(
+                        properties_datetime__isnull=False
+                    )
+                if qs_other_items_with_properties_datetime.exists():
+                    item_latest_properties_datetime = (
+                        qs_other_items_with_properties_datetime.latest('properties_datetime')
+                    )
+                    logger.info(
+                        'Found the item %s with the latest datetime properties %s',
+                        item_latest_properties_datetime,
+                        item_latest_properties_datetime.properties_datetime,
+                        extra={
+                            'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                        }
+                    )
+                    latest_datetime = max(
+                        new_end_datetime, item_latest_properties_datetime.properties_datetime
+                    )
+                else:
+                    logger.info(
+                        'No item with datetime found, use the updated item end_datetime '
+                        '%s as end extent',
+                        new_end_datetime,
+                        extra={
+                            'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                        }
+                    )
+                    latest_datetime = new_end_datetime
+                logger.info(
+                    'Search for the item\'s latest_datetime took %ss',
+                    time.time() - start,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+
+                updated |= True
+                new_extent_end_datetime = max(latest_end_datetime, latest_datetime)
+                logger.info(
+                    "Collection temporal extent_end_datetime %s updated to %s s",
+                    self.extent_end_datetime,
+                    new_extent_end_datetime,
+                    extra={
+                        'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                    }
+                )
+                self.extent_end_datetime = new_extent_end_datetime
+        elif new_end_datetime > self.extent_end_datetime:
+            # item's end_datetime did not define the right bound of
+            # the collection's temporal extent before update, which
+            # does not matter anyways, as it defines the right bound
+            # after update and collection's end_date can be simply
+            # adjusted
+            updated |= True
+            logger.info(
+                "Collection temporal extent end_datetime=%s updated to item end_datetime=%s",
+                self.extent_start_datetime,
+                new_end_datetime,
+                extra={
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-update'
+                }
+            )
+            self.extent_end_datetime = new_end_datetime
+
+        return updated
+
+    def _update_start_temporal_extent_on_item_delete(
+        self, old_start_datetime, item_name, qs_other_items=None
+    ):
+        '''This function is called from within update_temporal_extent() when an
+        item is deleted from the collection to check if the collection's
+        start_datetime needs to be updated.
+
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            old_start_datetime: datetime
+                item's old value for properties_start_datetime
+            item_name: str
+                the name of the item being treated
+            qs_other_items: QuerySet | None
+                queryset with all items of the collection excluding the one being updated.
+                (optional)
+
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+            return_qs: QuerySet | None
+                Queryset containing all items (but the one currently updated) that have
+                non-null properties_datetime values. This queryset might be used in
+                update_end_temporal_extent_on_item_update() and can be passed in already
+                evaluated state to save one DB hit.
+        '''
+        updated = False
+        return_qs = None
+        logger.debug(
+            "Item deleted (start_datetime=%s) from collection, updating the "
+            "collection's extent_start_datetime (current: %s) if needed",
+            old_start_datetime,
+            self.extent_start_datetime,
+            extra={
+                'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
+            }
+        )
+
+        if old_start_datetime == self.extent_start_datetime:
+            # item that is to be deleted defined left bound of collection's
+            # temporal extent
             logger.warning(
-                'Item was defining the start extent and its new start is more recent; '
-                'Looping over all items of the collection in order to find the new start extent,'
+                'Item was defining the collection\'s extent start bound. We need to loop '
+                'over all items of the collection in order to update the temporal extent, '
                 'this may take a while !',
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
             start = time.time()
+            # get earliest start_datetime or none, in case none exists
             qs_other_items_with_properties_start_datetime = qs_other_items.filter(
                 properties_start_datetime__isnull=False
             )
             if qs_other_items_with_properties_start_datetime.exists():
-                earliest_properties_start_datetime = (
-                    qs_other_items_with_properties_start_datetime.
-                    earliest('properties_start_datetime').properties_start_datetime
-                )
-                earliest_start_datetime = min(
-                    new_start_datetime, earliest_properties_start_datetime
-                )
+                earliest_start_datetime = qs_other_items_with_properties_start_datetime.earliest(
+                    'properties_start_datetime'
+                ).properties_start_datetime
             else:
-                earliest_start_datetime = new_start_datetime
+                earliest_start_datetime = None
             logger.info(
-                'Found the item with the earliest start_datetime properties %s in %ss',
-                earliest_start_datetime,
+                'Search for the item\'s earliest_start_datetime took %ss: found %s',
                 time.time() - start,
+                earliest_start_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
 
+            # get earliest datetime, or none in case none exists
             start = time.time()
-            # set earliest datetime to min(earliest_datetime of all items
-            # but the one currently updated and new_start_datetime)
             qs_other_items_with_properties_datetime = qs_other_items.filter(
                 properties_datetime__isnull=False
             )
             if qs_other_items_with_properties_datetime.exists():
-                other_items_earliest_properties_datetime = (
-                    qs_other_items_with_properties_datetime.earliest('properties_datetime'
-                                                                    ).properties_datetime
-                )
-                earliest_datetime = min(
-                    new_start_datetime, other_items_earliest_properties_datetime
-                )
+                earliest_datetime = qs_other_items_with_properties_datetime.earliest(
+                    'properties_datetime'
+                ).properties_datetime
                 return_qs = qs_other_items_with_properties_datetime
             else:
-                earliest_datetime = new_start_datetime
+                earliest_datetime = None
             logger.info(
-                'Found the item with the earliest datetime properties %s in %ss',
-                earliest_datetime,
+                'Search for the item\'s earliest_datetime took %ss: found %s',
                 time.time() - start,
+                earliest_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
 
-            updated |= True
-            new_extent_start = min(earliest_start_datetime, earliest_datetime)
+            # set collection's new start_datetime to the minimum of the earliest
+            # item's start_datetime or datetime
+            if earliest_start_datetime is not None and earliest_datetime is not None:
+                new_extent_start_datetime = min(earliest_start_datetime, earliest_datetime)
+            elif earliest_datetime is not None:
+                new_extent_start_datetime = earliest_datetime
+            elif earliest_start_datetime is not None:
+                new_extent_start_datetime = earliest_start_datetime
+            else:
+                new_extent_start_datetime = None
+
             logger.info(
-                "Collection temporal extent start_datetime updated from %s to %s",
-                collection.extent_start_datetime,
-                new_extent_start,
+                'Updated collection extent_start_datetime from %s to %s',
+                self.extent_start_datetime,
+                new_extent_start_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
-            collection.extent_start_datetime = new_extent_start
-    elif new_start_datetime < collection.extent_start_datetime:
-        # item's start_datetime did not define the left bound of the
-        # collection's temporal extent before update, which does not
-        # matter anyways, as it defines the new left bound after update
-        # and collection's start_datetime can be simply adjusted
-        logger.info(
-            "Collection temporal extent start_datetime=%s updated to item start_datetime=%s",
-            collection.extent_start_datetime,
-            new_start_datetime,
+            self.extent_start_datetime = new_extent_start_datetime
+            updated |= True
+
+        return updated, return_qs
+
+    def _update_end_temporal_extent_on_item_delete(
+        self,
+        old_end_datetime,
+        item_name,
+        qs_other_items=None,
+        qs_other_items_with_properties_datetime=None
+    ):
+        '''This function is called from within update_temporal_extent() when an
+        item is deleted from the collection to check if the collection's
+        end_datetime needs to be updated.
+
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            old_end_datetime: datetime
+                item's old value for properties_end_datetime
+            item_name: str
+                the name of the item being treated
+            qs_other_items: QuerySet | None
+                queryset with all items of the collection excluding the one being updated.
+                (optional)
+            qs_other_items_with_properties_datetimes: QuerySet | None
+                Already evaluated queryset with all items (but the one currently updated) that have
+                non-null properties_datetime values (optional).
+
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+        '''
+        updated = False
+        logger.debug(
+            "Item deleted (end_datetime=%s) from collection, updating the "
+            "collection's extent_end_datetime (current: %s) if needed",
+            old_end_datetime,
+            self.extent_end_datetime,
             extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
             }
         )
-        updated |= True
-        collection.extent_start_datetime = new_start_datetime
 
-    return updated, return_qs
-
-
-def update_end_temporal_extent_on_item_update(
-    collection,
-    old_end_datetime,
-    new_end_datetime,
-    item_name,
-    qs_other_items=None,
-    qs_other_items_with_properties_datetime=None
-):
-    '''This function is called from within update_temporal_extent() when an
-    item in the collection is updated to check if the collection's
-    end_datetime needs to be updated.
-
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        old_end_datetime: datetime
-            item's old value for properties_end_datetime
-        new_end_datetime: datetime
-            item's updated value for properties_end_datetime
-        item_name: str
-            the name of the item being treated
-        qs_other_items: QuerySet | None
-            queryset with all items of the collection excluding the one being updated. (optional)
-        qs_other_items_with_properties_datetimes: QuerySet | None
-            Already evaluated queryset with all items (but the one currently updated) that have
-            non-null properties_datetime values (optional).
-
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-    '''
-    updated = False
-    logger.debug(
-        "Updating collection extent_end_datetime %s with item "
-        "(old end_datetime: %s, new end_datetime: %s)",
-        collection.extent_end_datetime,
-        old_end_datetime,
-        new_end_datetime,
-        extra={
-            'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-        }
-    )
-
-    if old_end_datetime == collection.extent_end_datetime:
-        # item's old end_datetime was defining the right bound of
-        # the collection's temporal extent interval before update
-        if new_end_datetime > old_end_datetime:
-            logger.info(
-                "Collection temporal extent_end_datetime %s updated to item end_datetime %s",
-                collection.extent_end_datetime,
-                new_end_datetime,
-                extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-                }
-            )
-            # item's end_datetime was shifted to the right (later)
-            updated |= True
-            collection.extent_end_datetime = new_end_datetime
-        else:
-            # item's end_datetime was shifted to the left (earlier)
-            # but was defining the right bound of the collection's
-            # temporal extent.
-            # --> hence the new end_datetime of the collection needs
-            # to be determined:
-            # set latest end_datetime to max(new_end_datetime and
-            # end_datetime of all items but the one currently updated).
+        if old_end_datetime == self.extent_end_datetime:
+            # item that is to be deleted defined right bound of collection's
+            # temporal extent
             logger.warning(
-                'Item was defining the end extent and its new end is less recent; '
-                'Looping over all items of the collection in order to find the new end extent,'
+                'Item was defining the collection\'s extent end bound. We need to loop '
+                'over all items of the collection in order to update the temporal extent, '
                 'this may take a while !',
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
             start = time.time()
+            # get latest end_datetime or none, in case none exists
             qs_other_items_with_properties_end_datetime = qs_other_items.filter(
                 properties_end_datetime__isnull=False
             )
             if qs_other_items_with_properties_end_datetime.exists():
-                item_latest_end_datetime = (
-                    qs_other_items_with_properties_end_datetime.latest('properties_end_datetime')
-                )
-                logger.info(
-                    'Found the item %s with the latest end_datetime properties %s',
-                    item_latest_end_datetime,
-                    item_latest_end_datetime.properties_end_datetime,
-                    extra={
-                        'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-                    }
-                )
-                latest_end_datetime = max(
-                    new_end_datetime, item_latest_end_datetime.properties_end_datetime
-                )
+                latest_end_datetime = qs_other_items_with_properties_end_datetime.latest(
+                    'properties_end_datetime'
+                ).properties_end_datetime
             else:
-                logger.info(
-                    'No item with end_datetime found, use the updated item end_datetime '
-                    '%s as end extent',
-                    new_end_datetime,
-                    extra={
-                        'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-                    }
-                )
-                latest_end_datetime = new_end_datetime
+                latest_end_datetime = None
             logger.info(
-                'Search for the item\'s latest_end_datetime took %ss',
+                'Search for the item\'s latest_end_datetime took %ss: found %s',
                 time.time() - start,
+                latest_end_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
 
-            start = time.time()
-            # set latest datetime to max(new_end_datetime and
-            # end end_datetime of all items but the one currently updated)
             # get latest datetime, or none in case none exists and
             # use the already evaluated qs_other_items_with_properties_datetime, if it has
             # been passed to this function to save a DB hit.
+            start = time.time()
             if qs_other_items_with_properties_datetime is None:
                 qs_other_items_with_properties_datetime = qs_other_items.filter(
                     properties_datetime__isnull=False
                 )
             if qs_other_items_with_properties_datetime.exists():
-                item_latest_properties_datetime = (
-                    qs_other_items_with_properties_datetime.latest('properties_datetime')
-                )
-                logger.info(
-                    'Found the item %s with the latest datetime properties %s',
-                    item_latest_properties_datetime,
-                    item_latest_properties_datetime.properties_datetime,
-                    extra={
-                        'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-                    }
-                )
-                latest_datetime = max(
-                    new_end_datetime, item_latest_properties_datetime.properties_datetime
-                )
+                latest_datetime = qs_other_items_with_properties_datetime.latest(
+                    'properties_datetime'
+                ).properties_datetime
             else:
-                logger.info(
-                    'No item with datetime found, use the updated item end_datetime '
-                    '%s as end extent',
-                    new_end_datetime,
-                    extra={
-                        'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-                    }
-                )
-                latest_datetime = new_end_datetime
+                latest_datetime = None
             logger.info(
-                'Search for the item\'s latest_datetime took %ss',
+                'Search for the item\'s latest_datetime took %ss: found %s',
                 time.time() - start,
+                latest_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
 
-            updated |= True
-            new_extent_end_datetime = max(latest_end_datetime, latest_datetime)
+            # set collection's new end_datetime to the maximum of the latest
+            # item's end_datetime or datetime
+            if latest_end_datetime is not None and latest_datetime is not None:
+                new_extent_end_datetime = max(latest_end_datetime, latest_datetime)
+            elif latest_datetime is not None:
+                new_extent_end_datetime = latest_datetime
+            elif latest_end_datetime is not None:
+                new_extent_end_datetime = latest_end_datetime
+            else:
+                new_extent_end_datetime = None
+
             logger.info(
-                "Collection temporal extent_end_datetime %s updated to %s s",
-                collection.extent_end_datetime,
+                'Updated collection extent_end_datetime from %s to %s',
+                self.extent_end_datetime,
                 new_extent_end_datetime,
                 extra={
-                    'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
+                    'collection': self.name, 'item': item_name, 'trigger': 'item-delete'
                 }
             )
-            collection.extent_end_datetime = new_extent_end_datetime
-    elif new_end_datetime > collection.extent_end_datetime:
-        # item's end_datetime did not define the right bound of
-        # the collection's temporal extent before update, which
-        # does not matter anyways, as it defines the right bound
-        # after update and collection's end_date can be simply
-        # adjusted
-        updated |= True
-        logger.info(
-            "Collection temporal extent end_datetime=%s updated to item end_datetime=%s",
-            collection.extent_start_datetime,
-            new_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-update'
-            }
-        )
-        collection.extent_end_datetime = new_end_datetime
+            self.extent_end_datetime = new_extent_end_datetime
+            updated |= True
 
-    return updated
+        return updated
 
-
-def update_start_temporal_extent_on_item_delete(
-    collection, old_start_datetime, item_name, qs_other_items=None
-):
-    '''This function is called from within update_temporal_extent() when an
-    item is deleted from the collection to check if the collection's
-    start_datetime needs to be updated.
-
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        old_start_datetime: datetime
-            item's old value for properties_start_datetime
-        item_name: str
-            the name of the item being treated
-        qs_other_items: QuerySet | None
-            queryset with all items of the collection excluding the one being updated. (optional)
-
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-        return_qs: QuerySet | None
-            Queryset containing all items (but the one currently updated) that have
-            non-null properties_datetime values. This queryset might be used in
-            update_end_temporal_extent_on_item_update() and can be passed in already
-            evaluated state to save one DB hit.
-    '''
-    updated = False
-    return_qs = None
-    logger.debug(
-        "Item deleted (start_datetime=%s) from collection, updating the "
-        "collection's extent_start_datetime (current: %s) if needed",
+    def _update_temporal_extent(
+        self,
+        item,
+        action,
         old_start_datetime,
-        collection.extent_start_datetime,
-        extra={
-            'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-        }
-    )
-
-    if old_start_datetime == collection.extent_start_datetime:
-        # item that is to be deleted defined left bound of collection's
-        # temporal extent
-        logger.warning(
-            'Item was defining the collection\'s extent start bound. We need to loop '
-            'over all items of the collection in order to update the temporal extent, '
-            'this may take a while !',
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-        start = time.time()
-        # get earliest start_datetime or none, in case none exists
-        qs_other_items_with_properties_start_datetime = qs_other_items.filter(
-            properties_start_datetime__isnull=False
-        )
-        if qs_other_items_with_properties_start_datetime.exists():
-            earliest_start_datetime = qs_other_items_with_properties_start_datetime.earliest(
-                'properties_start_datetime'
-            ).properties_start_datetime
-        else:
-            earliest_start_datetime = None
-        logger.info(
-            'Search for the item\'s earliest_start_datetime took %ss: found %s',
-            time.time() - start,
-            earliest_start_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-
-        # get earliest datetime, or none in case none exists
-        start = time.time()
-        qs_other_items_with_properties_datetime = qs_other_items.filter(
-            properties_datetime__isnull=False
-        )
-        if qs_other_items_with_properties_datetime.exists():
-            earliest_datetime = qs_other_items_with_properties_datetime.earliest(
-                'properties_datetime'
-            ).properties_datetime
-            return_qs = qs_other_items_with_properties_datetime
-        else:
-            earliest_datetime = None
-        logger.info(
-            'Search for the item\'s earliest_datetime took %ss: found %s',
-            time.time() - start,
-            earliest_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-
-        # set collection's new start_datetime to the minimum of the earliest
-        # item's start_datetime or datetime
-        if earliest_start_datetime is not None and earliest_datetime is not None:
-            new_extent_start_datetime = min(earliest_start_datetime, earliest_datetime)
-        elif earliest_datetime is not None:
-            new_extent_start_datetime = earliest_datetime
-        elif earliest_start_datetime is not None:
-            new_extent_start_datetime = earliest_start_datetime
-        else:
-            new_extent_start_datetime = None
-
-        logger.info(
-            'Updated collection extent_start_datetime from %s to %s',
-            collection.extent_start_datetime,
-            new_extent_start_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-        collection.extent_start_datetime = new_extent_start_datetime
-        updated |= True
-
-    return updated, return_qs
-
-
-def update_end_temporal_extent_on_item_delete(
-    collection,
-    old_end_datetime,
-    item_name,
-    qs_other_items=None,
-    qs_other_items_with_properties_datetime=None
-):
-    '''This function is called from within update_temporal_extent() when an
-    item is deleted from the collection to check if the collection's
-    end_datetime needs to be updated.
-
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        old_end_datetime: datetime
-            item's old value for properties_end_datetime
-        item_name: str
-            the name of the item being treated
-        qs_other_items: QuerySet | None
-            queryset with all items of the collection excluding the one being updated. (optional)
-        qs_other_items_with_properties_datetimes: QuerySet | None
-            Already evaluated queryset with all items (but the one currently updated) that have
-            non-null properties_datetime values (optional).
-
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-    '''
-    updated = False
-    logger.debug(
-        "Item deleted (end_datetime=%s) from collection, updating the "
-        "collection's extent_end_datetime (current: %s) if needed",
+        new_start_datetime,
         old_end_datetime,
-        collection.extent_end_datetime,
-        extra={
-            'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-        }
-    )
+        new_end_datetime
+    ):
+        '''Updates the collection's temporal extent when item's are updated.
 
-    if old_end_datetime == collection.extent_end_datetime:
-        # item that is to be deleted defined right bound of collection's
-        # temporal extent
-        logger.warning(
-            'Item was defining the collection\'s extent end bound. We need to loop '
-            'over all items of the collection in order to update the temporal extent, '
-            'this may take a while !',
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-        start = time.time()
-        # get latest end_datetime or none, in case none exists
-        qs_other_items_with_properties_end_datetime = qs_other_items.filter(
-            properties_end_datetime__isnull=False
-        )
-        if qs_other_items_with_properties_end_datetime.exists():
-            latest_end_datetime = qs_other_items_with_properties_end_datetime.latest(
-                'properties_end_datetime'
-            ).properties_end_datetime
-        else:
-            latest_end_datetime = None
-        logger.info(
-            'Search for the item\'s latest_end_datetime took %ss: found %s',
-            time.time() - start,
-            latest_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
+        This function will only be called, if the item's properties _datetime, _start_datetime or
+        _end_datetime have changed (at least one of them). If the calling item has no range defined
+        (i.e. no properties.start_datetime and no properties.end_datetime, but a properties.datetime
+        only), this function will be called using the item's properties.datetime both for the
+        start_ and the end_datetime as well.
 
-        # get latest datetime, or none in case none exists and
-        # use the already evaluated qs_other_items_with_properties_datetime, if it has
-        # been passed to this function to save a DB hit.
-        start = time.time()
-        if qs_other_items_with_properties_datetime is None:
-            qs_other_items_with_properties_datetime = qs_other_items.filter(
-                properties_datetime__isnull=False
+        Args:
+            collection: Collection
+                Collection instance on which to operate
+            item: Item
+                Item that changed
+            action: str
+                either up insert, update or delete
+            old_start_datetime: datetime
+                item's old value for properties_start_datetime or properties_datetime
+            new_start_datetime: datetime
+                item's updated value for properties_start_datetime or properties_datetime
+            old_end_datetime: datetime
+                item's old value for properties_end_datetime or properties_datetime
+            new_end_datetime: datetime
+                item's updated value for properties_end_datetime or properties_datetime
+
+        Returns:
+            bool: True if temporal extent has been updated, false otherwise
+        '''
+        updated = False
+        qs_other_items_with_properties_datetime = None
+        # INSERT (as item_id is None)
+        if action == "insert":
+            logger.debug(
+                "Item Inserted (datetime: start=%s, end=%s) in collection "
+                "(current extent; start=%s, end=%s); updating the collection's temporal "
+                "extent if needed.",
+                new_start_datetime,
+                new_end_datetime,
+                self.extent_start_datetime,
+                self.extent_end_datetime,
+                extra={
+                    'collection': self.name, 'item': item.name, 'trigger': 'item-insert'
+                }
             )
-        if qs_other_items_with_properties_datetime.exists():
-            latest_datetime = qs_other_items_with_properties_datetime.latest(
-                'properties_datetime'
-            ).properties_datetime
-        else:
-            latest_datetime = None
-        logger.info(
-            'Search for the item\'s latest_datetime took %ss: found %s',
-            time.time() - start,
-            latest_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
+            updated = self._update_temporal_extent_on_item_insert(
+                new_start_datetime,
+                new_end_datetime,
+                item.name,
+            )
 
-        # set collection's new end_datetime to the maximum of the latest
-        # item's end_datetime or datetime
-        if latest_end_datetime is not None and latest_datetime is not None:
-            new_extent_end_datetime = max(latest_end_datetime, latest_datetime)
-        elif latest_datetime is not None:
-            new_extent_end_datetime = latest_datetime
-        elif latest_end_datetime is not None:
-            new_extent_end_datetime = latest_end_datetime
-        else:
-            new_extent_end_datetime = None
+        # UPDATE
+        elif action == "update":
+            logger.debug(
+                "Item updated (old datetime: start=%s, end=%s; new datetime: start=%s, end=%s) "
+                "in collection (current extent; start=%s, end=%s); updating the collection's "
+                "temporal extent if needed.",
+                old_start_datetime,
+                old_end_datetime,
+                new_start_datetime,
+                new_end_datetime,
+                self.extent_start_datetime,
+                self.extent_end_datetime,
+                extra={
+                    'collection': self.name, 'item': item.name, 'trigger': 'item-update'
+                }
+            )
+            qs_other_items = None
+            if old_start_datetime != new_start_datetime:
+                if (
+                    old_start_datetime == self.extent_start_datetime and
+                    new_start_datetime > old_start_datetime
+                ):
+                    # item has defined the left and bound of the
+                    # collection's temporal extent before the update.
+                    # Collection's left bound needs to be updated now:
+                    # get all items but the one to that is being updated:
+                    qs_other_items = type(item).objects.filter(collection_id=self.pk
+                                                              ).exclude(id=item.pk)
+                    updated_temp, qs_other_items_with_properties_datetime = (
+                        self._update_start_temporal_extent_on_item_update(
+                            old_start_datetime,
+                            new_start_datetime,
+                            item.name,
+                            qs_other_items
+                        )
+                    )
+                    updated |= updated_temp
+                else:
+                    # Item probably has defined the left bound before update and
+                    # might define the new left bound again
+                    updated_temp, qs_other_items_with_properties_datetime = (
+                        self._update_start_temporal_extent_on_item_update(
+                            old_start_datetime,
+                            new_start_datetime,
+                            item.name,
+                            qs_other_items=None
+                        )
+                    )
+                    updated |= updated_temp
 
-        logger.info(
-            'Updated collection extent_end_datetime from %s to %s',
-            collection.extent_end_datetime,
-            new_extent_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item_name, 'trigger': 'item-delete'
-            }
-        )
-        collection.extent_end_datetime = new_extent_end_datetime
-        updated |= True
+            if old_end_datetime != new_end_datetime:
+                if (
+                    old_end_datetime == self.extent_end_datetime and
+                    new_end_datetime < old_end_datetime
+                ):
+                    # item has defined the right bound of the
+                    # collection's temporal extent before the update.
+                    # Collection's right bound needs to be updated now:
+                    # get all items but the one that is being updated:
+                    qs_other_items = type(item).objects.filter(collection_id=self.pk
+                                                              ).exclude(id=item.pk)
 
-    return updated
+                    updated |= self._update_end_temporal_extent_on_item_update(
+                        old_end_datetime,
+                        new_end_datetime,
+                        item.name,
+                        qs_other_items=qs_other_items,
+                        qs_other_items_with_properties_datetime=
+                        qs_other_items_with_properties_datetime
+                    )
+                else:
+                    # Item probably has defined the right bound before update and
+                    # might define the new right bound again
+                    updated |= self._update_end_temporal_extent_on_item_update(
+                        old_end_datetime,
+                        new_end_datetime,
+                        item.name,
+                        qs_other_items=None,
+                        qs_other_items_with_properties_datetime=
+                        qs_other_items_with_properties_datetime
+                    )
 
-
-def update_temporal_extent(
-    collection,
-    item,
-    action,
-    old_start_datetime,
-    new_start_datetime,
-    old_end_datetime,
-    new_end_datetime
-):
-    '''Updates the collection's temporal extent when item's are updated.
-
-    This function will only be called, if the item's properties _datetime, _start_datetime or
-    _end_datetime have changed (at least one of them). If the calling item has no range defined
-    (i.e. no properties.start_datetime and no properties.end_datetime, but a properties.datetime
-    only), this function will be called using the item's properties.datetime both for the
-    start_ and the end_datetime as well.
-
-    Args:
-        collection: Collection
-            Collection instance on which to operate
-        item: Item
-            Item that changed
-        action: str
-            either up insert, update or delete
-        old_start_datetime: datetime
-            item's old value for properties_start_datetime or properties_datetime
-        new_start_datetime: datetime
-            item's updated value for properties_start_datetime or properties_datetime
-        old_end_datetime: datetime
-            item's old value for properties_end_datetime or properties_datetime
-        new_end_datetime: datetime
-            item's updated value for properties_end_datetime or properties_datetime
-
-    Returns:
-        bool: True if temporal extent has been updated, false otherwise
-    '''
-    updated = False
-    qs_other_items_with_properties_datetime = None
-    # INSERT (as item_id is None)
-    if action == "insert":
-        logger.debug(
-            "Item Inserted (datetime: start=%s, end=%s) in collection (current extent; start=%s, "
-            "end=%s); updating the collection's temporal extent if needed.",
-            new_start_datetime,
-            new_end_datetime,
-            collection.extent_start_datetime,
-            collection.extent_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item.name, 'trigger': 'item-insert'
-            }
-        )
-        updated = update_temporal_extent_on_item_insert(
-            collection,
-            new_start_datetime,
-            new_end_datetime,
-            item.name,
-        )
-
-    # UPDATE
-    elif action == "update":
-        logger.debug(
-            "Item updated (old datetime: start=%s, end=%s; new datetime: start=%s, end=%s) "
-            "in collection (current extent; start=%s, end=%s); updating the collection's "
-            "temporal extent if needed.",
-            old_start_datetime,
-            old_end_datetime,
-            new_start_datetime,
-            new_end_datetime,
-            collection.extent_start_datetime,
-            collection.extent_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item.name, 'trigger': 'item-update'
-            }
-        )
-        qs_other_items = None
-        if old_start_datetime != new_start_datetime:
+        # DELETE
+        elif action == 'delete':
+            logger.debug(
+                "Item deleted (datetime: start=%s, end=%s) "
+                "in collection (current extent; start=%s, end=%s); updating the collection's "
+                "temporal extent if needed.",
+                old_start_datetime,
+                old_end_datetime,
+                self.extent_start_datetime,
+                self.extent_end_datetime,
+                extra={
+                    'collection': self.name, 'item': item.name, 'trigger': 'item-delete'
+                }
+            )
             if (
-                old_start_datetime == collection.extent_start_datetime and
-                new_start_datetime > old_start_datetime
+                old_start_datetime == self.extent_start_datetime or
+                old_end_datetime == self.extent_end_datetime
             ):
-                # item has defined the left and bound of the
-                # collection's temporal extent before the update.
-                # Collection's left bound needs to be updated now:
-                # get all items but the one to that is being updated:
-                qs_other_items = type(item).objects.filter(collection_id=collection.pk
+                # get all items but the one to be deleted:
+                qs_other_items = type(item).objects.filter(collection_id=self.pk
                                                           ).exclude(id=item.pk)
                 updated_temp, qs_other_items_with_properties_datetime = (
-                    update_start_temporal_extent_on_item_update(
-                        collection,
+                    self._update_start_temporal_extent_on_item_delete(
                         old_start_datetime,
-                        new_start_datetime,
                         item.name,
                         qs_other_items
                     )
                 )
                 updated |= updated_temp
-            else:
-                # Item probably has defined the left bound before update and
-                # might define the new left bound again
-                updated_temp, qs_other_items_with_properties_datetime = (
-                    update_start_temporal_extent_on_item_update(
-                        collection,
-                        old_start_datetime,
-                        new_start_datetime,
-                        item.name,
-                        qs_other_items=None
-                    )
-                )
-                updated |= updated_temp
-
-        if old_end_datetime != new_end_datetime:
-            if (
-                old_end_datetime == collection.extent_end_datetime and
-                new_end_datetime < old_end_datetime
-            ):
-                # item has defined the right bound of the
-                # collection's temporal extent before the update.
-                # Collection's right bound needs to be updated now:
-                # get all items but the one that is being updated:
-                qs_other_items = type(item).objects.filter(collection_id=collection.pk
-                                                          ).exclude(id=item.pk)
-
-                updated |= update_end_temporal_extent_on_item_update(
-                    collection,
+                updated |= self._update_end_temporal_extent_on_item_delete(
                     old_end_datetime,
-                    new_end_datetime,
                     item.name,
                     qs_other_items=qs_other_items,
                     qs_other_items_with_properties_datetime=qs_other_items_with_properties_datetime
                 )
             else:
-                # Item probably has defined the right bound before update and
-                # might define the new right bound again
-                updated |= update_end_temporal_extent_on_item_update(
-                    collection,
+                updated_temp, qs_other_items_with_properties_datetime = (
+                    self._update_start_temporal_extent_on_item_delete(
+                        old_start_datetime,
+                        item.name,
+                        qs_other_items=None,
+                    )
+                )
+
+                updated |= updated_temp
+                updated |= self._update_end_temporal_extent_on_item_delete(
                     old_end_datetime,
-                    new_end_datetime,
                     item.name,
                     qs_other_items=None,
                     qs_other_items_with_properties_datetime=qs_other_items_with_properties_datetime
                 )
-
-    # DELETE
-    elif action == 'delete':
-        logger.debug(
-            "Item deleted (datetime: start=%s, end=%s) "
-            "in collection (current extent; start=%s, end=%s); updating the collection's "
-            "temporal extent if needed.",
-            old_start_datetime,
-            old_end_datetime,
-            collection.extent_start_datetime,
-            collection.extent_end_datetime,
-            extra={
-                'collection': collection.name, 'item': item.name, 'trigger': 'item-delete'
-            }
-        )
-        if (
-            old_start_datetime == collection.extent_start_datetime or
-            old_end_datetime == collection.extent_end_datetime
-        ):
-            # get all items but the one to be deleted:
-            qs_other_items = type(item).objects.filter(collection_id=collection.pk
-                                                      ).exclude(id=item.pk)
-            updated_temp, qs_other_items_with_properties_datetime = (
-                update_start_temporal_extent_on_item_delete(
-                    collection,
-                    old_start_datetime,
-                    item.name,
-                    qs_other_items
-                )
-            )
-            updated |= updated_temp
-            updated |= update_end_temporal_extent_on_item_delete(
-                collection,
-                old_end_datetime,
-                item.name,
-                qs_other_items=qs_other_items,
-                qs_other_items_with_properties_datetime=qs_other_items_with_properties_datetime
-            )
-        else:
-            updated_temp, qs_other_items_with_properties_datetime = (
-                update_start_temporal_extent_on_item_delete(
-                    collection,
-                    old_start_datetime,
-                    item.name,
-                    qs_other_items=None,
-                )
-            )
-
-            updated |= updated_temp
-            updated |= update_end_temporal_extent_on_item_delete(
-                collection,
-                old_end_datetime,
-                item.name,
-                qs_other_items=None,
-                qs_other_items_with_properties_datetime=qs_other_items_with_properties_datetime
-            )
-    return updated
+        return updated

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -228,6 +228,7 @@ class Collection(models.Model):
     def update_etag(self):
         '''Update the ETag with a new UUID
         '''
+        logger.debug('Updating collection etag', extra={'collection': self.name})
         self.etag = compute_etag()
 
     def update_bbox_extent(self, trigger, geometry, original_geometry, item_id, item_name):
@@ -256,7 +257,7 @@ class Collection(models.Model):
         try:
             # insert (as item_id is None)
             if trigger == 'insert':
-                logger.debug('Updating collections extent_geometry' ' as a item has been inserted')
+                logger.debug('Updating collections extent_geometry' ' as a item has been inserted',)
                 # the first item of this collection
                 if self.extent_geometry is None:
                     self.extent_geometry = Polygon.from_bbox(GEOSGeometry(geometry).extent)
@@ -403,7 +404,11 @@ class Collection(models.Model):
             old_values,
             [asset.eo_gsd, asset.geoadmin_variant, asset.proj_epsg],
             self.summaries,
-            extra={'collection': self.name},
+            extra={
+                'collection': self.name,
+                'item': asset.item.name,
+                'asset': asset.name,
+            },
         )
 
         if trigger == 'delete':

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -429,6 +429,11 @@ class Collection(models.Model):
                 end_datetime
             )
         else:
+            logger.critical(
+                'Failed to update collection temporal extent; invalid trigger parameter %s',
+                trigger,
+                extra={'collection', self.name, 'item', item.name}
+            )
             raise ValueError(f'Invalid trigger parameter; {trigger}')
 
         return updated

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -16,7 +16,7 @@ services:
     # for it to be ready before connecting
     # see: https://docs.docker.com/compose/startup-order/
     entrypoint: ["/app/wait-for-it.sh", "db:5432", "--", "python3", "manage.py"]
-    command: test --verbosity=2 --parallel=10
+    command: test --verbosity=2 --parallel=10 --no-input
     depends_on:
       - db
     environment:


### PR DESCRIPTION
This improves the logging of the collection updates (extent and summaries).

To simplify the logging and improve the filter possibilities, I moved all code related to the collection update in separate modules. This give the possibility for example on ELK to filter all the logs related to the collection update summaries, or to the update spatial extent, ...

In the last commits I refactored the collection update in mixins, this is not really needed and could be reverted if you don't like it ? Note that some logs are then still in the models.py module.

@rebert @hansmannj  @boecklic for the review you might want to review commit by commit, otherwise the diff is just huge due to reorganisation. The last 3 commits is just the refactoring in mixin.