### PR TITLE
Bug fix BGDIINF_SB-1690: raise error on invalid query parameters

### DIFF
--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -208,6 +208,25 @@ def _validate_asset_file_checksum(href, expected_multihash, asset_multihash):
         )
 
 
+def validate_collection_item_endpoint_get_requests(view, request):
+
+    queried_parameters = list(request.GET.copy().keys())
+
+    if type(view).__name__ == "CollectionList":
+        accepted_query_parameters = ['cursor', 'limit']
+    elif type(view).__name__ == "ItemsList":
+        accepted_query_parameters = ['bbox', 'cursor', 'datetime', 'limit']
+
+    # make sure that all queried_parameters are in the accepted_query_parameters
+    if not all(parameter in accepted_query_parameters for parameter in queried_parameters):
+        wrong_query_parameters = np.setdiff1d(queried_parameters,
+                                              accepted_query_parameters).tolist()
+        logger.error('Query contains the non-allowed parameter(s): %s', str(wrong_query_parameters))
+        message = f"The query contains the following non-queriable" \
+        f"parameter(s): {str(wrong_query_parameters)}."
+        raise ValidationError(code='query-invalid', detail=_(message))
+
+
 class ValidateSearchRequest:
     '''Validates the query parameter for the search endpoint.
 

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -209,6 +209,18 @@ def _validate_asset_file_checksum(href, expected_multihash, asset_multihash):
 
 
 def validate_collection_item_endpoint_get_requests(view, request):
+    '''Check GET requests on the collections and items endpoints (for the
+    CollectionList and ItemsList view) for invalid query parameters. Raise a
+    Validation error in case of invalid parameters.
+    Args:
+        view: view instance
+            view instance of the calling view
+        request: RequestDict
+            The GET request of the calling endpoint/view
+
+    Raises:
+        ValidationError
+    '''
 
     queried_parameters = list(request.GET.copy().keys())
 

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -27,6 +27,7 @@ from stac_api.serializers import LandingPageSerializer
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import utc_aware
 from stac_api.validators_serializer import ValidateSearchRequest
+from stac_api.validators_serializer import validate_collection_item_endpoint_get_requests
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,7 @@ class CollectionList(generics.GenericAPIView, views_mixins.CreateModelMixin):
 
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
+        validate_collection_item_endpoint_get_requests(self, request)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
@@ -254,6 +256,7 @@ class ItemsList(generics.GenericAPIView, views_mixins.CreateModelMixin):
         return Response(data)
 
     def get(self, request, *args, **kwargs):
+        validate_collection_item_endpoint_get_requests(self, request)
         return self.list(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -75,7 +75,7 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
     def test_collection_non_allowed_parameters(self):
         non_allowed_parameter = "no_limits"
         value = 100
-        response = self.client.get(f"/{STAC_BASE_V}/collections?{non_allowed_parameter}=100")
+        response = self.client.get(f"/{STAC_BASE_V}/collections?{non_allowed_parameter}={value}")
         self.assertStatusCode(400, response)
         json_data = response.json()
         self.assertIn(

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -72,6 +72,18 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
                          response.json()['description'],
                          msg='Unexpected error message')
 
+    def test_collection_non_allowed_parameters(self):
+        non_allowed_parameter = "no_limits"
+        value = 100
+        response = self.client.get(f"/{STAC_BASE_V}/collections?{non_allowed_parameter}=100")
+        self.assertStatusCode(400, response)
+        json_data = response.json()
+        self.assertIn(
+            non_allowed_parameter,
+            str(json_data['description']),
+            msg=f"Wrong query parameter {non_allowed_parameter} not found in error message"
+        )
+
 
 class CollectionsWriteEndpointTestCase(StacBaseTestCase):
 

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -88,7 +88,8 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
         non_allowed_parameter = "no_limits"
         value = 100
         response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?{non_allowed_parameter}=100"
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
+            f"?{non_allowed_parameter}={value}"
         )
         self.assertStatusCode(400, response)
         json_data = response.json()

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -84,6 +84,20 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
         response = self.client.get(f"/{STAC_BASE_V}/collections/non-existing-collection/items")
         self.assertStatusCode(404, response)
 
+    def test_item_non_allowed_parameters(self):
+        non_allowed_parameter = "no_limits"
+        value = 100
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?{non_allowed_parameter}=100"
+        )
+        self.assertStatusCode(400, response)
+        json_data = response.json()
+        self.assertIn(
+            non_allowed_parameter,
+            str(json_data['description']),
+            msg=f"Wrong query parameter {non_allowed_parameter} not found in error message"
+        )
+
 
 class ItemsDatetimeQueryEndpointTestCase(StacBaseTestCase):
 


### PR DESCRIPTION
The `collections` and `items` endpoints currently did not return errors on GET requests containing invalid parameters, e.g. on
https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.swissbuildings3d_2/items?limit=50&random_nonsense_parameter=blablablubb or
https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections?no_limits=50
This fix now raises a ValidationError in case invalid query parameters are found.

The corresponding unit tests are added, too.