### PR TITLE
BGDIINF_SB-1667: Fixed asset update/deletion crash

### DIFF
--- a/app/stac_api/collection_summaries.py
+++ b/app/stac_api/collection_summaries.py
@@ -78,7 +78,11 @@ class CollectionSummariesMixin():
                                    ('proj:epsg', 'proj_epsg'),
                                    ('eo:gsd', 'eo_gsd')]:
                 attribute_value = getattr(asset, attribute)
-                if not assets.filter(**{attribute: attribute_value}).exists():
+                if (
+                    not assets.filter(**{
+                        attribute: attribute_value
+                    }).exists() and attribute_value is not None
+                ):
                     logger.info(
                         'Removing %s %s from collection summaries',
                         key,
@@ -271,7 +275,9 @@ class CollectionSummariesMixin():
             self.summaries["proj:epsg"].append(proj_epsg)
             updated |= True
 
-        if not assets.exists() or not assets.filter(proj_epsg=original_proj_epsg).exists():
+        if (
+            not assets.exists() or not assets.filter(proj_epsg=original_proj_epsg).exists()
+        ) and original_proj_epsg is not None:
             logger.info(
                 'Removes original proj:epsg value %s from collection summaries',
                 original_proj_epsg,
@@ -326,7 +332,9 @@ class CollectionSummariesMixin():
             self.summaries["eo:gsd"].append(eo_gsd)
             updated |= True
 
-        if not assets.exists() or not assets.filter(eo_gsd=original_eo_gsd).exists():
+        if (
+            not assets.exists() or not assets.filter(eo_gsd=original_eo_gsd).exists()
+        ) and original_eo_gsd is not None:
             logger.info(
                 'Removes original eo:gsd value %s from collection summaries',
                 original_eo_gsd,

--- a/app/tests/test_collections_summaries.py
+++ b/app/tests/test_collections_summaries.py
@@ -145,6 +145,47 @@ class CollectionsSummariesTestCase(TestCase):
             "after asset has been deleted."
         )
 
+    def test_update_collection_summaries_empty_asset_delete(self):
+        # This test has been introduced due to a bug when removing an asset without eo:gsd,
+        # proj:espg and geoadmin:variant from a collections with summaries
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [], 'proj:epsg': [], 'geoadmin:variant': []
+            }
+        )
+        item = self.data_factory.create_item_sample(collection=self.collection).model
+        asset = self.data_factory.create_asset_sample(
+            item=item, required_only=True, geoadmin_variant=None, eo_gsd=None, proj_epsg=None
+        ).model
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [], 'proj:epsg': [], 'geoadmin:variant': []
+            }
+        )
+        asset2 = self.data_factory.create_asset_sample(
+            item=item, required_only=True, geoadmin_variant='krel', eo_gsd=2, proj_epsg=2056
+        ).model
+        self.assertIsNone(asset.geoadmin_variant)
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [2], 'proj:epsg': [2056], 'geoadmin:variant': ['krel']
+            }
+        )
+
+        asset.delete()
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [2], 'proj:epsg': [2056], 'geoadmin:variant': ['krel']
+            }
+        )
+
+        asset2.delete()
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [], 'proj:epsg': [], 'geoadmin:variant': []
+            }
+        )
+
     def test_update_collection_summaries_asset_update(self):
         # Tests if collection's summaries are updated correctly after an
         # asset was updated
@@ -174,13 +215,23 @@ class CollectionsSummariesTestCase(TestCase):
             "updated after asset has been inserted."
         )
 
-    def test_update_collection_summaries_none_variant(self):
+    def test_update_collection_summaries_none_values(self):
         # update a variant, that as been None as a start value
-        collection = self.data_factory.create_collection_sample().model
-        item = self.data_factory.create_item_sample(collection=collection, name='base-bbox').model
-        asset = self.add_asset(item, 'har', None, None, None)
-        self.assertEqual(collection.summaries["geoadmin:variant"], [])
+        item = self.data_factory.create_item_sample(collection=self.collection).model
+        asset = self.add_asset(item, 'asset-1', None, None, None)
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [], 'proj:epsg': [], 'geoadmin:variant': []
+            }
+        )
         asset.geoadmin_variant = "krel"
+        asset.eo_gsd = 2
+        asset.proj_epsg = 2056
         asset.full_clean()
         asset.save()
-        self.assertEqual(collection.summaries["geoadmin:variant"], ["krel"])
+
+        self.assertEqual(
+            self.collection.summaries, {
+                'eo:gsd': [2.0], 'proj:epsg': [2056], 'geoadmin:variant': ['krel']
+            }
+        )


### PR DESCRIPTION
When deleting an Asset that had no eo:gsd or proj:epsg or
geoadmin:variant (value as None) in a collection with non empty
summaries, a `ValueError("list.remove: x not in list")`. Same for
updating an Asset without eo:gsd or proj:epsg or
geoadmin:variant (value as None) with a value.