### PR TITLE
BGDIINF_SB-1571: Do not use the cache middleware for static files

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -16,6 +16,8 @@ from dotenv import load_dotenv
 
 from .version import APP_VERSION  # pylint: disable=unused-import
 
+STAC_VERSION = "0.9.0"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 print(f"BASE_DIR is {BASE_DIR}")

--- a/app/middleware/cache_headers.py
+++ b/app/middleware/cache_headers.py
@@ -29,7 +29,10 @@ class CacheHeadersMiddleware:
         if request.path in ['/checker', '/get-token']:
             # never cache the /checker and /get-token endpoints.
             add_never_cache_headers(response)
-        elif request.method in ('GET', 'HEAD'):
+        elif (
+            request.method in ('GET', 'HEAD') and
+            not request.path.startswith(f'/api/stac/{settings.STAC_VERSION}/static/')
+        ):
             logger.debug(
                 "Patching cache headers for request %s %s",
                 request.method,

--- a/app/middleware/cache_headers.py
+++ b/app/middleware/cache_headers.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.cache import add_never_cache_headers
@@ -31,7 +32,7 @@ class CacheHeadersMiddleware:
             add_never_cache_headers(response)
         elif (
             request.method in ('GET', 'HEAD') and
-            not request.path.startswith(f'/api/stac/{settings.STAC_VERSION}/static/')
+            not request.path.startswith(urlparse(settings.STATIC_URL).path)
         ):
             logger.debug(
                 "Patching cache headers for request %s %s",

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -34,8 +34,6 @@ from stac_api.validators_serializer import validate_json_payload
 
 logger = logging.getLogger(__name__)
 
-STAC_VERSION = "0.9.0"
-
 
 def create_or_update_str(created):
     if created:
@@ -192,7 +190,7 @@ class LandingPageSerializer(serializers.ModelSerializer):
     stac_version = serializers.SerializerMethodField()
 
     def get_stac_version(self, obj):
-        return STAC_VERSION
+        return settings.STAC_VERSION
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -368,7 +366,7 @@ class CollectionSerializer(NonNullModelSerializer):
         return list()
 
     def get_stac_version(self, obj):
-        return STAC_VERSION
+        return settings.STAC_VERSION
 
     def _update_or_create_providers(self, collection, providers_data):
         provider_ids = []
@@ -787,7 +785,7 @@ class ItemSerializer(NonNullModelSerializer):
         return list()
 
     def get_stac_version(self, obj):
-        return STAC_VERSION
+        return settings.STAC_VERSION
 
     def to_representation(self, instance):
         collection = instance.collection.name

--- a/app/tests/test_landing_page.py
+++ b/app/tests/test_landing_page.py
@@ -1,9 +1,6 @@
+from django.conf import settings
 from django.test import Client
 from django.test import TestCase
-
-from stac_api.serializers import STAC_VERSION
-
-from config.settings import API_BASE
 
 
 class IndexTestCase(TestCase):
@@ -12,7 +9,7 @@ class IndexTestCase(TestCase):
         self.client = Client()
 
     def test_landing_page(self):
-        response = self.client.get(f"/{API_BASE}/")
+        response = self.client.get(f"/{settings.API_BASE}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         required_keys = ['description', 'id', 'stac_version', 'links']
@@ -22,7 +19,7 @@ class IndexTestCase(TestCase):
             msg="missing required attribute in json answer"
         )
         self.assertEqual(response.json()['id'], 'ch')
-        self.assertEqual(response.json()['stac_version'], STAC_VERSION)
+        self.assertEqual(response.json()['stac_version'], settings.STAC_VERSION)
         for link in response.json()['links']:
             required_keys = ['href', 'rel']
             self.assertEqual(

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory
 
-from stac_api.serializers import STAC_VERSION
 from stac_api.serializers import AssetSerializer
 from stac_api.serializers import CollectionSerializer
 from stac_api.serializers import ItemSerializer
@@ -127,7 +126,7 @@ class CollectionSerializationTestCase(StacBaseTestCase):
                 'view',
                 'https://data.geo.admin.ch/stac/geoadmin-extension/1.0/schema.json'
             ],
-            'stac_version': STAC_VERSION,
+            'stac_version': settings.STAC_VERSION,
             'summaries': {
                 'eo:gsd': [3.4],
                 'geoadmin:variant': ['kgrs'],
@@ -283,7 +282,7 @@ class ItemSerializationTestCase(StacBaseTestCase):
                 'view',
                 'https://data.geo.admin.ch/stac/geoadmin-extension/1.0/schema.json'
             ],
-            'stac_version': STAC_VERSION,
+            'stac_version': settings.STAC_VERSION,
             'type': 'Feature'
         })
         self.check_stac_item(expected, python_native, collection_name)


### PR DESCRIPTION
Static files already have the cache header therefore do not overwrite
them.