### PR TITLE
ISSUE BGDIINF_SB_1631: wrong status on items and assets queries

### DIFF
--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -180,9 +180,10 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
         return queryset
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
         if not Collection.objects.filter(name=self.kwargs['collection_name']).exists():
+            logger.error("The collection %s does not exist", self.kwargs['collection_name'])
             raise Http404("This collection does not exists.")
+        queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
@@ -363,10 +364,13 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
         )
 
     def get(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        if not Collection.objects.filter(name=self.kwargs['collection_name']).exists() or \
-                not Item.objects.filter(name=self.kwargs['item_name']).exists():
+        if (not Collection.objects.filter(name=self.kwargs['collection_name']).exists() or
+                not Item.objects.filter(name=self.kwargs['item_name']).exists()):
+            logger.error("Either the collection (%s) or the item (%s) do not exist",
+                         self.kwargs['collection_name'], self.kwargs['item_name'])
             raise Http404("This collection does not exists.")
+
+        queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-
 from rest_framework import generics
 from rest_framework import mixins
 from rest_framework.permissions import AllowAny
@@ -181,7 +180,7 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-
+        get_object_or_404(queryset)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
@@ -363,7 +362,7 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-
+        get_object_or_404(queryset)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
+
 from rest_framework import generics
 from rest_framework import mixins
 from rest_framework.permissions import AllowAny

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -181,8 +181,8 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def list(self, request, *args, **kwargs):
         if not Collection.objects.filter(name=self.kwargs['collection_name']).exists():
-            logger.error("The collection, %s, does not exist", self.kwargs['collection_name'])
-            raise Http404(f"This collection, {self.kwargs['collection_name']}, does not exists.")
+            logger.error("The collection %s does not exist", self.kwargs['collection_name'])
+            raise Http404(f"The collection {self.kwargs['collection_name']} does not exists.")
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
@@ -365,11 +365,11 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         if not Collection.objects.filter(name=self.kwargs['collection_name']).exists():
-            logger.error("The collection, %s, does not exist", self.kwargs['collection_name'])
-            raise Http404("This collection does not exists.")
+            logger.error("The collection %s does not exist", self.kwargs['collection_name'])
+            raise Http404(f"The collection {self.kwargs['collection_name']} does not exist")
         if not Item.objects.filter(name=self.kwargs['item_name']).exists():
             logger.error(
-                "The item, %s, is not part of the collection, %s",
+                "The item %s is not part of the collection, %s",
                 self.kwargs['item_name'],
                 self.kwargs['collection_name']
             )

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-
+from django.http import Http404
 from rest_framework import generics
 from rest_framework import mixins
 from rest_framework.permissions import AllowAny
@@ -167,7 +167,6 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
         # filter based on the url
         queryset = Item.objects.filter(collection__name=self.kwargs['collection_name']
                                       ).prefetch_related('assets', 'links')
-
         bbox = self.request.query_params.get('bbox', None)
         date_time = self.request.query_params.get('datetime', None)
 
@@ -181,7 +180,8 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        get_object_or_404(queryset)
+        if not queryset.exists():
+            raise Http404("This collection does not exists.")
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
@@ -363,7 +363,10 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        get_object_or_404(queryset)
+        logger.error(" THIS IS WHERE WE NEED TO BE ATTENTIVE")
+        logger.error(str(queryset.exists()))
+        if not queryset.exists():
+            raise Http404("This collection does not exists.")
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -181,7 +181,7 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        if not queryset.exists():
+        if not Collection.objects.filter(name=self.kwargs['collection_name']).exists():
             raise Http404("This collection does not exists.")
         page = self.paginate_queryset(queryset)
         if page is not None:
@@ -364,7 +364,8 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        if not queryset.exists():
+        if not Collection.objects.filter(name=self.kwargs['collection_name']).exists() or \
+                not Item.objects.filter(name=self.kwargs['item_name']).exists():
             raise Http404("This collection does not exists.")
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.http import Http404
+
 from rest_framework import generics
 from rest_framework import mixins
 from rest_framework.permissions import AllowAny
@@ -363,8 +364,6 @@ class AssetsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        logger.error(" THIS IS WHERE WE NEED TO BE ATTENTIVE")
-        logger.error(str(queryset.exists()))
         if not queryset.exists():
             raise Http404("This collection does not exists.")
         page = self.paginate_queryset(queryset)

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -58,6 +58,22 @@ class AssetsEndpointTestCase(StacBaseTestCase):
                 asset.json, json_data['assets'][i], collection_name, item_name, ignore=['item']
             )
 
+    def test_assets_endpoint_collection_does_not_exist(self):
+        collection_name = "non-existent"
+        item_name = self.item.name
+        response = self.client.get(
+            f"/{API_BASE}/collections/{collection_name}/items/{item_name}/assets"
+        )
+        self.assertStatusCode(404, response)
+
+    def test_assets_endpoint_item_does_not_exist(self):
+        collection_name = self.collection.name
+        item_name = "non-existent"
+        response = self.client.get(
+            f"/{API_BASE}/collections/{collection_name}/items/{item_name}/assets"
+        )
+        self.assertStatusCode(404, response)
+
     def test_single_asset_endpoint(self):
         collection_name = self.collection.name
         item_name = self.item.name

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -76,6 +76,10 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
                 msg=f"The field {date_field} has an invalid date"
             )
 
+    def test_items_endpoint_non_existing_collection(self):
+        response = self.client.get(f"/{API_BASE}/collections/non-existing-collection/items")
+        self.assertStatusCode(404, response)
+
 
 class ItemsDatetimeQueryEndpointTestCase(StacBaseTestCase):
 


### PR DESCRIPTION
Issue : When trying to access the items from a non existing collection,
or when trying to access the assets from one non existing item, the
application would return a 200 status with an empty list of items or
assets.

Fix : using the get_object_or_404() method allows consistent comportment
with other endpoints which returned a correct 404 not found status.