### PR TITLE
BGDIINF_SB-1681: Log exception also on production build

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -99,7 +99,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'middleware.logging.ExceptionLoggingMiddleware',
     'middleware.cache_headers.CacheHeadersMiddleware',
     'middleware.cors.CORSHeadersMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -101,6 +101,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'middleware.cache_headers.CacheHeadersMiddleware',
     'middleware.cors.CORSHeadersMiddleware',
+    'middleware.exception.ExceptionLoggingMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 

--- a/app/middleware/exception.py
+++ b/app/middleware/exception.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+class ExceptionLoggingMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        # NOTE: this process_exception is not called for REST Framework endpoints. For those
+        # the exceptions handling and logging is done within stac_api.apps.custom_exception_handler
+        extra = {"request": request}
+        logger.critical(repr(exception), extra=extra, exc_info=sys.exc_info())

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import sys
 
 from django.http import HttpResponse
 from django.http import JsonResponse
@@ -43,27 +42,3 @@ class RequestResponseLoggingMiddleware:
         # the view is called.
 
         return response
-
-
-class ExceptionLoggingMiddleware:
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-        # One-time configuration and initialization.
-
-    def __call__(self, request):
-        # Code to be executed for each request before
-        # the view (and later middleware) are called.
-
-        response = self.get_response(request)
-
-        # Code to be executed for each request/response after
-        # the view is called.
-
-        return response
-
-    def process_exception(self, request, exception):
-        extra = {
-            "request": request
-        }
-        logger.critical(repr(exception), extra=extra, exc_info=sys.exc_info())

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -1,6 +1,6 @@
 import logging
 import time
-import traceback
+import sys
 
 from django.http import HttpResponse
 from django.http import JsonResponse
@@ -64,6 +64,6 @@ class ExceptionLoggingMiddleware:
 
     def process_exception(self, request, exception):
         extra = {
-            "request": request, "exception": repr(exception), "traceback": traceback.format_exc()
+            "request": request
         }
-        logger.critical(repr(exception), extra=extra)
+        logger.critical(repr(exception), extra=extra, exc_info=sys.exc_info())

--- a/app/stac_api/apps.py
+++ b/app/stac_api/apps.py
@@ -96,6 +96,8 @@ class CursorPagination(pagination.CursorPagination):
 
 
 def custom_exception_handler(exc, context):
+    # NOTE: this exception handler is only called for REST Framework endpoints. Other endpoints
+    # exception are handled via middleware.exception.
     if isinstance(exc, django.core.exceptions.ValidationError):
         # Translate django ValidationError to Rest Framework ValidationError,
         # this is required because some validation cannot be done in the Rest


### PR DESCRIPTION
On production build with the DEBUG=False the exception where not logged
because the rest framework custom exception handler in apps.py did
caught all exceptions and returned a proper 500 message (JSON or HTML
depending on Accept header or format query). Due to this the logging exception middleware was not called.

So now we logs the exception in the custom exception handler instead of
in the exception middleware. This means that for all exceptions on the
API endpoints we will have a log message from logger="stac_api.app" with
level CRITICAL and with exc_info=True. 
On the other hand all exceptions happening from
the admin interface endpoints, we will have a log from
logger="django.server" of level ERROR with exc_info=True. This is due to the fact that for those endpoints the rest framework custom exception is not called.

I've tried also to remove the custom exception handler, and leave it to the exception handler to change the HTTP 500 message body to our convention: `{'code': 500, 'description': 'Internal Server Error'}`, but then we will always have a JSON response instead of an API response like for other normal response (meaning the rest framework api html response for browser)