### PR TITLE
BGDIINF_SB-1711: Fixed the POST /search pagination

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -270,7 +270,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ],
-    'DEFAULT_PAGINATION_CLASS': 'stac_api.apps.CursorPagination',
+    'DEFAULT_PAGINATION_CLASS': 'stac_api.pagination.CursorPagination',
     'PAGE_SIZE': os.environ.get('PAGE_SIZE', 100),
     'PAGE_SIZE_LIMIT': os.environ.get('PAGE_SIZE_LIMIT', 100),
     'EXCEPTION_HANDLER': 'stac_api.apps.custom_exception_handler',

--- a/app/stac_api/apps.py
+++ b/app/stac_api/apps.py
@@ -4,9 +4,7 @@ import sys
 import django.core.exceptions
 from django.apps import AppConfig
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 
-from rest_framework import pagination
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
@@ -22,77 +20,6 @@ class StacApiConfig(AppConfig):
         # hooks are executed and signal handlers are active
         # https://docs.djangoproject.com/en/3.1/topics/signals/#django.dispatch.receiver
         import stac_api.signals  # pylint: disable=import-outside-toplevel, unused-import
-
-
-class CursorPagination(pagination.CursorPagination):
-    ordering = 'id'
-    page_size_query_param = 'limit'
-    max_page_size = settings.REST_FRAMEWORK['PAGE_SIZE_LIMIT']
-
-    def get_paginated_response(self, data):
-        links = []
-        next_page = self.get_next_link()
-        previous_page = self.get_previous_link()
-        if next_page is not None:
-            links.append({'rel': 'next', 'href': next_page})
-        if previous_page is not None:
-            links.append({'rel': 'previous', 'href': previous_page})
-
-        if 'links' not in data and not links:
-            data.update({'links': []})
-        elif 'links' not in data and links:
-            data.update({'links': [links]})
-        elif links:
-            data['links'] += links
-        return Response(data)
-
-    def get_page_size(self, request):
-        # Overwrite the default implementation about the page size as this one
-        # don't validate the query parameter, its simply correct it if it is not valid
-        # here we want to return a 400 BAD REQUEST when the provided page size is invalid.
-
-        # POST 'limit' param has a higher priority than GET
-        if self.page_size_query_param in request.data:
-            integer_string = request.data[self.page_size_query_param]
-        else:
-            integer_string = request.query_params.get(self.page_size_query_param, self.page_size)
-
-        try:
-            page_size = int(integer_string)
-        except ValueError as error:
-            logger.error(
-                'Invalid query parameter limit=%s: must be an integer',
-                integer_string,
-                extra={'request': request}
-            )
-            raise ValidationError(
-                _('invalid limit query parameter: must be an integer'),
-                code='limit'
-            )
-
-        if page_size <= 0:
-            logger.error(
-                'Invalid query parameter limit=%d: negative number not allowed',
-                page_size,
-                extra={'request': request}
-            )
-            raise ValidationError(
-                _('limit query parameter to small, must be in range 1..%d') % (self.max_page_size),
-                code='limit'
-            )
-        if self.max_page_size and page_size > self.max_page_size:
-            logger.error(
-                'Invalid query parameter limit=%d: number bigger than the max size of %d',
-                page_size,
-                self.max_page_size,
-                extra={'request': request}
-            )
-            raise ValidationError(
-                _('limit query parameter to big, must be in range 1..%d') % (self.max_page_size),
-                code='limit'
-            )
-
-        return page_size
 
 
 def custom_exception_handler(exc, context):

--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -1,0 +1,81 @@
+import logging
+
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import pagination
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+logger = logging.getLogger(__name__)
+
+
+class CursorPagination(pagination.CursorPagination):
+    ordering = 'id'
+    page_size_query_param = 'limit'
+    max_page_size = settings.REST_FRAMEWORK['PAGE_SIZE_LIMIT']
+
+    def get_paginated_response(self, data):
+        links = []
+        next_page = self.get_next_link()
+        previous_page = self.get_previous_link()
+        if next_page is not None:
+            links.append({'rel': 'next', 'href': next_page})
+        if previous_page is not None:
+            links.append({'rel': 'previous', 'href': previous_page})
+
+        if 'links' not in data and not links:
+            data.update({'links': []})
+        elif 'links' not in data and links:
+            data.update({'links': [links]})
+        elif links:
+            data['links'] += links
+        return Response(data)
+
+    def get_page_size(self, request):
+        # Overwrite the default implementation about the page size as this one
+        # don't validate the query parameter, its simply correct it if it is not valid
+        # here we want to return a 400 BAD REQUEST when the provided page size is invalid.
+
+        # POST 'limit' param has a higher priority than GET
+        if self.page_size_query_param in request.data:
+            integer_string = request.data[self.page_size_query_param]
+        else:
+            integer_string = request.query_params.get(self.page_size_query_param, self.page_size)
+
+        try:
+            page_size = int(integer_string)
+        except ValueError as error:
+            logger.error(
+                'Invalid query parameter limit=%s: must be an integer',
+                integer_string,
+                extra={'request': request}
+            )
+            raise ValidationError(
+                _('invalid limit query parameter: must be an integer'),
+                code='limit'
+            )
+
+        if page_size <= 0:
+            logger.error(
+                'Invalid query parameter limit=%d: negative number not allowed',
+                page_size,
+                extra={'request': request}
+            )
+            raise ValidationError(
+                _('limit query parameter to small, must be in range 1..%d') % (self.max_page_size),
+                code='limit'
+            )
+        if self.max_page_size and page_size > self.max_page_size:
+            logger.error(
+                'Invalid query parameter limit=%d: number bigger than the max size of %d',
+                page_size,
+                self.max_page_size,
+                extra={'request': request}
+            )
+            raise ValidationError(
+                _('limit query parameter to big, must be in range 1..%d') % (self.max_page_size),
+                code='limit'
+            )
+
+        return page_size

--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -1,11 +1,17 @@
 import logging
+from urllib import parse
 
 from django.conf import settings
+from django.core.handlers.wsgi import WSGIRequest
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import pagination
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param
+
+from stac_api.utils import get_query_param
 
 logger = logging.getLogger(__name__)
 
@@ -15,14 +21,26 @@ class CursorPagination(pagination.CursorPagination):
     page_size_query_param = 'limit'
     max_page_size = settings.REST_FRAMEWORK['PAGE_SIZE_LIMIT']
 
-    def get_paginated_response(self, data):
+    def get_next_link(self, request=None):  # pylint: disable=arguments-differ
+        next_page = super().get_next_link()
+        if next_page:
+            return {'rel': 'next', 'href': next_page}
+        return None
+
+    def get_previous_link(self, request=None):  # pylint: disable=arguments-differ
+        previous_page = super().get_previous_link()
+        if previous_page:
+            return {'rel': 'previous', 'href': previous_page}
+        return None
+
+    def get_paginated_response(self, data, request=None):  # pylint: disable=arguments-differ
         links = []
-        next_page = self.get_next_link()
-        previous_page = self.get_previous_link()
-        if next_page is not None:
-            links.append({'rel': 'next', 'href': next_page})
-        if previous_page is not None:
-            links.append({'rel': 'previous', 'href': previous_page})
+        next_link = self.get_next_link(request)
+        previous_link = self.get_previous_link(request)
+        if next_link is not None:
+            links.append(next_link)
+        if previous_link is not None:
+            links.append(previous_link)
 
         if 'links' not in data and not links:
             data.update({'links': []})
@@ -37,11 +55,7 @@ class CursorPagination(pagination.CursorPagination):
         # don't validate the query parameter, its simply correct it if it is not valid
         # here we want to return a 400 BAD REQUEST when the provided page size is invalid.
 
-        # POST 'limit' param has a higher priority than GET
-        if self.page_size_query_param in request.data:
-            integer_string = request.data[self.page_size_query_param]
-        else:
-            integer_string = request.query_params.get(self.page_size_query_param, self.page_size)
+        integer_string = self.get_raw_page_size(request)
 
         try:
             page_size = int(integer_string)
@@ -79,3 +93,58 @@ class CursorPagination(pagination.CursorPagination):
             )
 
         return page_size
+
+    def get_raw_page_size(self, request):
+        return request.query_params.get(self.page_size_query_param, str(self.page_size))
+
+
+class GetPostCursorPagination(CursorPagination):
+
+    def get_raw_page_size(self, request):
+        if request.method == 'POST':
+            # For POST method the page size, aka `limit` parameter is in the body and not in the
+            # URL query
+            return request.data.get(self.page_size_query_param, str(self.page_size))
+        return super().get_raw_page_size(request)
+
+    def decode_cursor(self, request):
+        if request.method == 'POST':
+            # Patched the cursor in the url query from POST payload
+            cursor_encoded = request.data.get(self.cursor_query_param)
+            if cursor_encoded:
+                # Here we need to patch the request with the cursor. The original
+                # decode_cursor() method is taking the cursor from the URL query
+                # that's why we create a new request object being a copy of the
+                # original one plus the cursor as URL query. We need to do this
+                # copy because request objects are immutable.
+                environ = request.environ.copy()
+                environ['QUERY_STRING'] += parse.urlencode(
+                    {self.cursor_query_param: cursor_encoded},
+                    doseq=True,
+                )
+                request = Request(WSGIRequest(environ))
+        return super().decode_cursor(request)
+
+    def get_next_link(self, request=None):
+        next_link = super().get_next_link(request)
+        return self.patch_link(next_link, request)
+
+    def get_previous_link(self, request=None):
+        previous_link = super().get_previous_link(request)
+        return self.patch_link(previous_link, request)
+
+    def patch_link(self, link, request):
+        if link and request and request.method == 'POST':
+            cursor = get_query_param(link['href'], self.cursor_query_param)
+            limit = get_query_param(link['href'], self.page_size_query_param)
+            if cursor:
+                link['href'] = remove_query_param(link['href'], self.cursor_query_param)
+            if limit:
+                link['href'] = remove_query_param(link['href'], self.page_size_query_param)
+            body = {}
+            if limit:
+                body['limit'] = limit[0]
+            if cursor:
+                body['cursor'] = cursor[0]
+            link.update({'method': 'POST', 'merge': True, 'body': body})
+        return link

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 from datetime import datetime
 from datetime import timezone
+from urllib import parse
 
 import boto3
 import multihash
@@ -195,6 +196,22 @@ def harmonize_post_get_for_search(request):
         if 'collections' in query_param:
             query_param['collections'] = query_param['collections'].split(',')  # to array
     return query_param
+
+
+def get_query_param(url, key):
+    '''Get an URL query parameter by key
+
+    Args:
+        url: string
+            url to parse and retrieve query parameter
+        key: string
+            query parameter key to retrieve
+    Returns: string
+        Query parameter value
+    '''
+    (scheme, netloc, path, query, fragment) = parse.urlsplit(url)
+    query_dict = parse.parse_qs(query, keep_blank_values=True)
+    return query_dict.pop(key, None)
 
 
 class CommandHandler():

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -198,20 +198,46 @@ def harmonize_post_get_for_search(request):
     return query_param
 
 
-def get_query_param(url, key):
-    '''Get an URL query parameter by key
+def get_query_params(url, keys):
+    '''Get URL query parameters by keys
 
     Args:
         url: string
             url to parse and retrieve query parameter
-        key: string
-            query parameter key to retrieve
-    Returns: string
-        Query parameter value
+        keys: string | [string]
+            query parameter key(s) to retrieve
+    Returns: string | [string]
+        Query parameter value(s)
     '''
     (scheme, netloc, path, query, fragment) = parse.urlsplit(url)
     query_dict = parse.parse_qs(query, keep_blank_values=True)
-    return query_dict.pop(key, None)
+    if isinstance(keys, str):
+        return query_dict.get(keys, None)
+    return [query_dict.get(key, None) for key in keys if key]
+
+
+def remove_query_params(url, keys):
+    """
+    Given a URL and a key/val pair, remove an item(s) in the query
+    parameters of the URL, and return the new URL.
+
+    Args:
+        url: string
+            url to parse and retrieve query parameter
+        keys: string | [string]
+            query parameter key(s) to remove
+    Returns: string
+        New URL string
+    """
+    (scheme, netloc, path, query, fragment) = parse.urlsplit(url)
+    query_dict = parse.parse_qs(query, keep_blank_values=True)
+    if isinstance(keys, str):
+        query_dict.pop(keys, None)
+    else:
+        [query_dict.pop(key, None) for key in keys if key]  # pylint: disable=expression-not-assigned
+
+    query = parse.urlencode(sorted(query_dict.items()), doseq=True)
+    return parse.urlunsplit((scheme, netloc, path, query, fragment))
 
 
 class CommandHandler():

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -520,7 +520,7 @@ class ValidateSearchRequest:
                 Copy of the harmonized QueryDict
         '''
         accepted_query_parameters = [
-            "bbox", "collections", "datetime", "ids", "intersects", "limit", "query"
+            "bbox", "collections", "datetime", "ids", "intersects", "limit", "cursor", "query"
         ]
         wrong_query_parameters = set(query_param.keys()).difference(set(accepted_query_parameters))
         if wrong_query_parameters:

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -522,7 +522,8 @@ class AssetDetail(
         return self.destroy(request, *args, **kwargs)
 
 
-class TestHttp500(AssetDetail):
+class TestHttp500(generics.GenericAPIView):
+    queryset = LandingPage.objects.all()
 
     def get(self, request, *args, **kwargs):
         logger.debug('Test request that raises an exception')

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -19,6 +19,7 @@ from stac_api.models import Collection
 from stac_api.models import ConformancePage
 from stac_api.models import Item
 from stac_api.models import LandingPage
+from stac_api.pagination import GetPostCursorPagination
 from stac_api.serializers import AssetSerializer
 from stac_api.serializers import CollectionSerializer
 from stac_api.serializers import ConformancePageSerializer
@@ -317,6 +318,7 @@ class ItemDetail(
 class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
     permission_classes = [AllowAny]
     serializer_class = ItemSerializer
+    pagination_class = GetPostCursorPagination
 
     def get_queryset(self):
         queryset = Item.objects.all().prefetch_related('assets', 'links')
@@ -384,7 +386,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
         }
 
         if page is not None:
-            return self.get_paginated_response(data)
+            return self.paginator.get_paginated_response(data, request)
         return Response(data)
 
     def get(self, request, *args, **kwargs):

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -50,7 +50,7 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
 
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=0")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too small, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 
@@ -62,13 +62,13 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
 
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=-1")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too small, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=1000")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to big, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too big, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -47,7 +47,7 @@ class ApiPaginationTestCase(StacBaseTestCase):
     def test_invalid_limit_query(self):
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=0")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too small, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 
@@ -59,13 +59,13 @@ class ApiPaginationTestCase(StacBaseTestCase):
 
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=-1")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to small, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too small, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 
         response = self.client.get(f"/{STAC_BASE_V}/collections?limit=1000")
         self.assertStatusCode(400, response)
-        self.assertEqual(['limit query parameter to big, must be in range 1..100'],
+        self.assertEqual(['limit query parameter too big, must be in range 1..100'],
                          response.json()['description'],
                          msg='Unexpected error message')
 

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -32,6 +32,7 @@ class ApiGenericTestCase(StacBaseTestCase):
         with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True):
             response = self.client.get("/tests/test_http_500")
             self.assertStatusCode(500, response)
+            self.assertEqual(response.json()['description'], "AttributeError('test exception')")
 
 
 class ApiPaginationTestCase(StacBaseTestCase):

--- a/app/tests/test_search_endpoint.py
+++ b/app/tests/test_search_endpoint.py
@@ -268,7 +268,7 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
         self.assertStatusCode(200, response)
         json_data_payload = response.json()
         self.assertEqual(
-            len(json_data_payload['features']), limit, msg="More than one item returned."
+            len(json_data_payload['features']), limit, msg=f"More than {limit} item(s) returned."
         )
 
     def test_query_created(self):

--- a/app/tests/test_search_endpoint.py
+++ b/app/tests/test_search_endpoint.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 from datetime import timedelta
@@ -5,6 +6,8 @@ from datetime import timedelta
 from django.conf import settings
 from django.test import Client
 
+from stac_api.utils import fromisoformat
+from stac_api.utils import get_link
 from stac_api.utils import isoformat
 from stac_api.utils import utc_aware
 
@@ -15,6 +18,153 @@ from tests.utils import client_login
 logger = logging.getLogger(__name__)
 
 STAC_BASE_V = settings.STAC_BASE_V
+
+
+class SearchEndpointPaginationTestCase(StacBaseTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.title_for_query = 'Item for pagination test'
+        cls.factory = Factory()
+        cls.collection = cls.factory.create_collection_sample().model
+        cls.items = cls.factory.create_item_samples(
+            [
+                'item-1',
+                'item-2',
+                'item-switzerland',
+                'item-switzerland-west',
+                'item-switzerland-east',
+                'item-switzerland-north',
+                'item-switzerland-south',
+                'item-paris'
+            ],
+            cls.collection,
+            properties_title=[
+                'My item',
+                cls.title_for_query,
+                None,
+                'My item',
+                'My item',
+                cls.title_for_query,
+                'My item',
+                cls.title_for_query
+            ],
+            db_create=True,
+        )
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+        client_login(self.client)
+        self.path = f'/{STAC_BASE_V}/search'
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_get_pagination(self):
+        limit = 1
+        query = {
+            "ids": ','.join([self.items[1]['name'], self.items[4]['name'], self.items[6]['name']]),
+            "limit": limit
+        }
+        response = self.client.get(self.path, query)
+        self.assertStatusCode(200, response)
+        json_data = response.json()
+        self.assertEqual(len(json_data['features']), limit)
+        # get the next link
+        next_link = get_link(json_data['links'], 'next')
+        self.assertIsNotNone(next_link, msg='No next link found')
+        self.assertEqual(next_link.get('method', 'GET'), 'GET')
+        self.assertNotIn('body', next_link)
+        self.assertNotIn('merge', next_link)
+
+        # Get the next page
+        query_next = query.copy()
+        response = self.client.get(next_link['href'])
+        self.assertStatusCode(200, response)
+        json_data_next = response.json()
+        self.assertEqual(len(json_data_next['features']), limit)
+
+        # make sure the next page is different than the original
+        self.assertNotEqual(
+            json_data['features'],
+            json_data_next['features'],
+            msg='Next page should not be the same as the first one'
+        )
+
+        # get the previous link
+        previous_link = get_link(json_data_next['links'], 'previous')
+        self.assertIsNotNone(previous_link, msg='No previous link found')
+        self.assertEqual(previous_link.get('method', 'GET'), 'GET')
+        self.assertNotIn('body', previous_link)
+        self.assertNotIn('merge', previous_link)
+
+        # Get the previous page
+        response = self.client.get(previous_link['href'])
+        self.assertStatusCode(200, response)
+        json_data_previous = response.json()
+        self.assertEqual(len(json_data_previous['features']), limit)
+
+        # make sure the previous data is identical to the first page
+        self.assertEqual(
+            json_data_previous['features'],
+            json_data['features'],
+            msg='previous page should be the same as the first one'
+        )
+
+    def test_post_pagination(self):
+        limit = 1
+        query = {"query": {"title": {"startsWith": self.title_for_query}}, "limit": limit}
+        response = self.client.post(self.path, data=query, content_type="application/json")
+        self.assertStatusCode(200, response)
+        json_data = response.json()
+        self.assertEqual(len(json_data['features']), limit)
+        # get the next link
+        next_link = get_link(json_data['links'], 'next')
+        self.assertIsNotNone(next_link, msg='No next link found')
+        self.assertEqual(next_link.get('method', 'POST'), 'POST')
+        self.assertIn('body', next_link)
+        self.assertIn('merge', next_link)
+
+        # Get the next page
+        query_next = query.copy()
+        if next_link['merge'] and next_link['body']:
+            query_next.update(next_link['body'])
+        response = self.client.post(
+            next_link['href'], data=query_next, content_type="application/json"
+        )
+        self.assertStatusCode(200, response)
+        json_data_next = response.json()
+        self.assertEqual(len(json_data_next['features']), limit)
+
+        # make sure the next page is different than the original
+        self.assertNotEqual(
+            json_data['features'],
+            json_data_next['features'],
+            msg='Next page should not be the same as the first one'
+        )
+
+        # get the previous link
+        previous_link = get_link(json_data_next['links'], 'previous')
+        self.assertIsNotNone(previous_link, msg='No previous link found')
+        self.assertEqual(previous_link.get('method', 'POST'), 'POST')
+        self.assertIn('body', previous_link)
+        self.assertIn('merge', previous_link)
+
+        # Get the previous page
+        query_previous = query.copy()
+        if previous_link['merge'] and previous_link['body']:
+            query_previous.update(previous_link['body'])
+        response = self.client.post(
+            previous_link['href'], data=query_previous, content_type="application/json"
+        )
+        self.assertStatusCode(200, response)
+        json_data_previous = response.json()
+        self.assertEqual(len(json_data_previous['features']), limit)
+
+        # make sure the previous data is identical to the first page
+        self.assertEqual(
+            json_data_previous['features'],
+            json_data['features'],
+            msg='previous page should be the same as the first one'
+        )
 
 
 class SearchEndpointTestCaseOne(StacBaseTestCase):
@@ -44,47 +194,41 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
         self.client = Client()
         client_login(self.client)
         self.path = f'/{STAC_BASE_V}/search'
+        self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_query(self):
         # get match
         title = "My item 1"
-        query = '{"title":{"eq":"%s"}}' % title
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?query={query}&limit=100")
+        query = {"title": {"eq": title}}
+        response = self.client.get(f"{self.path}?query={json.dumps(query)}")
         self.assertStatusCode(200, response)
         json_data_get = response.json()
-        self.assertEqual(json_data_get['features'][0]['properties']['title'], title)
+        for feature in json_data_get['features']:
+            self.assertEqual(feature['properties']['title'], title)
         self.assertEqual(len(json_data_get['features']), 1)
 
         # post match
-        payload = """
-        {"query":
-            {"title":
-                {"eq":"My item 1"}
-            }
-        }
-        """
+        payload = {"query": {"title": {"eq": "My item 1"}}}
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         json_data_post = response.json()
-        self.assertEqual(json_data_post['features'][0]['properties']['title'], title)
         self.assertEqual(len(json_data_post['features']), 1)
 
         # compare get and post
-        self.assertEqual(
-            json_data_get['features'][0]['properties']['title'],
-            json_data_post['features'][0]['properties']['title']
-        )
+        self.assertEqual(json_data_get['features'], json_data_post['features'])
+
+        for feature in json_data_post['features']:
+            self.assertEqual(feature['properties']['title'], title)
 
     def test_query_non_allowed_parameters(self):
         wrong_query_parameter = "cherry"
-        payload = f"""
-        {{"{wrong_query_parameter}":
-            {{"created":
-                {{"lte":"9999-12-31T09:07:39.399892Z"}}
-            }},
-            "limit": 1
-        }}
-        """
+        payload = {
+            wrong_query_parameter: {
+                "created": {
+                    "lte": "9999-12-31T09:07:39.399892Z"
+                }
+            }, "limit": 1
+        }
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(400, response)
         json_data = response.json()
@@ -97,14 +241,15 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
     def test_query_multiple_non_allowed_parameters(self):
         wrong_query_parameter1 = "cherry"
         wrong_query_parameter2 = "no_limits"
-        payload = f"""
-        {{"{wrong_query_parameter1}":
-            {{"created":
-                {{"lte":"9999-12-31T09:07:39.399892Z"}}
-            }},
-            "{wrong_query_parameter2}": 1
-        }}
-        """
+        payload = {
+            wrong_query_parameter1: {
+                "created": {
+                    "lte": "9999-12-31T09:07:39.399892Z"
+                }
+            },
+            wrong_query_parameter2: 1
+        }
+
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(400, response)
         json_data = response.json()
@@ -122,176 +267,113 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         json_data_payload = response.json()
-        self.assertEqual(len(json_data_payload['features']), 1, msg="More than one item returned.")
-
-        # limit in url
-        payload.pop('limit')
-        response = self.client.post(
-            f"{self.path}?limit={limit}", data=payload, content_type="application/json"
-        )
-        self.assertStatusCode(200, response)
-        json_data_url = response.json()
-
-        # compare limit in payload and limit in url
         self.assertEqual(
-            json_data_payload['features'],
-            json_data_url['features'],
-            msg="Limit parameter in payload and in URL yielded different responses."
+            len(json_data_payload['features']), limit, msg="More than one item returned."
         )
 
     def test_query_created(self):
+        limit = 1
         # get match
-        query = '{"created": {"lte": "9999-12-31T09:07:39.399892Z"}}'
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?query={query}&limit=1")
+        query = {"created": {"lte": "9999-12-31T09:07:39.399892Z"}}
+        response = self.client.get(
+            f"/{STAC_BASE_V}/search"
+            f"?query={json.dumps(query)}&limit={limit}"
+        )
         self.assertStatusCode(200, response)
         json_data_get = response.json()
-        self.assertEqual(len(json_data_get['features']), 1)
+        self.assertEqual(len(json_data_get['features']), limit)
 
         # post match
-        payload = """
-        {"query":
-            {"created":
-                {"lte":"9999-12-31T09:07:39.399892Z"}
-            },
-            "limit": 1
-        }
-        """
+        payload = {"query": query, "limit": limit}
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         json_data_post = response.json()
-        self.assertEqual(len(json_data_post['features']), 1)
+        self.assertEqual(len(json_data_post['features']), limit)
         # compare get and post
         self.assertEqual(
-            json_data_get['features'][0]['properties']['created'],
-            json_data_post['features'][0]['properties']['created'],
+            json_data_get['features'],
+            json_data_post['features'],
             msg="GET and POST responses do not match when filtering for date created"
         )
+        for feature in json_data_get['features']:
+            self.assertLessEqual(
+                fromisoformat(feature['properties']['created']),
+                fromisoformat(query['created']['lte'])
+            )
 
     def test_query_updated(self):
+        limit = 1
         # get match
-        query = '{"updated": {"lte": "9999-12-31T09:07:39.399892Z"}}'
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?query={query}&limit=1")
+        query = {"updated": {"lte": "9999-12-31T09:07:39.399892Z"}}
+        response = self.client.get(f"{self.path}?query={json.dumps(query)}&limit={limit}")
         self.assertStatusCode(200, response)
         json_data_get = response.json()
-        self.assertEqual(len(json_data_get['features']), 1)
+        self.assertEqual(len(json_data_get['features']), limit)
 
         # post match
-        payload = """
-        {"query":
-            {"updated":
-                {"lte":"9999-12-31T09:07:39.399892Z"}
-            },
-            "limit": 1
-        }
-        """
+        payload = {"query": query, "limit": limit}
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         json_data_post = response.json()
-        self.assertEqual(len(json_data_post['features']), 1)
+        self.assertEqual(len(json_data_post['features']), limit)
         # compare get and post
         self.assertEqual(
-            json_data_get['features'][0]['properties']['updated'],
-            json_data_post['features'][0]['properties']['updated'],
+            json_data_get['features'],
+            json_data_post['features'],
             msg="GET and POST responses do not match when filtering for date updated"
         )
 
+        for feature in json_data_get['features']:
+            self.assertLessEqual(
+                fromisoformat(feature['properties']['updated']),
+                fromisoformat(query['updated']['lte'])
+            )
+
     def test_query_data_in(self):
-        payload = """
-        {"query":
-            {"title":
-                {"in":["My item 1","My item 2"]}
-            }
-        }
-        """
+        titles = ["My item 1", "My item 2"]
+        payload = {"query": {"title": {"in": titles}}}
         response = self.client.post(self.path, data=payload, content_type="application/json")
-        json_data = response.json()
-        list_expected_items = ['item-1', 'item-2']
-        self.assertIn(json_data['features'][0]['id'], list_expected_items)
-        self.assertIn(json_data['features'][1]['id'], list_expected_items)
-
-    def test_post_pagination(self):
-        data = """
-        {"query":
-             {"title":
-                {"startsWith":"My item"}
-            },
-         "limit": 1
-        }
-        """
-        response = self.client.post(self.path, data=data, content_type="application/json")
         self.assertStatusCode(200, response)
         json_data = response.json()
-        links = json_data['links']
-        # get the curser value of next
-        for link in links:
-            if link['rel'] == 'next':
-                cursor = link['href'].split('?')[1]
-        item_id1 = json_data['features'][0]['id']
-
-        # pagination
-        response = self.client.get(f"{self.path}?{cursor}")
-        self.assertStatusCode(200, response)
-        json_data = response.json()
-        item_id2 = json_data['features'][0]['id']
-        self.assertNotEqual(item_id1, item_id2)
+        for feature in json_data['features']:
+            self.assertIn(feature['properties']['title'], titles)
 
     def test_post_intersects_valid(self):
-        data = """
-        { "intersects":
-            { "type": "POINT",
-              "coordinates": [6, 47]
-            }
-        }
-        """
-        response = self.client.post(f"{self.path}", data=data, content_type="application/json")
+        data = {"intersects": {"type": "POINT", "coordinates": [6, 47]}}
+        response = self.client.post(self.path, data=data, content_type="application/json")
         json_data = response.json()
         self.assertEqual(json_data['features'][0]['id'], 'item-3')
 
     def test_post_intersects_invalid(self):
-        data = """
-        { "intersects":
-            { "type": "POINT",
-              "coordinates": [6, 47, "kaputt"]
-            }
-        }
-        """
-        response = self.client.post(f"{self.path}", data=data, content_type="application/json")
+        data = {"intersects": {"type": "POINT", "coordinates": [6, 47, "kaputt"]}}
+        response = self.client.post(self.path, data=data, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_collections_get(self):
         # match
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?collections=collection-1,har")
+        collections = ['collection-1', 'har']
+        response = self.client.get(f"{self.path}?collections={','.join(collections)}")
         self.assertStatusCode(200, response)
         json_data = response.json()
         for feature in json_data['features']:
-            self.assertEqual(feature['collection'], 'collection-1')
+            self.assertIn(feature['collection'], collections)
         # no match
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?collections=collection-11,har")
+        response = self.client.get(f"{self.path}?collections=collection-11,har")
         self.assertStatusCode(200, response)
         json_data = response.json()
         self.assertEqual(len(json_data['features']), 0)
 
     def test_collections_post_valid(self):
-        payload = """
-           { "collections": [
-              "collection-1"
-               ]
-           }
-           """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        collections = ["collection-1"]
+        payload = {"collections": collections}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         json_data = response.json()
         for feature in json_data['features']:
-            self.assertEqual(feature['collection'], 'collection-1')
+            self.assertIn(feature['collection'], collections)
 
     def test_collections_post_invalid(self):
-        payload = """
-           { "collections": [
-              "collection-1",
-              9999
-               ]
-           }
-           """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        payload = {"collections": ["collection-1", 9999]}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(400, response)
 
 
@@ -322,163 +404,106 @@ class SearchEndpointTestCaseTwo(StacBaseTestCase):
         self.client = Client()
         client_login(self.client)
         self.path = f'/{STAC_BASE_V}/search'
+        self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_ids_get_valid(self):
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?ids=item-1,item-2")
+        items = ['item-1', 'item-2']
+        response = self.client.get(f"{self.path}?ids={','.join(items)}")
         self.assertStatusCode(200, response)
         json_data = response.json()
-        list_expected_items = ['item-1', 'item-2']
-        self.assertIn(json_data['features'][0]['id'], list_expected_items)
-        self.assertIn(json_data['features'][1]['id'], list_expected_items)
+        for feature in json_data['features']:
+            self.assertIn(feature['id'], items)
 
     def test_ids_post_valid(self):
-        payload = """
-                  { "ids": [
-                    "item-1",
-                    "item-2"
-                      ]
-                  }
-        """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        items = ['item-1', 'item-2']
+        payload = {"ids": items}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         json_data = response.json()
-        list_expected_items = ['item-1', 'item-2']
-        self.assertIn(json_data['features'][0]['id'], list_expected_items)
-        self.assertIn(json_data['features'][1]['id'], list_expected_items)
+        for feature in json_data['features']:
+            self.assertIn(feature['id'], items)
 
     def test_ids_post_invalid(self):
-        payload = """
-                  { "ids": [
-                    "item-1",
-                    "item-2",
-                    1
-                      ]
-                  }
-        """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        payload = {"ids": ["item-1", "item-2", 1]}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_ids_first_and_only_prio(self):
-        response = self.client.get(
-            f"/{STAC_BASE_V}/search"
-            f"?ids=item-1,item-2&collections=not_exist"
-        )
+        items = ['item-1', 'item-2']
+        response = self.client.get(f"{self.path}?ids={','.join(items)}&collections=not_exist")
         self.assertStatusCode(200, response)
         json_data = response.json()
-        list_expected_items = ['item-1', 'item-2']
-        self.assertIn(json_data['features'][0]['id'], list_expected_items)
-        self.assertIn(json_data['features'][1]['id'], list_expected_items)
+
+        for feature in json_data['features']:
+            self.assertIn(feature['id'], items)
 
     def test_bbox_valid(self):
-        payload = """
-        { "bbox": [
-            6,
-            47,
-            6.5,
-            47.5
-            ]
-        }
-        """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        payload = {"bbox": [6, 47, 6.5, 47.5]}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         json_data_post = response.json()
         list_expected_items = ['item-1', 'item-2']
         self.assertIn(json_data_post['features'][0]['id'], list_expected_items)
         self.assertIn(json_data_post['features'][1]['id'], list_expected_items)
 
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?bbox=6,47,6.5,47.5&limit=100")
+        response = self.client.get(f"{self.path}?bbox={','.join(map(str, payload['bbox']))}")
         json_data_get = response.json()
         self.assertStatusCode(200, response)
-        self.assertEqual(json_data_get['features'][0]['id'], json_data_post['features'][0]['id'])
+        self.assertEqual(json_data_get['features'], json_data_post['features'])
 
     def test_bbox_as_point(self):
         # bbox as a point
-        payload = """
-        { "bbox": [
-            6.1,
-            47.1,
-            6.1,
-            47.1
-            ],
-          "limit": 100
-        }
-        """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        payload = {"bbox": [6.1, 47.1, 6.1, 47.1]}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         json_data_post = response.json()
         list_expected_items = ['item-3', 'item-4', 'item-6']
         self.assertIn(json_data_post['features'][0]['id'], list_expected_items)
         self.assertIn(json_data_post['features'][1]['id'], list_expected_items)
         self.assertIn(json_data_post['features'][2]['id'], list_expected_items)
 
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?bbox=6.1,47.1,6.1,47.1&limit=100")
+        response = self.client.get(f"{self.path}?bbox={','.join(map(str, payload['bbox']))}")
         json_data_get = response.json()
         self.assertStatusCode(200, response)
-
-        self.assertIn(json_data_get['features'][0]['id'], list_expected_items)
-        self.assertIn(json_data_get['features'][1]['id'], list_expected_items)
-        self.assertIn(json_data_get['features'][2]['id'], list_expected_items)
-        self.assertEqual(json_data_get['features'][0]['id'], json_data_post['features'][0]['id'])
+        self.assertEqual(json_data_get['features'], json_data_post['features'])
 
     def test_bbox_post_invalid(self):
-        payload = """
-        { "bbox": [
-            6,
-            47,
-            6.5,
-            47.5,
-            5.5
-            ]
-        }
-        """
-        response = self.client.post(f"{self.path}", data=payload, content_type="application/json")
+        payload = {"bbox": [6, 47, 6.5, 47.5, 5.5]}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(400, response)
 
     def test_bbox_get_invalid(self):
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?bbox=6,47,6.5,47.5,5.5")
+        response = self.client.get(f"{self.path}?bbox=6,47,6.5,47.5,5.5")
         self.assertStatusCode(400, response)
 
     def test_datetime_open_end_range_query_get(self):
-        response = self.client.get(
-            f"/{STAC_BASE_V}/search"
-            f"?datetime={isoformat(self.yesterday)}/..&limit=100"
-        )
+        response = self.client.get(f"{self.path}?datetime={isoformat(self.yesterday)}/..&limit=100")
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(0, len(json_data['features']))
 
     def test_datetime_open_start_range_query(self):
-        response = self.client.get(
-            f"/{STAC_BASE_V}/search"
-            f"?datetime=../{isoformat(self.yesterday)}&limit=100"
-        )
+        response = self.client.get(f"{self.path}?datetime=../{isoformat(self.yesterday)}&limit=100")
         json_data = response.json()
         self.assertStatusCode(200, response)
-        self.assertEqual(8, len(json_data['features']), msg="More than two item found")
+        self.assertEqual(8, len(json_data['features']), msg="Not 8 items found")
         self.assertEqual('item-1', json_data['features'][0]['id'])
         self.assertEqual('item-8', json_data['features'][7]['id'])
 
-        payload = """
-        { "datetime": "../%s"
-        }
-        """ % isoformat(self.yesterday)
-        json_data = response.json()
+        payload = {"datetime": f"../{isoformat(self.yesterday)}"}
+        response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
-        self.assertEqual(8, len(json_data['features']), msg="More than two item found")
-        self.assertEqual('item-1', json_data['features'][0]['id'])
-        self.assertEqual('item-8', json_data['features'][7]['id'])
+        json_data_post = response.json()
+        self.assertEqual(json_data_post["features"], json_data["features"])
 
     def test_datetime_invalid_range_query_get(self):
-        response = self.client.get(f"/{STAC_BASE_V}/search" f"?datetime=../..&limit=100")
+        response = self.client.get(f"{self.path}?datetime=../..&limit=100")
         self.assertStatusCode(400, response)
 
     def test_datetime_exact_query_get(self):
-        response = self.client.get(
-            f"/{STAC_BASE_V}/search"
-            f"?datetime=2020-10-28T13:05:10Z&limit=100"
-        )
+        response = self.client.get(f"{self.path}?datetime=2020-10-28T13:05:10Z&limit=100")
+        self.assertStatusCode(200, response)
         json_data = response.json()
         self.assertEqual(7, len(json_data['features']), msg="Seven items Found")
         self.assertEqual('item-1', json_data['features'][0]['id'])
         self.assertEqual('item-8', json_data['features'][6]['id'])
-        self.assertStatusCode(200, response)
 
     def test_datetime_invalid_format_query_get(self):
         response = self.client.get(f"/{STAC_BASE_V}/search?datetime=NotADate&limit=100")

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -912,42 +912,44 @@ components:
       type: object
     link:
       properties:
-        # body:
-        #   description: For POST requests, the link can specify the HTTP body as a JSON object.
-        #   type: object
-        # headers:
-        #   description: Object key values pairs they map to headers
-        #   example:
-        #     Accept: application/json
-        #   type: object
+        body:
+          description: For POST requests, the link can specify the HTTP body as a JSON object.
+          type: object
+        headers:
+          description: Object key values pairs they map to headers
+          example:
+            Accept: application/json
+          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
           type: string
-        # length:
-        #   type: integer
-        # merge:
-        #   default: false
-        #   description: >-
-        #     This is only valid when the server is responding to POST request.
+        length:
+          type: integer
+        merge:
+          default: false
+          description: >-
+            This is only valid when the server is responding to POST request.
 
-        #     If merge is true, the client is expected to merge the body value
-        #     into the current request body before following the link.
-        #     This avoids passing large post bodies back and forth when following
-        #     links, particularly for navigating pages through the `POST /search`
-        #     endpoint.
 
-        #     NOTE: To support form encoding it is expected that a client be able
-        #     to merge in the key value pairs specified as JSON
-        #     `{"next": "token"}` will become `&next=token`.
-        #   type: boolean
-        # method:
-        #   default: GET
-        #   description: Specifies the HTTP method that the link expects
-        #   enum:
-        #     - GET
-        #     - POST
-        #   type: string
+            If merge is true, the client is expected to merge the body value
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
+
+
+            NOTE: To support form encoding it is expected that a client be able
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
+          type: boolean
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+            - GET
+            - POST
+          type: string
         rel:
           description: >-
             Relationship between the current document and the linked document.

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -755,7 +755,7 @@ components:
           proj:epsg: "2056"
           type: image/tiff; application=geotiff
           updated: "2020-07-14T12:30:00Z"
-    itemCollection:
+    itemsSearch:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain values relevant
         to a STAC entity
@@ -764,8 +764,6 @@ components:
           items:
             $ref: "#/components/schemas/item"
           type: array
-        links:
-          $ref: "#/components/schemas/itemCollectionLinks"
         type:
           enum:
             - FeatureCollection
@@ -774,7 +772,21 @@ components:
         - features
         - type
       type: object
-    itemCollectionLinks:
+    itemsSearchGet:
+      allOf:
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchLinks"
+    itemsSearchPost:
+      allOf:
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchPostLinks"
+    itemsSearchLinks:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next`
         relation type.
@@ -785,6 +797,21 @@ components:
           rel: next
       items:
         $ref: "#/components/schemas/link"
+      type: array
+    itemsSearchPostLinks:
+      description: >-
+        An array of links. Can be used for pagination, e.g. by providing a link with the `next`
+        relation type.
+      example:
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+          rel: self
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+          rel: next
+          method: POST
+          body: {}
+          merge: true
+      items:
+        $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
       description: Item identifier (unique per collection)
@@ -912,43 +939,9 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
-          type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
-
-
-            If merge is true, the client is expected to merge the body value
-            into the current request body before following the link.
-            This avoids passing large post bodies back and forth when following
-            links, particularly for navigating pages through the `POST /search`
-            endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able
-            to merge in the key value pairs specified as JSON
-            `{"next": "token"}` will become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-            - GET
-            - POST
           type: string
         rel:
           description: >-
@@ -966,11 +959,39 @@ components:
           description: The media type of the link target
           example: application/geo+json
           type: string
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+            - GET
+            - POST
+          type: string
       required:
         - href
         - rel
       title: Link
       type: object
+    linkPostSearch:
+      allOf:
+        - $ref: "#/components/schemas/link"
+        - type: object
+          properties:
+            body:
+              default: {}
+              description: For `POST /search` requests, the link can specify the HTTP body as a JSON object.
+              type: object
+            merge:
+              default: false
+              description: >-
+                This is only valid when the server is responding to `POST /search `request.
+
+
+                If merge is true, the client is expected to merge the body value
+                into the current request body before following the link.
+                This avoids passing large post bodies back and forth when following
+                links, particularly for navigating pages through the `POST /search`
+                endpoint.
+              type: boolean
     multilinestringGeoJSON:
       properties:
         coordinates:

--- a/spec/paths.yml
+++ b/spec/paths.yml
@@ -140,10 +140,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchGet"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"
@@ -166,10 +163,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchPost"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -1124,9 +1124,43 @@ components:
       type: object
     link:
       properties:
+        body:
+          description: For POST requests, the link can specify the HTTP body as a
+            JSON object.
+          type: object
+        headers:
+          description: Object key values pairs they map to headers
+          example:
+            Accept: application/json
+          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
+          type: string
+        length:
+          type: integer
+        merge:
+          default: false
+          description: >-
+            This is only valid when the server is responding to POST request.
+
+
+            If merge is true, the client is expected to merge the body value into
+            the current request body before following the link. This avoids passing
+            large post bodies back and forth when following links, particularly for
+            navigating pages through the `POST /search` endpoint.
+
+
+            NOTE: To support form encoding it is expected that a client be able to
+            merge in the key value pairs specified as JSON `{"next": "token"}` will
+            become `&next=token`.
+          type: boolean
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+          - GET
+          - POST
           type: string
         rel:
           description: >-

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -969,7 +969,7 @@ components:
           proj:epsg: "2056"
           type: image/tiff; application=geotiff
           updated: "2020-07-14T12:30:00Z"
-    itemCollection:
+    itemsSearch:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain values
         relevant to a STAC entity
@@ -978,8 +978,6 @@ components:
           items:
             $ref: "#/components/schemas/item"
           type: array
-        links:
-          $ref: "#/components/schemas/itemCollectionLinks"
         type:
           enum:
           - FeatureCollection
@@ -988,7 +986,21 @@ components:
       - features
       - type
       type: object
-    itemCollectionLinks:
+    itemsSearchGet:
+      allOf:
+      - $ref: "#/components/schemas/itemsSearch"
+      - type: object
+        properties:
+          links:
+            $ref: "#/components/schemas/itemsSearchLinks"
+    itemsSearchPost:
+      allOf:
+      - $ref: "#/components/schemas/itemsSearch"
+      - type: object
+        properties:
+          links:
+            $ref: "#/components/schemas/itemsSearchPostLinks"
+    itemsSearchLinks:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with
         the `next` relation type.
@@ -999,6 +1011,21 @@ components:
         rel: next
       items:
         $ref: "#/components/schemas/link"
+      type: array
+    itemsSearchPostLinks:
+      description: >-
+        An array of links. Can be used for pagination, e.g. by providing a link with
+        the `next` relation type.
+      example:
+      - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        rel: self
+      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        rel: next
+        method: POST
+        body: {}
+        merge: true
+      items:
+        $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
       description: Item identifier (unique per collection)
@@ -1124,43 +1151,9 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a
-            JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
-          type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
-
-
-            If merge is true, the client is expected to merge the body value into
-            the current request body before following the link. This avoids passing
-            large post bodies back and forth when following links, particularly for
-            navigating pages through the `POST /search` endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able to
-            merge in the key value pairs specified as JSON `{"next": "token"}` will
-            become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-          - GET
-          - POST
           type: string
         rel:
           description: >-
@@ -1178,11 +1171,39 @@ components:
           description: The media type of the link target
           example: application/geo+json
           type: string
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+          - GET
+          - POST
+          type: string
       required:
       - href
       - rel
       title: Link
       type: object
+    linkPostSearch:
+      allOf:
+      - $ref: "#/components/schemas/link"
+      - type: object
+        properties:
+          body:
+            default: {}
+            description: For `POST /search` requests, the link can specify the HTTP
+              body as a JSON object.
+            type: object
+          merge:
+            default: false
+            description: >-
+              This is only valid when the server is responding to `POST /search `request.
+
+
+              If merge is true, the client is expected to merge the body value into
+              the current request body before following the link. This avoids passing
+              large post bodies back and forth when following links, particularly
+              for navigating pages through the `POST /search` endpoint.
+            type: boolean
     multilinestringGeoJSON:
       properties:
         coordinates:
@@ -1685,10 +1706,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchGet"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"
@@ -1710,10 +1728,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchPost"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -1266,9 +1266,43 @@ components:
       type: object
     link:
       properties:
+        body:
+          description: For POST requests, the link can specify the HTTP body as a
+            JSON object.
+          type: object
+        headers:
+          description: Object key values pairs they map to headers
+          example:
+            Accept: application/json
+          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
+          type: string
+        length:
+          type: integer
+        merge:
+          default: false
+          description: >-
+            This is only valid when the server is responding to POST request.
+
+
+            If merge is true, the client is expected to merge the body value into
+            the current request body before following the link. This avoids passing
+            large post bodies back and forth when following links, particularly for
+            navigating pages through the `POST /search` endpoint.
+
+
+            NOTE: To support form encoding it is expected that a client be able to
+            merge in the key value pairs specified as JSON `{"next": "token"}` will
+            become `&next=token`.
+          type: boolean
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+          - GET
+          - POST
           type: string
         rel:
           description: >-

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -1111,7 +1111,7 @@ components:
           proj:epsg: "2056"
           type: image/tiff; application=geotiff
           updated: "2020-07-14T12:30:00Z"
-    itemCollection:
+    itemsSearch:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain values
         relevant to a STAC entity
@@ -1120,8 +1120,6 @@ components:
           items:
             $ref: "#/components/schemas/item"
           type: array
-        links:
-          $ref: "#/components/schemas/itemCollectionLinks"
         type:
           enum:
           - FeatureCollection
@@ -1130,7 +1128,21 @@ components:
       - features
       - type
       type: object
-    itemCollectionLinks:
+    itemsSearchGet:
+      allOf:
+      - $ref: "#/components/schemas/itemsSearch"
+      - type: object
+        properties:
+          links:
+            $ref: "#/components/schemas/itemsSearchLinks"
+    itemsSearchPost:
+      allOf:
+      - $ref: "#/components/schemas/itemsSearch"
+      - type: object
+        properties:
+          links:
+            $ref: "#/components/schemas/itemsSearchPostLinks"
+    itemsSearchLinks:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with
         the `next` relation type.
@@ -1141,6 +1153,21 @@ components:
         rel: next
       items:
         $ref: "#/components/schemas/link"
+      type: array
+    itemsSearchPostLinks:
+      description: >-
+        An array of links. Can be used for pagination, e.g. by providing a link with
+        the `next` relation type.
+      example:
+      - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        rel: self
+      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        rel: next
+        method: POST
+        body: {}
+        merge: true
+      items:
+        $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
       description: Item identifier (unique per collection)
@@ -1266,43 +1293,9 @@ components:
       type: object
     link:
       properties:
-        body:
-          description: For POST requests, the link can specify the HTTP body as a
-            JSON object.
-          type: object
-        headers:
-          description: Object key values pairs they map to headers
-          example:
-            Accept: application/json
-          type: object
         href:
           example: http://data.example.com/buildings/123
           format: url
-          type: string
-        length:
-          type: integer
-        merge:
-          default: false
-          description: >-
-            This is only valid when the server is responding to POST request.
-
-
-            If merge is true, the client is expected to merge the body value into
-            the current request body before following the link. This avoids passing
-            large post bodies back and forth when following links, particularly for
-            navigating pages through the `POST /search` endpoint.
-
-
-            NOTE: To support form encoding it is expected that a client be able to
-            merge in the key value pairs specified as JSON `{"next": "token"}` will
-            become `&next=token`.
-          type: boolean
-        method:
-          default: GET
-          description: Specifies the HTTP method that the link expects
-          enum:
-          - GET
-          - POST
           type: string
         rel:
           description: >-
@@ -1320,11 +1313,39 @@ components:
           description: The media type of the link target
           example: application/geo+json
           type: string
+        method:
+          default: GET
+          description: Specifies the HTTP method that the link expects
+          enum:
+          - GET
+          - POST
+          type: string
       required:
       - href
       - rel
       title: Link
       type: object
+    linkPostSearch:
+      allOf:
+      - $ref: "#/components/schemas/link"
+      - type: object
+        properties:
+          body:
+            default: {}
+            description: For `POST /search` requests, the link can specify the HTTP
+              body as a JSON object.
+            type: object
+          merge:
+            default: false
+            description: >-
+              This is only valid when the server is responding to `POST /search `request.
+
+
+              If merge is true, the client is expected to merge the body value into
+              the current request body before following the link. This avoids passing
+              large post bodies back and forth when following links, particularly
+              for navigating pages through the `POST /search` endpoint.
+            type: boolean
     multilinestringGeoJSON:
       properties:
         coordinates:
@@ -2464,10 +2485,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchGet"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"
@@ -2489,10 +2507,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemCollection"
-            text/html:
-              schema:
-                type: string
+                $ref: "#/components/schemas/itemsSearchPost"
           description: A feature collection.
         "500":
           $ref: "#/components/responses/ServerError"


### PR DESCRIPTION
The `POST /search` did not worked as defined in the spec. The original body with the DB query needs to be passed to the next request. 
To be consistent the spec changed as follow:

`GET /search`:
  - DB query in URL query
 - limit and cursor for pagination are part of the URL query and are set to the link['href']

`POST /search`:
 - DB query is in the POST body/payload as JSON
 - limit and cursor for pagination are also in the POST body/payload and only accepted there (ignored if passed in the URL queryparam)

Test link: https://service-stac.dev.bgdi.ch/api/stac/v0.9/search
API Spec test link: https://service-stac.dev.bgdi.ch/api/stac/static/spec/v0.9/api.html


The last commit also fixed a missleading CRITICA log in unittest:

    CRITICAL - stac_api.apps: KeyError('collection_name') ...

This message was due to the TestHttp500 view wich raised a KeyError
before raising the expected AttributeError