### PR TITLE
BGDIINF_SB-1624: Comment ou temporarly asset management

### DIFF
--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -4,7 +4,7 @@ import os
 import time
 from uuid import uuid4
 
-import botocore.exceptions
+# import botocore.exceptions # Un-comment with BGDIINF_SB-1625
 import multihash
 
 from django.conf import settings
@@ -23,7 +23,7 @@ from stac_api.collection_summaries import CollectionSummariesMixin
 from stac_api.collection_temporal_extent import CollectionTemporalExtentMixin
 from stac_api.managers import ItemManager
 from stac_api.utils import get_asset_path
-from stac_api.utils import get_s3_resource
+# from stac_api.utils import get_s3_resource # Un-comment with BGDIINF_SB-1625
 from stac_api.validators import MEDIA_TYPES
 from stac_api.validators import validate_geoadmin_variant
 from stac_api.validators import validate_geometry
@@ -523,30 +523,75 @@ class Asset(models.Model):
         self.etag = compute_etag()
 
     def move_asset(self, source, dest):
-        logger.info("Renaming asset on s3 from %s to %s", source, dest)
-        s3 = get_s3_resource()
+        # Un-comment and remove the warning with BGDIINF_SB-1625
+        logger.warning(
+            'Asset %s has been renamed to %s, file needs to renamed on S3 as well !',
+            source,
+            dest,
+            extra={
+                'collection': self.item.collection.name, 'item': self.item.name, 'asset': self.name
+            }
+        )
+        # logger.info(
+        #     "Renaming asset on s3 from %s to %s",
+        #     source,
+        #     dest,
+        #     extra={
+        #         'collection': self.item.collection.name,
+        #         'item': self.item.name,
+        #         'asset': self.name
+        #     }
+        # )
+        # s3 = get_s3_resource()
 
-        try:
-            s3.Object(settings.AWS_STORAGE_BUCKET_NAME,
-                      dest).copy_from(CopySource=f'{settings.AWS_STORAGE_BUCKET_NAME}/{source}')
-            s3.Object(settings.AWS_STORAGE_BUCKET_NAME, source).delete()
-            self.file.name = dest
-        except botocore.exceptions.ClientError as error:
-            logger.error(
-                'Failed to move asset %s from %s to %s: %s', self.name, source, dest, error
-            )
-            raise error
+        # try:
+        #     s3.Object(settings.AWS_STORAGE_BUCKET_NAME,
+        #               dest).copy_from(CopySource=f'{settings.AWS_STORAGE_BUCKET_NAME}/{source}')
+        #     s3.Object(settings.AWS_STORAGE_BUCKET_NAME, source).delete()
+        #     self.file.name = dest
+        # except botocore.exceptions.ClientError as error:
+        #     logger.error(
+        #         'Failed to move asset %s from %s to %s: %s',
+        #         self.name,
+        #         source,
+        #         dest,
+        #         error,
+        #         extra={
+        #             'collection': self.item.collection.name,
+        #             'item': self.item.name,
+        #             'asset': self.name
+        #         }
+        #     )
+        #     raise error
 
-    def remove_asset(self, source):
-        logger.info("Remove asset on s3 from %s", source)
-        s3 = get_s3_resource()
+    # def remove_asset(self, source):
+    #     logger.info(
+    #         "Remove asset on s3 from %s",
+    #         source,
+    #         extra={
+    #             'collection': self.item.collection.name,
+    #             'item': self.item.name,
+    #             'asset': self.name
+    #         }
+    #     )
+    #     s3 = get_s3_resource()
 
-        try:
-            s3.Object(settings.AWS_STORAGE_BUCKET_NAME, source).delete()
-        except botocore.exceptions.ClientError as error:
-            logger.error('Failed to remove asset %s from %s: %s', self.name, source, error)
-        self.file.name = ''
-        self.checksum_multihash = ''
+    #     try:
+    #         s3.Object(settings.AWS_STORAGE_BUCKET_NAME, source).delete()
+    #     except botocore.exceptions.ClientError as error:
+    #         logger.error(
+    #             'Failed to remove asset %s from %s: %s',
+    #             self.name,
+    #             source,
+    #             error,
+    #             extra={
+    #                 'collection': self.item.collection.name,
+    #                 'item': self.item.name,
+    #                 'asset': self.name
+    #             }
+    #         )
+    #     self.file.name = ''
+    #     self.checksum_multihash = ''
 
     # alter save-function, so that the corresponding collection of the parent item of the asset
     # is saved, too.

--- a/app/stac_api/signals.py
+++ b/app/stac_api/signals.py
@@ -1,17 +1,17 @@
-import logging
+# Un-comment with BGDIINF_SB-1625
+# import logging
 
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
+# from django.db.models.signals import pre_delete
+# from django.dispatch import receiver
 
-from stac_api.models import Asset
+# from stac_api.models import Asset
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
 
-
-@receiver(pre_delete, sender=Asset)
-def delete_s3_asset(sender, instance, **kwargs):
-    # The file is not automatically deleted by Django
-    # when the object holding its reference is deleted
-    # hence it has to be done here.
-    logger.info("The asset %s is deleted from s3", instance.file.name)
-    instance.file.delete(save=False)
+# @receiver(pre_delete, sender=Asset)
+# def delete_s3_asset(sender, instance, **kwargs):
+#     # The file is not automatically deleted by Django
+#     # when the object holding its reference is deleted
+#     # hence it has to be done here.
+#     logger.info("The asset %s is deleted from s3", instance.file.name)
+#     instance.file.delete(save=False)

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -687,12 +687,13 @@ class AdminAssetTestCase(AdminBaseTestCase, S3TestMixin):
         response = self.client.post(reverse('admin:stac_api_asset_change', args=[asset.id]), data)
         self.assertEqual(response.status_code, 302)
 
+        # Un-comment with BGDIINF_SB-1625
         # Assert that the location on s3 has been changed
-        new_path = f"{asset.item.collection.name}/{asset.item.name}/{data['name']}"
-        self.assertS3ObjectExists(new_path)
+        # new_path = f"{asset.item.collection.name}/{asset.item.name}/{data['name']}"
+        # self.assertS3ObjectExists(new_path)
 
-        asset.refresh_from_db()
-        self.assertEqual(asset.file.name, new_path)
+        # asset.refresh_from_db()
+        # self.assertEqual(asset.file.name, new_path)
 
     def test_add_asset_with_invalid_data(self):
         # Login the user first
@@ -733,4 +734,4 @@ class AdminAssetTestCase(AdminBaseTestCase, S3TestMixin):
             Asset.objects.filter(name=data["name"]).exists(), msg="Admin page asset still in DB"
         )
 
-        self.assertS3ObjectNotExists(path)
+        # self.assertS3ObjectNotExists(path) # Un-comment with BGDIINF_SB-1625


### PR DESCRIPTION
In order to avoid any bad surprise short for the go live on march and
due the performance issue when changing item geometry the asset
management on S3 is temporarly commented out. This needs to be somehow
reintroduce after the go live within BGDIINF_SB-1625