### PR TITLE
Do not update the collection extent and summaries on collection delete.

### DIFF
--- a/app/stac_api/signals.py
+++ b/app/stac_api/signals.py
@@ -14,4 +14,4 @@ def delete_s3_asset(sender, instance, **kwargs):
     # when the object holding its reference is deleted
     # hence it has to be done here.
     logger.info("The asset %s is deleted from s3", instance.file.name)
-    instance.file.delete()
+    instance.file.delete(save=False)


### PR DESCRIPTION
When deleting a collection from the admin page, the update extent and
summaries was triggered for each asset and items that was also deleted.

When deleting from the admin page, the model's delete() method are not
called, but the `pre_delete` signal is sent. With this signal we are
deleting asset on S3 using the File delete() method. This method
triggered and Asset update which was triggering a collection summaries
update and an item update which triggered a collection extent update.

Because we are deleting an asset (file and metadata) it doesn't make
sense to save the metadata object.

This improves massevely performance for deletion from admin page
(deletion of a collection with several thousand items did not work
before due to timesout)