### PR TITLE
adding local / Pod IP to ALLOWED_HOSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ The service is configured by Environment Variable:
 | LOGGING_CFG | `'logging-cfg-local.yml'` | Logging configuration file             |
 | SECRET_KEY | - | Secret key for django |
 | ALLOWED_HOSTS | `''` | See django ALLOWED_HOSTS. On local development and DEV staging this is overwritten with `'*'` |
+| THIS_POD_IP | No default | The IP of the POD the service is running on |
 | HTTP_CACHE_SECONDS | `600` | Sets the `Cache-Control: max-age` and `Expires` headers of the GET and HEAD requests to the api views. |
 | HTTP_STATIC_CACHE_SECONDS | `3600` | Sets the `Cache-Control: max-age` header of GET, HEAD requests to the static files. |
 | STORAGE_ASSETS_CACHE_SECONDS | `7200` | Sets the `Cache-Control: max-age` and `Expires` headers of the GET and HEAD on the assets file uploaded via admin page. |

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -45,7 +45,10 @@ DEBUG = False
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ('HTTP_CLOUDFRONT_FORWARDED_PROTO', 'https')
 
-ALLOWED_HOSTS = []
+# We need to have the IP of the Pod/localhost in ALLOWED_HOSTS
+# as well to be able to scrape prometheus /metrics
+# see kubernetes config on how `THIS_POD_IP` is obtained
+ALLOWED_HOSTS = [os.getenv('THIS_POD_IP')]
 ALLOWED_HOSTS += os.getenv('ALLOWED_HOSTS', '').split(',')
 
 # SERVICE_HOST = os.getenv('SERVICE_HOST', '127.0.0.1:8000')

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -21,7 +21,7 @@ from django.urls import path
 urlpatterns = [
     path('', include('stac_api.urls')),
     path('api/stac/admin/', admin.site.urls),
-    path('prometheus/', include('django_prometheus.urls')),
+    path('', include('django_prometheus.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
The localhost IP / IP of the Pod must be in `ALLOWED_HOSTS` to allow request from local without host header. This is the case e.g. for prometheus (in principle it's the same issue with the health check)