### PR TITLE
BGDIINF_SB-1660 remove datetime from queriable fields

### DIFF
--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -257,7 +257,9 @@ class ValidateSearchRequest:
         self.max_times_same_query_attribute = 20
         self.max_query_attributes = 50
 
-        self.queriabel_date_fields = ['datetime', 'created', 'updated']
+        # Note: if these values are adapted, don't forget to
+        # update the spec accordingly.
+        self.queriabel_date_fields = ['created', 'updated']
         self.queriabel_str_fields = ['title']
 
     def validate(self, request):
@@ -393,12 +395,11 @@ class ValidateSearchRequest:
                               f"a string operator." \
                               f"For numbers use one of these {int_operators}"
                     self.errors[f"query-operator-{operator}"] = _(message)
+                self._query_validate_in_operator(attribute, value)
             else:
                 message = f"Invalid operator in query argument. The operator {operator} " \
                           f"is not supported. Use: {operators}"
                 self.errors[f"query-operator-{operator}"] = _(message)
-
-            self._query_validate_in_operator(attribute, value)
 
     def _query_validate_in_operator(self, attribute, value):
         '''

--- a/app/tests/test_search_endpoint.py
+++ b/app/tests/test_search_endpoint.py
@@ -206,22 +206,22 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
     def test_query_data_in(self):
         payload = """
         {"query":
-            {"datetime":
-                {"in":["2020-10-28T13:05:10Z","2525-10-19T00:00:00Z"]}
+            {"title":
+                {"in":["My item 1","My item 2"]}
             }
         }
         """
         response = self.client.post(self.path, data=payload, content_type="application/json")
         json_data = response.json()
-        list_expected_items = ['item-1', 'item-3']
+        list_expected_items = ['item-1', 'item-2']
         self.assertIn(json_data['features'][0]['id'], list_expected_items)
         self.assertIn(json_data['features'][1]['id'], list_expected_items)
 
     def test_post_pagination(self):
         data = """
         {"query":
-            {"datetime":
-                {"lt":"2525-01-02T00:00:00Z"}
+             {"title":
+                {"startsWith":"My item"}
             },
          "limit": 1
         }

--- a/spec/components/parameters.yml
+++ b/spec/components/parameters.yml
@@ -10,44 +10,14 @@ components:
     #  schema:
     #    type: string
     bbox:
-      description: >-
-        Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four numbers:
-
-
-        * Lower left corner, coordinate axis 1
-
-        * Lower left corner, coordinate axis 2
-
-        * Upper right corner, coordinate axis 1
-
-        * Upper right corner, coordinate axis 2
-
-
-        The coordinate reference system of the values is WGS 84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
-
-
-        For WGS 84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value
-        (west-most box edge) is larger than the third value (east-most box edge).
-
-
-        If a feature has multiple spatial geometry properties, it is the decision of the
-        server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
       explode: false
       in: query
       name: bbox
       required: false
       schema:
-        items:
-          type: number
-        maxItems: 4
-        minItems: 4
-        type: array
+        $ref: "#/components/schemas/bbox"
       style: form
+      example:
     collectionId:
       description: Local identifier of a collection
       in: path
@@ -56,9 +26,6 @@ components:
       schema:
         type: string
     collectionsArray:
-      description: >-
-        Array of Collection IDs to include in the search for items.
-        Only Items in one of the provided Collections will be searched
       explode: false
       in: query
       name: collections
@@ -66,33 +33,13 @@ components:
       schema:
         $ref: "#/components/schemas/collectionsArray"
     datetime:
-      description: >-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
-        Examples:
-
-
-        * A date-time: "2018-02-12T23:20:50Z"
-
-        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
-        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
-
-
-        Only features that have a temporal property that intersects the value of
-        `datetime` are selected.
-
-
-        If a feature has multiple temporal properties, it is the decision of the
-        server whether only a single temporal property is used to determine
-        the extent or all relevant temporal properties.
       explode: false
       in: query
       name: datetime
       required: false
       schema:
-        type: string
+        $ref: "#/components/schemas/datetimeQuery"
+      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
       style: form
     featureId:
       description: Local identifier of a feature
@@ -111,78 +58,21 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/ids"
-    collectionsLimit:
-      description: >-
-        The optional limit parameter limits the number of collections that are presented in the response
-        document.
-
-
-        To retrieve the next collections result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
-    itemsLimit:
-      description: >-
-        The optional limit parameter limits the number of items that are presented in the response
-        document.
-
-
-        Only items are counted that are on the first level of the collection in the response
-        document. Nested objects contained within the explicitly requested items shall not be
-        counted.
-
-
-        To retrieve the next items result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
     limit:
-      description: >-
-        The optional limit parameter limits the number of results that are presented in the response
-        document.
-
-
-        To retrieve the next result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
       explode: false
       in: query
       name: limit
       required: false
       schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
+        $ref: "#/components/schemas/limit"
       style: form
-    query:
-      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
-      in: query
-      name: query
-      required: false
-      schema:
-        type: string
+    # query:
+    #   description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
+    #   in: query
+    #   name: query
+    #   required: false
+    #   schema:
+    #     type: string
     IfNoneMatch:
       name: If-None-Match
       in: header

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -95,14 +95,10 @@ components:
         (east-most box edge).
 
 
-        If a feature has multiple spatial geometry properties, it is the
-        decision of the server whether only a single spatial geometry property
-        is used to determine the extent or all relevant geometries.
-
         Example: The bounding box of Switzerland in
         WGS 84 (from 5.96°E to 10.49°E and from 45.82°N to 47.81°N) would be
         represented in JSON as `[5.96, 45.82, 10.49, 47.81]` and in a query as
-        `bbox=5.96, 45.82, 10.49, 47.81`."
+        `bbox=5.96,45.82,10.49,47.81`."
       example:
         - 5.96
         - 45.82
@@ -115,17 +111,9 @@ components:
       type: array
       readOnly: true
     bboxFilter:
-      description: Only return items that intersect the provided bounding box.
       properties:
         bbox:
           $ref: "#/components/schemas/bbox"
-      type: object
-      example:
-        bbox:
-          - 5.96
-          - 45.82
-          - 10.49
-          - 47.81
     checksum:multihash:
       description: >-
         `sha2-256` or `md5` checksum of the asset in [multihash](https://multiformats.io/multihash/)
@@ -329,12 +317,32 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+    datetimeQuery:
+      description: >-
+        Either a date-time or an interval, open or closed. Date and time expressions
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+
+        Examples:
+
+
+        * A date-time: "2018-02-12T23:20:50Z"
+
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+
+        Only features that have a temporal property that intersects the value of
+        `datetime` are selected.
+
+
+        When used as URL query argument, the value must be correctly url-encoded.
+      example: 2018-02-12T00:00:00Z/2018-03-18T12:31:12Z
+      type: string
     datetimeFilter:
-      description: An object representing a date+time based filter.
       properties:
         datetime:
-          $ref: "#/components/schemas/datetime"
-      type: object
+          $ref: "#/components/schemas/datetimeQuery"
     description:
       description: >-
         Detailed multi-line description to fully explain the catalog or
@@ -822,13 +830,14 @@ components:
       example: proprietary
       type: string
     limit:
-      default: 10
+      default: 100
       description: >-
-        The optional limit parameter limits the number of collections that are presented
-        in the response document.
+        The `limit` parameter limits the number of results that are included
+        in the response.
 
 
-        To retrieve the next collections result, uses the `next` link from the response.
+        To retrieve the next bunch of result, use the `next` link in the `links`
+        section of the response.
 
 
         Minimum = 1. Maximum = 100. Default = 100.
@@ -1217,7 +1226,9 @@ components:
                 comparison must be performed.
               type: string
           type: object
-      description: Apply query operations to a specific property
+      description: >-
+        Apply query operations to a specific property. The following properties
+        are currently supported: `created`, `updated`, `title`.
     searchBody:
       allOf:
         #        - $ref: "#/components/schemas/assetQueryFilter"

--- a/spec/paths.yml
+++ b/spec/paths.yml
@@ -17,7 +17,7 @@ paths:
     get:
       operationId: getCollections
       parameters:
-        - $ref: "#/components/parameters/collectionsLimit"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           $ref: "#/components/responses/Collections"
@@ -62,7 +62,7 @@ paths:
       operationId: getFeatures
       parameters:
         - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/itemsLimit"
+        - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/bbox"
         - $ref: "#/components/parameters/datetime"
       responses:
@@ -128,7 +128,8 @@ paths:
       operationId: getSearchSTAC
       parameters:
         # - $ref: "#/components/parameters/assetQuery"
-        - $ref: "#/components/parameters/query"
+        # Note: this is commented here since not part of the official spec
+        # - $ref: "#/components/parameters/query"
         - $ref: "#/components/parameters/bbox"
         - $ref: "#/components/parameters/datetime"
         - $ref: "#/components/parameters/limit"

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -29,44 +29,14 @@ tags:
 components:
   parameters:
     bbox:
-      description: >-
-        Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four numbers:
-
-
-        * Lower left corner, coordinate axis 1
-
-        * Lower left corner, coordinate axis 2
-
-        * Upper right corner, coordinate axis 1
-
-        * Upper right corner, coordinate axis 2
-
-
-        The coordinate reference system of the values is WGS 84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
-
-
-        For WGS 84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value (west-most
-        box edge) is larger than the third value (east-most box edge).
-
-
-        If a feature has multiple spatial geometry properties, it is the decision
-        of the server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
       explode: false
       in: query
       name: bbox
       required: false
       schema:
-        items:
-          type: number
-        maxItems: 4
-        minItems: 4
-        type: array
+        $ref: "#/components/schemas/bbox"
       style: form
+      example:
     collectionId:
       description: Local identifier of a collection
       in: path
@@ -75,9 +45,6 @@ components:
       schema:
         type: string
     collectionsArray:
-      description: >-
-        Array of Collection IDs to include in the search for items. Only Items in
-        one of the provided Collections will be searched
       explode: false
       in: query
       name: collections
@@ -85,33 +52,13 @@ components:
       schema:
         $ref: "#/components/schemas/collectionsArray"
     datetime:
-      description: >-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
-        Examples:
-
-
-        * A date-time: "2018-02-12T23:20:50Z"
-
-        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
-        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
-
-
-        Only features that have a temporal property that intersects the value of `datetime`
-        are selected.
-
-
-        If a feature has multiple temporal properties, it is the decision of the server
-        whether only a single temporal property is used to determine the extent or
-        all relevant temporal properties.
       explode: false
       in: query
       name: datetime
       required: false
       schema:
-        type: string
+        $ref: "#/components/schemas/datetimeQuery"
+      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
       style: form
     featureId:
       description: Local identifier of a feature
@@ -130,79 +77,14 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/ids"
-    collectionsLimit:
-      description: >-
-        The optional limit parameter limits the number of collections that are presented
-        in the response document.
-
-
-        To retrieve the next collections result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
-    itemsLimit:
-      description: >-
-        The optional limit parameter limits the number of items that are presented
-        in the response document.
-
-
-        Only items are counted that are on the first level of the collection in the
-        response document. Nested objects contained within the explicitly requested
-        items shall not be counted.
-
-
-        To retrieve the next items result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
     limit:
-      description: >-
-        The optional limit parameter limits the number of results that are presented
-        in the response document.
-
-
-        To retrieve the next result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
       explode: false
       in: query
       name: limit
       required: false
       schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
+        $ref: "#/components/schemas/limit"
       style: form
-    query:
-      description: Query for properties in items. Use the JSON form of the queryFilter
-        used in POST.
-      in: query
-      name: query
-      required: false
-      schema:
-        type: string
     IfNoneMatch:
       name: If-None-Match
       in: header
@@ -449,13 +331,9 @@ components:
         box edge) is larger than the third value (east-most box edge).
 
 
-        If a feature has multiple spatial geometry properties, it is the decision
-        of the server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
-
         Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E
         and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82,
-        10.49, 47.81]` and in a query as `bbox=5.96, 45.82, 10.49, 47.81`."
+        10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
       example:
       - 5.96
       - 45.82
@@ -468,17 +346,9 @@ components:
       type: array
       readOnly: true
     bboxFilter:
-      description: Only return items that intersect the provided bounding box.
       properties:
         bbox:
           $ref: "#/components/schemas/bbox"
-      type: object
-      example:
-        bbox:
-        - 5.96
-        - 45.82
-        - 10.49
-        - 47.81
     checksum:multihash:
       description: >-
         `sha2-256` or `md5` checksum of the asset in [multihash](https://multiformats.io/multihash/)
@@ -682,12 +552,32 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+    datetimeQuery:
+      description: >-
+        Either a date-time or an interval, open or closed. Date and time expressions
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+
+        Examples:
+
+
+        * A date-time: "2018-02-12T23:20:50Z"
+
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+
+        Only features that have a temporal property that intersects the value of `datetime`
+        are selected.
+
+
+        When used as URL query argument, the value must be correctly url-encoded.
+      example: 2018-02-12T00:00:00Z/2018-03-18T12:31:12Z
+      type: string
     datetimeFilter:
-      description: An object representing a date+time based filter.
       properties:
         datetime:
-          $ref: "#/components/schemas/datetime"
-      type: object
+          $ref: "#/components/schemas/datetimeQuery"
     description:
       description: >-
         Detailed multi-line description to fully explain the catalog or collection.
@@ -1159,13 +1049,14 @@ components:
       example: proprietary
       type: string
     limit:
-      default: 10
+      default: 100
       description: >-
-        The optional limit parameter limits the number of collections that are presented
-        in the response document.
+        The `limit` parameter limits the number of results that are included in the
+        response.
 
 
-        To retrieve the next collections result, uses the `next` link from the response.
+        To retrieve the next bunch of result, use the `next` link in the `links` section
+        of the response.
 
 
         Minimum = 1. Maximum = 100. Default = 100.
@@ -1530,7 +1421,9 @@ components:
               case-insensitive comparison must be performed.
             type: string
         type: object
-      description: Apply query operations to a specific property
+      description: >-
+        Apply query operations to a specific property. The following properties are
+        currently supported: `created`, `updated`, `title`.
     searchBody:
       allOf:
       - $ref: "#/components/schemas/queryFilter"
@@ -1605,7 +1498,7 @@ paths:
     get:
       operationId: getCollections
       parameters:
-      - $ref: "#/components/parameters/collectionsLimit"
+      - $ref: "#/components/parameters/limit"
       responses:
         "200":
           $ref: "#/components/responses/Collections"
@@ -1650,7 +1543,7 @@ paths:
       operationId: getFeatures
       parameters:
       - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/itemsLimit"
+      - $ref: "#/components/parameters/limit"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"
       responses:
@@ -1712,7 +1605,6 @@ paths:
         Retrieve Items matching filters. Intended as a shorthand API for simple queries.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/query"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"
       - $ref: "#/components/parameters/limit"

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -85,44 +85,14 @@ tags:
 components:
   parameters:
     bbox:
-      description: >-
-        Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four numbers:
-
-
-        * Lower left corner, coordinate axis 1
-
-        * Lower left corner, coordinate axis 2
-
-        * Upper right corner, coordinate axis 1
-
-        * Upper right corner, coordinate axis 2
-
-
-        The coordinate reference system of the values is WGS 84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
-
-
-        For WGS 84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value (west-most
-        box edge) is larger than the third value (east-most box edge).
-
-
-        If a feature has multiple spatial geometry properties, it is the decision
-        of the server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
       explode: false
       in: query
       name: bbox
       required: false
       schema:
-        items:
-          type: number
-        maxItems: 4
-        minItems: 4
-        type: array
+        $ref: "#/components/schemas/bbox"
       style: form
+      example:
     collectionId:
       description: Local identifier of a collection
       in: path
@@ -131,9 +101,6 @@ components:
       schema:
         type: string
     collectionsArray:
-      description: >-
-        Array of Collection IDs to include in the search for items. Only Items in
-        one of the provided Collections will be searched
       explode: false
       in: query
       name: collections
@@ -141,33 +108,13 @@ components:
       schema:
         $ref: "#/components/schemas/collectionsArray"
     datetime:
-      description: >-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
-        Examples:
-
-
-        * A date-time: "2018-02-12T23:20:50Z"
-
-        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
-        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
-
-
-        Only features that have a temporal property that intersects the value of `datetime`
-        are selected.
-
-
-        If a feature has multiple temporal properties, it is the decision of the server
-        whether only a single temporal property is used to determine the extent or
-        all relevant temporal properties.
       explode: false
       in: query
       name: datetime
       required: false
       schema:
-        type: string
+        $ref: "#/components/schemas/datetimeQuery"
+      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
       style: form
     featureId:
       description: Local identifier of a feature
@@ -186,79 +133,14 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/ids"
-    collectionsLimit:
-      description: >-
-        The optional limit parameter limits the number of collections that are presented
-        in the response document.
-
-
-        To retrieve the next collections result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
-    itemsLimit:
-      description: >-
-        The optional limit parameter limits the number of items that are presented
-        in the response document.
-
-
-        Only items are counted that are on the first level of the collection in the
-        response document. Nested objects contained within the explicitly requested
-        items shall not be counted.
-
-
-        To retrieve the next items result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
-      style: form
     limit:
-      description: >-
-        The optional limit parameter limits the number of results that are presented
-        in the response document.
-
-
-        To retrieve the next result, uses the `next` link from the response.
-
-
-        Minimum = 1. Maximum = 100. Default = 100.
       explode: false
       in: query
       name: limit
       required: false
       schema:
-        default: 100
-        maximum: 100
-        minimum: 1
-        type: integer
+        $ref: "#/components/schemas/limit"
       style: form
-    query:
-      description: Query for properties in items. Use the JSON form of the queryFilter
-        used in POST.
-      in: query
-      name: query
-      required: false
-      schema:
-        type: string
     IfNoneMatch:
       name: If-None-Match
       in: header
@@ -591,13 +473,9 @@ components:
         box edge) is larger than the third value (east-most box edge).
 
 
-        If a feature has multiple spatial geometry properties, it is the decision
-        of the server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
-
         Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E
         and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82,
-        10.49, 47.81]` and in a query as `bbox=5.96, 45.82, 10.49, 47.81`."
+        10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
       example:
       - 5.96
       - 45.82
@@ -610,17 +488,9 @@ components:
       type: array
       readOnly: true
     bboxFilter:
-      description: Only return items that intersect the provided bounding box.
       properties:
         bbox:
           $ref: "#/components/schemas/bbox"
-      type: object
-      example:
-        bbox:
-        - 5.96
-        - 45.82
-        - 10.49
-        - 47.81
     checksum:multihash:
       description: >-
         `sha2-256` or `md5` checksum of the asset in [multihash](https://multiformats.io/multihash/)
@@ -824,12 +694,32 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+    datetimeQuery:
+      description: >-
+        Either a date-time or an interval, open or closed. Date and time expressions
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+
+        Examples:
+
+
+        * A date-time: "2018-02-12T23:20:50Z"
+
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+
+
+        Only features that have a temporal property that intersects the value of `datetime`
+        are selected.
+
+
+        When used as URL query argument, the value must be correctly url-encoded.
+      example: 2018-02-12T00:00:00Z/2018-03-18T12:31:12Z
+      type: string
     datetimeFilter:
-      description: An object representing a date+time based filter.
       properties:
         datetime:
-          $ref: "#/components/schemas/datetime"
-      type: object
+          $ref: "#/components/schemas/datetimeQuery"
     description:
       description: >-
         Detailed multi-line description to fully explain the object (collection, item,
@@ -1301,13 +1191,14 @@ components:
       example: proprietary
       type: string
     limit:
-      default: 10
+      default: 100
       description: >-
-        The optional limit parameter limits the number of collections that are presented
-        in the response document.
+        The `limit` parameter limits the number of results that are included in the
+        response.
 
 
-        To retrieve the next collections result, uses the `next` link from the response.
+        To retrieve the next bunch of result, use the `next` link in the `links` section
+        of the response.
 
 
         Minimum = 1. Maximum = 100. Default = 100.
@@ -1676,7 +1567,9 @@ components:
               case-insensitive comparison must be performed.
             type: string
         type: object
-      description: Apply query operations to a specific property
+      description: >-
+        Apply query operations to a specific property. The following properties are
+        currently supported: `created`, `updated`, `title`.
     searchBody:
       allOf:
       - $ref: "#/components/schemas/queryFilter"
@@ -2031,7 +1924,7 @@ paths:
     get:
       operationId: getCollections
       parameters:
-      - $ref: "#/components/parameters/collectionsLimit"
+      - $ref: "#/components/parameters/limit"
       responses:
         "200":
           $ref: "#/components/responses/Collections"
@@ -2221,7 +2114,7 @@ paths:
       operationId: getFeatures
       parameters:
       - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/itemsLimit"
+      - $ref: "#/components/parameters/limit"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"
       responses:
@@ -2491,7 +2384,6 @@ paths:
         Retrieve Items matching filters. Intended as a shorthand API for simple queries.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/query"
       - $ref: "#/components/parameters/bbox"
       - $ref: "#/components/parameters/datetime"
       - $ref: "#/components/parameters/limit"


### PR DESCRIPTION
This PR contains the following changes:

- remove `datetime` from queryable fields in GET and POST /search (it's redundant with the `datetime` query parameter)
- spec: remove `query` parameter in GET /search
- spec: cleanup in GET/POST /search