### PR TITLE
BGDIINF_SB-1647 filter assets for their collection and/or item

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -134,11 +134,11 @@ class ItemAdmin(admin.GeoModelAdmin):
         # make sense.
 
         # this asserts that the request comes from the autocomplete filters.
-        if "autocomplete" in request.__dict__['environ']['PATH_INFO']:
-            if "item__collection" in request.__dict__['environ']['HTTP_REFERER']:
-                current_collection_pk = request.__dict__['environ']['HTTP_REFERER'].split(
-                    'item__collection='
-                )[1].split("&")[0]
+        environ = request.environ.copy()
+        if "autocomplete" in environ['PATH_INFO']:
+            if "item__collection" in environ['HTTP_REFERER']:
+                current_collection_pk = environ['HTTP_REFERER'].split('item__collection='
+                                                                     )[1].split("&")[0]
                 queryset = self.model.objects.filter(collection__pk__exact=current_collection_pk)
         elif search_term.startswith('"') and search_term.endswith('"'):
             search_terms = search_term.strip('"').split('/', maxsplit=2)


### PR DESCRIPTION
Added autocomplete search fields and dropdown list filters for filtering assets for their collection and/or items.
Following behaviour is implemented:
If a collection is defined in the `filter by collection name` filter, only those items will appear
in the dropdown list of the `filter by item name` filter, that are in the currently selected collection.
ItemAdmin's `get_search_results()` was overriden with a few "hacky" lines for this.
Otherwise, all items would appear in the list, which does not make sense.

Note: The responsiveness after clicking on those filters could be better. Its a bit slow when there are many items or collections. Probably will improve this soon. The performance problem is due to the large number of assets, items and collections and was already a problem before the "hacky" lines were inserted.

P.S.: Any ideas for a cleaner approach or improving the performance are welcome :slightly_smiling_face: 