### PR TITLE
BGDIINF_SB-1715: Removed the Browsable API view

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -157,17 +157,14 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'
+    }, {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'
+    }, {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'
+    }, {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'
+    }
 ]
 
 # Internationalization
@@ -265,6 +262,7 @@ TEST_RUNNER = 'tests.runner.TestRunner'
 # set authentication schemes
 
 REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',


### PR DESCRIPTION
This view has currently a bug in the /search endpoint, where the POST
form is wrong, it is using the POST form of the /items view. This is due
to the fact that we reuse the ItemSerializer for the /search view.

Because the browsable view doesn't bring much advantages and because we
know that DRF has a performance issue and that we might have migrate the
views in other serializer framework, we decided to simply remove it for
now as it not yet very known to the customer.