### PR TITLE
BGDIINF_SB-1626: make sure that the required read only fields are checked in unittest

### DIFF
--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -114,6 +114,7 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('collection', expected, current, ignore)
+        # check required fields
         for key, value in [
             ('stac_version', '0.9.0'),
             ('crs', ['http://www.opengis.net/def/crs/OGC/1.3/CRS84']),
@@ -121,9 +122,10 @@ class StacBaseTestCase(TestCase):
         ]:
             self.assertIn(key, current)
             self.assertEqual(value, current[key])
-        for key in ['extent', 'summaries', 'links', 'created', 'updated']:
+        for key in ['id', 'extent', 'summaries', 'links', 'description', 'license']:
             self.assertIn(key, current, msg=f'Collection {key} is missing')
         for date_field in ['created', 'updated']:
+            self.assertIn(date_field, current, msg=f'Collection {date_field} is missing')
             self.assertTrue(
                 fromisoformat(current[date_field]),
                 msg=f"The collection field {date_field} has an invalid date"
@@ -165,14 +167,17 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('item', expected, current, ignore=ignore)
+
+        # check required fields
         for key, value in [('stac_version', '0.9.0'), ('type', 'Feature')]:
             self.assertIn(key, current)
             self.assertEqual(value, current[key])
-        for key in ['bbox', 'links', 'properties']:
+        for key in ['id', 'bbox', 'links', 'properties', 'assets', 'geometry']:
             self.assertIn(key, current, msg=f'Item {key} is missing')
-        for key in ['created', 'updated']:
-            self.assertIn(key, current['properties'], msg=f'Item properties.{key} is missing')
         for date_field in ['created', 'updated']:
+            self.assertIn(
+                date_field, current['properties'], msg=f'Item properties.{date_field} is missing'
+            )
             self.assertTrue(
                 fromisoformat(current['properties'][date_field]),
                 msg=f"The item field {date_field} has an invalid date"
@@ -215,9 +220,12 @@ class StacBaseTestCase(TestCase):
         if ignore is None:
             ignore = []
         self._check_stac_dictsubset('asset', expected, current, ignore=ignore)
-        for key in ['links', 'created', 'updated']:
+
+        # check required fields
+        for key in ['links', 'id', 'type', 'checksum:multihash', 'href']:
             self.assertIn(key, current, msg=f'Asset {key} is missing')
         for date_field in ['created', 'updated']:
+            self.assertIn(date_field, current, msg=f'Asset {date_field} is missing')
             self.assertTrue(
                 fromisoformat(current[date_field]),
                 msg=f"The asset field {date_field} has an invalid date"

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -173,6 +173,9 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
             path, data=asset.get_json('post'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_attribute': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         # Make sure that the asset is not found in DB
         self.assertFalse(
@@ -192,6 +195,14 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
             path, data=asset.get_json('post', keep_read_only=True), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual(
+            {
+                'created': ['Found read-only property in payload'],
+                'href': ['Found read-only property in payload']
+            },
+            response.json()['description'],
+            msg='Unexpected error message',
+        )
 
         # Make sure that the asset is not found in DB
         self.assertFalse(
@@ -237,6 +248,16 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
             path, data=asset.get_json('post'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual(
+            {
+                'eo:gsd': ['A valid number is required.'],
+                'geoadmin:lang': ['"12" is not a valid choice.'],
+                'proj:epsg': ['A valid integer is required.'],
+                'type': ['"dummy" is not a valid choice.']
+            },
+            response.json()['description'],
+            msg='Unexpected error message',
+        )
 
         # Make sure that the asset is not found in DB
         self.assertFalse(
@@ -268,6 +289,17 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
             path, data=asset.get_json('post'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual(
+            {
+                'geoadmin:variant': [
+                    'Invalid geoadmin:variant, special characters beside one '
+                    'space are not allowed',
+                    'Ensure this field has no more than 25 characters.'
+                ]
+            },
+            response.json()['description'],
+            msg='Unexpected error message',
+        )
 
 
 class AssetsWriteEndpointAssetFileTestCase(StacBaseTestCase):
@@ -537,6 +569,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             path, data=changed_asset.get_json('put'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_attribute': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_asset_endpoint_put_read_only_in_payload(self):
         collection_name = self.collection['name']
@@ -558,6 +593,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_asset_endpoint_put_rename_asset(self):
         collection_name = self.collection['name']
@@ -639,6 +677,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             path, data=changed_asset.get_json('patch'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_payload': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_asset_endpoint_patch_read_only_in_payload(self):
         collection_name = self.collection['name']
@@ -658,6 +699,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             content_type="application/json"
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
 
 class AssetsDeleteEndpointTestCase(StacBaseTestCase):

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -50,15 +50,27 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
 
         response = self.client.get(f"/{API_BASE}/collections?limit=0")
         self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=test")
         self.assertStatusCode(400, response)
+        self.assertEqual(['invalid limit query parameter: must be an integer'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=-1")
         self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=1000")
         self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to big, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
 
 class CollectionsWriteEndpointTestCase(StacBaseTestCase):
@@ -91,6 +103,9 @@ class CollectionsWriteEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'id': ['This field must be unique.']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collections_post_extra_payload(self):
         collection = self.collection_factory.create_sample(extra_payload='not allowed')
@@ -101,6 +116,9 @@ class CollectionsWriteEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_payload': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collections_post_read_only_in_payload(self):
         collection = self.collection_factory.create_sample(created=utc_aware(datetime.utcnow()))
@@ -111,6 +129,9 @@ class CollectionsWriteEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_invalid_collections_post(self):
         # the dataset already exists in the database
@@ -122,6 +143,9 @@ class CollectionsWriteEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'license': ['Not a valid string.']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collections_min_mandatory_post(self):
         # a post with the absolute valid minimum
@@ -151,6 +175,14 @@ class CollectionsWriteEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual(
+            {
+                'description': ['This field is required.'],
+                'license': ['This field is required.'],
+            },
+            response.json()['description'],
+            msg='Unexpected error message',
+        )
 
 
 class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
@@ -203,6 +235,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_payload': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collections_put_read_only_in_payload(self):
         sample = self.collection_factory.create_sample(
@@ -215,6 +250,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collection_put_change_id(self):
         sample = self.collection_factory.create_sample(
@@ -290,6 +328,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'extra_payload': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_collection_patch_read_only_in_payload(self):
         collection_name = self.collection.name  # get a name that is registered in the service
@@ -302,6 +343,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_authorized_collection_delete(self):
         path = f'/{API_BASE}/collections/{self.collection.name}'

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -46,19 +46,27 @@ class ApiPaginationTestCase(StacBaseTestCase):
     def test_invalid_limit_query(self):
         response = self.client.get(f"/{API_BASE}/collections?limit=0")
         self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=test")
         self.assertStatusCode(400, response)
+        self.assertEqual(['invalid limit query parameter: must be an integer'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=-1")
         self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
         response = self.client.get(f"/{API_BASE}/collections?limit=1000")
         self.assertStatusCode(400, response)
-
-    def test_http_error_invalid_query_param(self):
-        response = self.client.get(f"/{API_BASE}/collections?limit=0")
-        self.assertStatusCode(400, response)
+        self.assertEqual(['limit query parameter to big, must be in range 1..100'],
+                         response.json()['description'],
+                         msg='Unexpected error message')
 
     def test_pagination(self):
 


### PR DESCRIPTION
Unittest improvements:

- Make sure that in case of an expected HTTP 400, the error message is the one we expect. HTTP 400 have many different reason that's why we should test the reason as well in unittest
- Make sure also that STAC required read only fields are present in unittest.