### PR TITLE
BGDIINF_SB-1659 bugfix in search endpoint (POST and GET)

### DIFF
--- a/app/stac_api/managers.py
+++ b/app/stac_api/managers.py
@@ -215,12 +215,16 @@ class ItemQuerySet(models.QuerySet):
             for operator in query[attribute]:
                 value = query[attribute][operator]  # get the values given by the operator
 
+                if attribute in ["updated", "created"]:
+                    prefix = ""
+                else:
+                    prefix = "properties_"
+
                 # __eq does not exist, but = does it as well
                 if operator == 'eq':
-                    query_filter = f"properties_{attribute}"
+                    query_filter = f"{prefix}{attribute}"
                 else:
-                    query_filter = f"properties_{attribute}__{operator.lower()}"
-
+                    query_filter = f"{prefix}{attribute}__{operator.lower()}"
                 return self.filter(**{query_filter: value})
 
 

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 import botocore
 import multihash
+import numpy as np
 from multihash import from_hex_string
 from multihash import to_hex_string
 
@@ -276,6 +277,20 @@ class ValidateSearchRequest:
         '''
         # harmonize GET and POST
         query_param = harmonize_post_get_for_search(request)
+        queried_parameters = list(query_param.keys())
+        accepted_query_parameters = [
+            "bbox", "collections", "cursor", "datetime", "ids", "intersects", "limit", "query"
+        ]
+        # make sure that all queried_parameters are in the accepted_query_parameters
+        if not all(parameter in accepted_query_parameters for parameter in queried_parameters):
+            wrong_query_parameters = np.setdiff1d(queried_parameters,
+                                                  accepted_query_parameters).tolist()
+            logger.error(
+                'Query contains the non-allowed parameter(s): %s', str(wrong_query_parameters)
+            )
+            message = f"The query contains the following non-queriable" \
+            f"parameter(s): {str(wrong_query_parameters)}."
+            raise ValidationError(code='query-invalid', detail=_(message))
 
         if 'bbox' in query_param:
             self.validate_bbox(query_param['bbox'])
@@ -421,7 +436,7 @@ class ValidateSearchRequest:
             else:
                 if not isinstance(value, str):
                     message = f"{message} The values have to be strings." \
-                              f" The value {val} is not a string"
+                              f" The value {value} is not a string"
             if message != '':
                 self.errors[f"query-attributes-{attribute}"] = _(message)
 

--- a/app/tests/test_search_endpoint.py
+++ b/app/tests/test_search_endpoint.py
@@ -75,6 +75,62 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
             json_data_post['features'][0]['properties']['title']
         )
 
+    def test_query_created(self):
+        # get match
+        query = '{"created": {"lte": "9999-12-31T09:07:39.399892Z"}}'
+        response = self.client.get(f"/{API_BASE}/search" f"?query={query}&limit=1")
+        self.assertStatusCode(200, response)
+        json_data_get = response.json()
+        self.assertEqual(len(json_data_get['features']), 1)
+
+        # post match
+        payload = """
+        {"query":
+            {"created":
+                {"lte":"9999-12-31T09:07:39.399892Z"}
+            },
+            "limit": 1
+        }
+        """
+        response = self.client.post(self.path, data=payload, content_type="application/json")
+        self.assertStatusCode(200, response)
+        json_data_post = response.json()
+        self.assertEqual(len(json_data_post['features']), 1)
+        # compare get and post
+        self.assertEqual(
+            json_data_get['features'][0]['properties']['created'],
+            json_data_post['features'][0]['properties']['created'],
+            msg="GET and POST responses do not match when filtering for date created"
+        )
+
+    def test_query_updated(self):
+        # get match
+        query = '{"updated": {"lte": "9999-12-31T09:07:39.399892Z"}}'
+        response = self.client.get(f"/{API_BASE}/search" f"?query={query}&limit=1")
+        self.assertStatusCode(200, response)
+        json_data_get = response.json()
+        self.assertEqual(len(json_data_get['features']), 1)
+
+        # post match
+        payload = """
+        {"query":
+            {"updated":
+                {"lte":"9999-12-31T09:07:39.399892Z"}
+            },
+            "limit": 1
+        }
+        """
+        response = self.client.post(self.path, data=payload, content_type="application/json")
+        self.assertStatusCode(200, response)
+        json_data_post = response.json()
+        self.assertEqual(len(json_data_post['features']), 1)
+        # compare get and post
+        self.assertEqual(
+            json_data_get['features'][0]['properties']['updated'],
+            json_data_post['features'][0]['properties']['updated'],
+            msg="GET and POST responses do not match when filtering for date updated"
+        )
+
     def test_query_data_in(self):
         payload = """
         {"query":


### PR DESCRIPTION
BGDIINF_SB-1659:
Filtering for `updated` or `created` dates did not work both in GET and POST requests on the search endpoint.
It yielded an error message:
FieldError "Cannot resolve keyword 'properties_updated' into field" 

Internally the query appended the text 'properties_' before the 'updated' or 'created'. Hence `filter_by_query()` in `managers.py` was adapted.
Also new unit tests were added that test POST and GET requests filtering for 'updated' and 'created'.

BGDIINF_SB-1657:
Incorrectly spelled or arbitrary query parameters were accepted and did not yield error messages currently.
So the allowed query parameters were limited to `bbox, collections, cursor, datetime, ids, intersects, limit and query` and validated. Any other query parameter or incorrectly spelled query parameters will yield a 400.
Unit tests covering cases with (multiple) wrong query parameters were added.
