### PR TITLE
BGDIINF_SB-1669: Removed un-necessary validation for asset href

### DIFF
--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -21,14 +21,12 @@ from stac_api.models import LandingPageLink
 from stac_api.models import Provider
 from stac_api.models import get_asset_path
 from stac_api.utils import build_asset_href
-from stac_api.utils import build_asset_href_prefix
 from stac_api.utils import isoformat
 from stac_api.validators import MEDIA_TYPES_MIMES
 from stac_api.validators import validate_asset_multihash
 from stac_api.validators import validate_geoadmin_variant
 from stac_api.validators import validate_item_properties_datetimes
 from stac_api.validators import validate_name
-from stac_api.validators_serializer import validate_and_parse_href_url
 from stac_api.validators_serializer import validate_asset_file
 from stac_api.validators_serializer import validate_json_payload
 
@@ -532,20 +530,14 @@ class AssetsDictSerializer(DictSerializer):
 class HrefField(serializers.Field):
     '''Special Href field for Assets'''
 
+    # pylint: disable=abstract-method
+
     def to_representation(self, value):
         # build an absolute URL from the file path
         request = self.context.get("request")
         path = value.name
 
         return build_asset_href(request, path)
-
-    def to_internal_value(self, data):
-        # extract the file path part from the
-        # provided URL and do some sanity checks
-        request = self.context.get("request")
-        url = validate_and_parse_href_url(build_asset_href_prefix(request), data)
-
-        return url.path[1:]  # strip the leading '/'
 
 
 class AssetBaseSerializer(NonNullModelSerializer):

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -100,30 +100,6 @@ def get_s3_resource():
     )
 
 
-def build_asset_href_prefix(request):
-    '''Build the asset href prefix based on the settings or request
-
-    This prefix can be then used for domain validation.
-
-    Args:
-        request: HttpRequest
-            Request object
-
-    Returns:
-        The asset href prefix either from settings.AWS_S3_CUSTOM_DOMAIN or from the request
-    '''
-    # Assets file are served by an AWS S3 services. This service uses the same domain as
-    # the API but could defer, especially for local development, so check first
-    # AWS_S3_CUSTOM_DOMAIN
-    if settings.AWS_S3_CUSTOM_DOMAIN:
-        # By definition we should not mixed up HTTP Scheme (HTTP/HTTPS) within our service,
-        # although the Assets file are not served by django we configure it with the same scheme
-        # as django that's why it is kind of safe to use the django scheme.
-        return f'{request.scheme if request.scheme else "https"}://{settings.AWS_S3_CUSTOM_DOMAIN}'
-
-    return request.build_absolute_uri('/')
-
-
 def build_asset_href(request, path):
     '''Build asset href
 

--- a/app/stac_api/validators.py
+++ b/app/stac_api/validators.py
@@ -87,12 +87,13 @@ def validate_geoadmin_variant(variant):
     '''
     if not re.match('^([a-zA-Z0-9]+\\s)*[a-zA-Z0-9]+$', variant):
         logger.error(
-            "Invalid geoadmin:variant property %s, special characters not allowed." \
+            "Invalid geoadmin:variant property \"%s\", special characters not allowed." \
             "One space in between is the exception.",
             variant
         )
         raise ValidationError(
-            _("Invalid geoadmin:variant, special characters beside one space are not allowed"),
+            _(f'Invalid geoadmin:variant "{variant}", '
+              'special characters beside one space are not allowed'),
             code="geoadmin:variant"
         )
 

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from decimal import Decimal
-from urllib.parse import urlparse
 
 import botocore
 import multihash
@@ -85,38 +84,6 @@ def validate_asset_href_path(item, asset_name, path):
         raise ValidationError({
             'href': _(f"Invalid path; should be {expected_path} but got {path}")
         })
-
-
-def validate_and_parse_href_url(url_prefix, href):
-    '''Parse and validate href URL
-
-    Validate the given href which needs to ba a valid URL with the same domain as the given prefix
-
-    Args:
-        url_prefix:
-            URL prefix to use for domain validation
-        href: string
-            href url string to parse and validate
-
-    Returns:
-        Parse url object
-
-    Raises:
-        ValidationError in case of invalid href
-    '''
-    logger.debug('Validate and parse href url %s, url_prefix=%s', href, url_prefix)
-    url_prefix = urlparse(url_prefix)
-    try:
-        url = urlparse(href)
-    except ValueError as error:
-        logger.error('Invalid href %s, must be a valid URL', href)
-        raise ValidationError({'href': _('Invalid value, must be a valid URL')}) from error
-
-    # the asset should come from the same host
-    if url.netloc != url_prefix.netloc:
-        logger.error('Invalid href %s, must be on domain %s', href, url_prefix.netloc)
-        raise ValidationError({'href': _(f'Invalid value, must be on domain {url_prefix.netloc}')})
-    return url
 
 
 def validate_asset_file(href, original_name, attrs):

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -308,8 +308,8 @@ class AssetsWriteEndpointTestCase(StacBaseTestCase):
         self.assertEqual(
             {
                 'geoadmin:variant': [
-                    'Invalid geoadmin:variant, special characters beside one '
-                    'space are not allowed',
+                    'Invalid geoadmin:variant "more than twenty-five characters with s", '
+                    'special characters beside one space are not allowed',
                     'Ensure this field has no more than 25 characters.'
                 ]
             },


### PR DESCRIPTION
Asset href has been already set as read-only, but there were still some
code for href validation that was not anymore in use. This code as been
removed to avoid missunderstanding of the use of AWS_S3_CUSTOM_DOMAIN

Also improved an error message for POST/PUT Asset