### PR TITLE
BGDIINF_SB-1638: Profiling tool

### DIFF
--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -53,7 +53,7 @@ formatters:
   standard:
     (): logging_utilities.formatters.extra_formatter.ExtraFormatter
     format: "[%(utc_isotime)s] %(levelname)-8s - %(name)-26s : %(message)s"
-    # extra_fmt: " - extra: %s"
+    extra_fmt: " - duration: %(duration)s"
     # extra_pretty_print: True
   standard-file:
     (): logging_utilities.formatters.extra_formatter.ExtraFormatter

--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -15,6 +15,8 @@ from .settings_prod import *  # pylint: disable=wildcard-import, unused-wildcard
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
+if DEBUG:
+    print('WARNING - running in debug mode !')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/

--- a/app/stac_api/management/commands/profile_cursor_paginator.py
+++ b/app/stac_api/management/commands/profile_cursor_paginator.py
@@ -1,0 +1,67 @@
+import cProfile
+import logging
+import pstats
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from rest_framework.pagination import CursorPagination
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from stac_api.models import Item
+from stac_api.utils import CommandHandler
+
+logger = logging.getLogger(__name__)
+
+API_BASE = settings.API_BASE
+
+
+class Handler(CommandHandler):
+
+    def profiling(self):
+        # pylint: disable=import-outside-toplevel,possibly-unused-variable
+        collection_id = self.options["collection"]
+        qs = Item.objects.filter(collection__name=collection_id).prefetch_related('assets', 'links')
+        request = Request(
+            APIRequestFactory().
+            get(f'{API_BASE}/collections/{collection_id}/items?limit={self.options["limit"]}')
+        )
+        paginator = CursorPagination()
+
+        cProfile.runctx(
+            'paginator.paginate_queryset(qs, request)',
+            None,
+            locals(),
+            f'{settings.BASE_DIR}/logs/stats-file',
+            sort=self.options['sort']
+        )
+        stats = pstats.Stats(f'{settings.BASE_DIR}/logs/stats-file')
+        stats.sort_stats(self.options['sort']).print_stats()
+
+        self.print_success('Done')
+
+
+class Command(BaseCommand):
+    help = """Paginator paginate_queryset() profiling command
+
+    Profiling of the method paginator.paginate_queryset(qs, request)
+
+    See https://docs.python.org/3.7/library/profile.html
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--collection',
+            type=str,
+            default='perftest-collection-0',
+            help="Collection ID to use for the queryset profiling"
+        )
+        parser.add_argument('--limit', type=int, default=100, help="Limit to use for the queryset")
+        parser.add_argument('--sort', type=str, default='tottime', help="Profiling output sorting")
+        parser.add_argument(
+            '--lines', type=str, default=50, help="Profiling output numbers of line to show"
+        )
+
+    def handle(self, *args, **options):
+        Handler(self, options).profiling()

--- a/app/stac_api/management/commands/profile_item_serializer.py
+++ b/app/stac_api/management/commands/profile_item_serializer.py
@@ -1,0 +1,61 @@
+import cProfile
+import logging
+import pstats
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from rest_framework.test import APIRequestFactory
+
+from stac_api.models import Item
+from stac_api.utils import CommandHandler
+
+logger = logging.getLogger(__name__)
+
+API_BASE = settings.API_BASE
+
+
+class Handler(CommandHandler):
+
+    def profiling(self):
+        # pylint: disable=import-outside-toplevel,possibly-unused-variable
+        from stac_api.serializers import ItemSerializer
+        collection_id = self.options["collection"]
+        qs = Item.objects.filter(collection__name=collection_id
+                                ).prefetch_related('assets', 'links')[:self.options['limit']]
+        context = {
+            'request': APIRequestFactory().get(f'{API_BASE}/collections/{collection_id}/items')
+        }
+        cProfile.runctx(
+            'ItemSerializer(qs, context=context, many=True).data',
+            None,
+            locals(),
+            f'{settings.BASE_DIR}/logs/stats-file',
+            sort=self.options['sort']
+        )
+        stats = pstats.Stats(f'{settings.BASE_DIR}/logs/stats-file')
+        stats.sort_stats(self.options['sort']).print_stats()
+
+        self.print_success('Done')
+
+
+class Command(BaseCommand):
+    help = """ItemSerializer profiling command
+
+    Profiling of the serialization of many items.
+
+    See https://docs.python.org/3.7/library/profile.html
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--collection',
+            type=str,
+            default='perftest-collection-0',
+            help="Collection ID to use for the ItemSerializer profiling"
+        )
+        parser.add_argument('--limit', type=int, default=100, help="Limit to use for the query")
+        parser.add_argument('--sort', type=str, default='tottime', help="Profiling output sorting")
+
+    def handle(self, *args, **options):
+        Handler(self, options).profiling()

--- a/app/stac_api/profiling.py
+++ b/app/stac_api/profiling.py
@@ -1,0 +1,34 @@
+import cProfile
+import functools
+import io
+import os
+import pstats
+
+
+def profiling(function_to_profile):
+    ''''Profiling wrapper for debugging
+
+    You can use this wrapper to get some profiling data on the function. The profiling data are
+    printed in the console.
+    '''
+
+    @functools.wraps(function_to_profile)
+    def wrapper(*args, **kwargs):
+        profiler = cProfile.Profile()
+
+        profiler.enable()
+        return_value = function_to_profile(*args, **kwargs)
+        profiler.disable()
+
+        stream = io.StringIO()
+        stats = pstats.Stats(profiler,
+                             stream=stream).sort_stats(os.getenv('PROFILING_SORT_KEY', 'cumtime'))
+        stats_lines = os.getenv('PROFILING_STATS_LINES', None)
+        if stats_lines:
+            stats.print_stats(stats_lines)
+        else:
+            stats.print_stats()
+
+        return return_value
+
+    return wrapper


### PR DESCRIPTION
Added 2 django command line for profiling `ItemSerializer.data` and the the `paginator.paginate_queryset(qs, request)` method. Also added a decorator to profile any method. Profiling should only be used for debugging/testing as it adds a lot of overhead.