### PR TITLE
BGDIINF_SB-1664: Fixes and improvement of the admin Asset page

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -18,29 +18,6 @@ from stac_api.models import Provider
 from stac_api.utils import build_asset_href
 
 
-@admin.register(Asset)
-class AssetAdmin(admin.ModelAdmin):
-    readonly_fields = ['href', 'checksum_multihash']
-
-    def save_model(self, request, obj, form, change):
-        if obj.description == '':
-            # The admin interface with TextArea uses empty string instead
-            # of None. We use None for empty value, None value are stripped
-            # then in the output will empty string not.
-            obj.description = None
-        super().save_model(request, obj, form, change)
-
-    # Note: this is a bit hacky and only required to get access
-    # to the request object in 'href' method.
-    def get_form(self, request, obj=None, **kwargs):  # pylint: disable=arguments-differ
-        self.request = request  # pylint: disable=attribute-defined-outside-init
-        return super().get_form(request, obj, **kwargs)
-
-    def href(self, instance):
-        path = instance.file.name
-        return build_asset_href(self.request, path)
-
-
 class LandingPageLinkInline(admin.TabularInline):
     model = LandingPageLink
     extra = 0
@@ -86,6 +63,13 @@ class CollectionAdmin(admin.ModelAdmin):
     ]
     inlines = [ProviderInline, CollectionLinkInline]
     search_fields = ['name']
+    list_display = ['name']
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if search_term.startswith('"') and search_term.endswith('"'):
+            queryset |= self.model.objects.filter(name__exact=search_term.strip('"'))
+        return queryset, use_distinct
 
 
 class ItemLinkInline(admin.TabularInline):
@@ -118,3 +102,61 @@ class ItemAdmin(admin.GeoModelAdmin):
     map_template = finders.find('admin/ol_swisstopo.html')  # custom swisstopo
     wms_layer = 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale'
     wms_url = 'https://wms.geo.admin.ch/'
+    list_display = ['name', 'collection']
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if search_term.startswith('"') and search_term.endswith('"'):
+            queryset |= self.model.objects.filter(name__exact=search_term.strip('"'))
+        return queryset, use_distinct
+
+
+@admin.register(Asset)
+class AssetAdmin(admin.ModelAdmin):
+    autocomplete_fields = ['item']
+    search_fields = ['name']
+    readonly_fields = ['collection', 'href', 'checksum_multihash']
+    list_display = ['name', 'item', 'collection']
+    fieldsets = (
+        (None, {
+            'fields': ('name', 'item', 'collection')
+        }),
+        ('File', {
+            'fields': ('file', 'media_type', 'href', 'checksum_multihash')
+        }),
+        ('Description', {
+            'fields': ('title', 'description')
+        }),
+        ('Attributes', {
+            'fields': ('eo_gsd', 'proj_epsg', 'geoadmin_variant', 'geoadmin_lang')
+        }),
+    )
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if search_term.startswith('"') and search_term.endswith('"'):
+            queryset |= self.model.objects.filter(name__exact=search_term.strip('"'))
+        return queryset, use_distinct
+
+    def collection(self, instance):
+        return instance.item.collection
+
+    collection.admin_order_field = 'item__collection'
+
+    def save_model(self, request, obj, form, change):
+        if obj.description == '':
+            # The admin interface with TextArea uses empty string instead
+            # of None. We use None for empty value, None value are stripped
+            # then in the output will empty string not.
+            obj.description = None
+        super().save_model(request, obj, form, change)
+
+    # Note: this is a bit hacky and only required to get access
+    # to the request object in 'href' method.
+    def get_form(self, request, obj=None, **kwargs):  # pylint: disable=arguments-differ
+        self.request = request  # pylint: disable=attribute-defined-outside-init
+        return super().get_form(request, obj, **kwargs)
+
+    def href(self, instance):
+        path = instance.file.name
+        return build_asset_href(self.request, path)

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -328,7 +328,8 @@ class Item(models.Model):
         return instance
 
     def __str__(self):
-        return self.name
+        # This is used in the admin page in the autocomplete_fields of the Asset page
+        return f"{self.collection.name}/{self.name}"
 
     def update_etag(self):
         '''Update the ETag with a new UUID


### PR DESCRIPTION
The asset admin page for create/update an asset could not be displayed
when the DB contained a lot of Items (several hundred of thousand). This
was due to the fact that the view was trying to load all items for the
select box.

Now this issue has been solved by using an auto_complete_fields.

Other than that some other improvements have been done:

- Moved the AssetAdmin at the end of the file to have a consistent class
order
- Added collection and item in the list view
- Allow the search of wholeword using ""
- Organized the asset fields in fieldset
- Displayed the collection name in the asset view (Currently not dynamically updated when the item is changed, for this a save and refresh is unfortunately needed)

Here below some printscreen of the improvement:

![admin-asset-change](https://user-images.githubusercontent.com/67745584/107966994-deec0580-6fac-11eb-8eb0-2ba71dbe3ac6.png)
![admin-asset-list](https://user-images.githubusercontent.com/67745584/107967005-e3182300-6fac-11eb-880e-798eab7d4f88.png)
