### PR TITLE
Improved logging

### DIFF
--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -53,7 +53,7 @@ formatters:
   standard:
     (): logging_utilities.formatters.extra_formatter.ExtraFormatter
     format: "[%(utc_isotime)s] %(levelname)-8s - %(name)-26s : %(message)s"
-    extra_fmt: " - duration: %(duration)s"
+    # extra_fmt: " - duration: %(duration)s"
     # extra_pretty_print: True
   standard-file:
     (): logging_utilities.formatters.extra_formatter.ExtraFormatter

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -17,7 +17,9 @@ class RequestResponseLoggingMiddleware:
     def __call__(self, request):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
-        logger.info("request", extra={"request": request})
+        logger.info(
+            "Request %s %s", request.method.upper(), request.path, extra={"request": request}
+        )
         start = time.time()
 
         response = self.get_response(request)
@@ -36,7 +38,7 @@ class RequestResponseLoggingMiddleware:
         if isinstance(response, (HttpResponse, JsonResponse)):
             extra["response"]["content"] = str(response.content)[:200]
 
-        logger.info("request-response", extra=extra)
+        logger.info("Response %s", response.status_code, extra=extra)
         # Code to be executed for each request/response after
         # the view is called.
 


### PR DESCRIPTION
The logging middleware message was not very usefull. It did not helped
at all on local developement because we don't use the json format with
the request dictionary and on Kibana the message 'request' did not
helped neither unless we activate the whole request object.