### PR TITLE
fixed small issue in _filter_by_datetime_range

### DIFF
--- a/app/stac_api/managers.py
+++ b/app/stac_api/managers.py
@@ -103,7 +103,7 @@ class ItemQuerySet(models.QuerySet):
             # open end range
             return self.filter(
                 Q(properties_datetime__gte=start_datetime) |
-                Q(properties_end_datetime__gte=start_datetime)
+                Q(properties_start_datetime__gte=start_datetime)
             )
             # else fixed range
         return self.filter(


### PR DESCRIPTION
when checking all the .filter(), Q(), et al. expressions for BGDIINF_SB-1541, I came along this Q()
and thought, it might be `properties_start_datetime` instead of `properties_end_datetime` here.

There were no unit tests complaining after this change. Probably the existing tests need to be adapted or new ones added? I'll create a ticket for that, what do you think @rebert ?