### PR TITLE
BGDIINF_SB-1723: Collection upsert

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -38,8 +38,14 @@ urlpatterns = [
 if settings.DEBUG:
     import debug_toolbar
     from stac_api.views_test import TestHttp500
+    from stac_api.views_test import TestCollectionUpsertHttp500
 
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),
         path('tests/test_http_500', TestHttp500.as_view()),
+        path(
+            'tests/test_collection_upsert_http_500/<collection_name>',
+            TestCollectionUpsertHttp500.as_view(),
+            name='test-collection-detail-http-500'
+        ),
     ] + urlpatterns

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     import debug_toolbar
-    from stac_api.views import TestHttp500
+    from stac_api.views_test import TestHttp500
 
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -463,7 +463,19 @@ class CollectionSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
 
     def update_or_create(self, validated_data, **kwargs):
         """
-        Create and return a new `Collection` instance, given the validated data.
+        Update or create the collection object selected by kwargs and return the instance.
+
+        When no collection object matching the kwargs selection, a new object is created.
+
+        Args:
+            validated_data: dict
+                Copy of the validated_data to use for update
+            kwargs: dict
+                Object selection arguments (NOTE: the selection arguments must match a unique
+                object in DB otherwise an IntegrityError will be raised)
+
+        Returns: tuple
+            Collection instance and True if created otherwise false
         """
         providers_data = validated_data.pop('providers', [])
         links_data = validated_data.pop('links', [])

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -31,6 +31,7 @@ from stac_api.validators import validate_item_properties_datetimes
 from stac_api.validators import validate_name
 from stac_api.validators_serializer import validate_asset_file
 from stac_api.validators_serializer import validate_json_payload
+from stac_api.validators_serializer import validate_uniqueness_and_create
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,30 @@ def update_or_create_links(model, instance, instance_type, links_data):
         instance.name,
         extra={instance_type: instance}
     )
+
+
+class UpsertModelSerializerMixin:
+    """Add support for Upsert in serializer
+    """
+
+    def upsert(self, **kwargs):
+        """
+        Update or insert an instance and return it.
+        """
+        self.instance, created = self.update_or_create(self.validated_data.copy(), **kwargs)
+        return self.instance, created
+
+    def update_or_create(self, validated_data, **kwargs):
+        """This method must be implemented by the serializer and must make use of the DB
+        objects.update_or_create() method.
+
+        Args:
+            validated_data: dict
+                Copy of the validated_data to be used in the objects.update_or_create() method.
+            **kwargs:
+                Must be a unique query to be used in the objects.update_or_create() method.
+        """
+        raise NotImplementedError("update_or_create() not implemented")
 
 
 class NonNullModelSerializer(serializers.ModelSerializer):
@@ -315,7 +340,7 @@ class CollectionLinkSerializer(NonNullModelSerializer):
     )
 
 
-class CollectionSerializer(NonNullModelSerializer):
+class CollectionSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
 
     class Meta:
         model = Collection
@@ -340,10 +365,7 @@ class CollectionSerializer(NonNullModelSerializer):
     # NOTE: when explicitely declaring fields, we need to add the validation as for the field
     # in model !
     id = serializers.CharField(
-        required=True,
-        max_length=255,
-        source="name",
-        validators=[validate_name, UniqueValidator(queryset=Collection.objects.all())]
+        required=True, max_length=255, source="name", validators=[validate_name]
     )
     title = serializers.CharField(required=False, allow_blank=False, default=None, max_length=255)
     # Also links are required in the spec, the main links (self, root, items) are automatically
@@ -414,7 +436,7 @@ class CollectionSerializer(NonNullModelSerializer):
         """
         providers_data = validated_data.pop('providers', [])
         links_data = validated_data.pop('links', [])
-        collection = Collection.objects.create(**validated_data)
+        collection = validate_uniqueness_and_create(Collection, validated_data)
         self._update_or_create_providers(collection=collection, providers_data=providers_data)
         update_or_create_links(
             instance_type="collection",
@@ -438,6 +460,22 @@ class CollectionSerializer(NonNullModelSerializer):
             links_data=links_data
         )
         return super().update(instance, validated_data)
+
+    def update_or_create(self, validated_data, **kwargs):
+        """
+        Create and return a new `Collection` instance, given the validated data.
+        """
+        providers_data = validated_data.pop('providers', [])
+        links_data = validated_data.pop('links', [])
+        collection, created = Collection.objects.update_or_create(**kwargs, defaults=validated_data)
+        self._update_or_create_providers(collection=collection, providers_data=providers_data)
+        update_or_create_links(
+            instance_type="collection",
+            model=CollectionLink,
+            instance=collection,
+            links_data=links_data
+        )
+        return collection, created
 
     def to_representation(self, instance):
         name = instance.name

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -520,12 +520,3 @@ class AssetDetail(
     @etag(get_asset_etag)
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
-
-
-class TestHttp500(generics.GenericAPIView):
-    queryset = LandingPage.objects.all()
-
-    def get(self, request, *args, **kwargs):
-        logger.debug('Test request that raises an exception')
-
-        raise AttributeError('test exception')

--- a/app/stac_api/views_mixins.py
+++ b/app/stac_api/views_mixins.py
@@ -1,11 +1,21 @@
 import logging
 
+from django.db import transaction
+
 from rest_framework import status
 from rest_framework.response import Response
 
 from stac_api.utils import get_link
 
 logger = logging.getLogger(__name__)
+
+
+def get_success_headers(data):
+    try:
+        return {'Location': get_link(data['links'], 'self', raise_exception=True)['href']}
+    except KeyError as err:
+        logger.error('Failed to set the Location header for model creation %s: %s', err, data)
+        return {}
 
 
 class CreateModelMixin:
@@ -24,6 +34,7 @@ class CreateModelMixin:
     def get_write_request_data(self, request, *args, **kwargs):
         return request.data
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         data = self.get_write_request_data(request, *args, **kwargs)
         serializer = self.get_serializer(data=data)
@@ -36,27 +47,26 @@ class CreateModelMixin:
         serializer.save()
 
     def get_success_headers(self, data):
-        try:
-            return {'Location': get_link(data['links'], 'self', raise_exception=True)['href']}
-        except KeyError as err:
-            logger.error('Failed to set the Location header for item creation: %s', err)
-            return {}
+        return get_success_headers(data)
 
 
-class UpdateModelMixin:
+class UpdateInsertModelMixin:
     """
-    Update a model instance.
+    Update/insert a model instance.
 
-    This is a copy of the original UpdateModelMixin, but the request.data needs to be patched with
+    This is a copy of the original UpdateMixin, but the request.data needs to be patched with
     the collection_name and/or item_name depending on the view. This patching cannot be done with
     the original mixin because the request.data is immutable.
 
     This new mixin allow this patching through the `get_write_request_data` method.
+
+    It also add the upsert method to perform update_or_create operation
     """
 
     def get_write_request_data(self, request, *args, partial=False, **kwargs):
         return request.data
 
+    @transaction.atomic
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         serializer_kwargs = {'partial': partial}
@@ -73,12 +83,39 @@ class UpdateModelMixin:
 
         return Response(serializer.data)
 
+    @transaction.atomic
+    def upsert(self, request, *args, **kwargs):
+        data = self.get_write_request_data(request, *args, **kwargs)
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        lookup = {}
+        if self.lookup_url_kwarg:
+            lookup = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}
+        instance, created = self.perform_upsert(serializer, lookup)
+
+        if getattr(instance, '_prefetched_objects_cache', None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}  # pylint: disable=protected-access
+
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+            headers=self.get_success_headers(serializer.data)
+        )
+
     def perform_update(self, serializer):
         serializer.save()
+
+    def perform_upsert(self, serializer, lookup):
+        return serializer.upsert(**lookup)
 
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.update(request, *args, **kwargs)
+
+    def get_success_headers(self, data):
+        return get_success_headers(data)
 
 
 class DestroyModelMixin:
@@ -89,6 +126,7 @@ class DestroyModelMixin:
     instead of 204 No Content.
     """
 
+    @transaction.atomic
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         self.perform_destroy(instance)

--- a/app/stac_api/views_test.py
+++ b/app/stac_api/views_test.py
@@ -1,0 +1,16 @@
+import logging
+
+from rest_framework import generics
+
+from stac_api.models import LandingPage
+
+logger = logging.getLogger(__name__)
+
+
+class TestHttp500(generics.GenericAPIView):
+    queryset = LandingPage.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        logger.debug('Test request that raises an exception')
+
+        raise AttributeError('test exception')

--- a/app/stac_api/views_test.py
+++ b/app/stac_api/views_test.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework import generics
 
 from stac_api.models import LandingPage
+from stac_api.views import CollectionDetail
 
 logger = logging.getLogger(__name__)
 
@@ -13,4 +14,11 @@ class TestHttp500(generics.GenericAPIView):
     def get(self, request, *args, **kwargs):
         logger.debug('Test request that raises an exception')
 
+        raise AttributeError('test exception')
+
+
+class TestCollectionUpsertHttp500(CollectionDetail):
+
+    def perform_upsert(self, serializer, lookup):
+        serializer.upsert(**lookup)
         raise AttributeError('test exception')

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.test import TestCase
+from django.test import TransactionTestCase
 
 from stac_api.utils import fromisoformat
 from stac_api.utils import get_link
@@ -19,7 +20,9 @@ TEST_LINK_ROOT_HREF = 'http://testserver/api/stac/v0.9'
 TEST_LINK_ROOT = {'rel': 'root', 'href': f'{TEST_LINK_ROOT_HREF}/'}
 
 
-class StacBaseTestCase(TestCase):
+class StacTestMixin:
+    """Adds some useful checks for STAC API unittesting
+    """
 
     # we keep the TestCase nomenclature here therefore we disable the pylint invalid-name
     def assertStatusCode(self, code, response, msg=None):  # pylint: disable=invalid-name
@@ -407,3 +410,12 @@ class StacBaseTestCase(TestCase):
             self.assertEqual(
                 value, current[key], msg=f'{path}: current value is not equal to the expected'
             )
+
+
+class StacBaseTestCase(TestCase, StacTestMixin):
+    """Django TestCase with additional STAC check methods"""
+
+
+class StacBaseTransactionTestCase(TransactionTestCase, StacTestMixin):
+    """Django TransactionTestCase with additional STAC check methods
+    """

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -11,6 +11,7 @@ from stac_api.utils import get_link
 from tests.base_test import StacBaseTestCase
 from tests.data_factory import Factory
 from tests.utils import client_login
+from tests.utils import disableLogger
 from tests.utils import get_http_error_description
 from tests.utils import mock_s3_asset_file
 
@@ -29,7 +30,7 @@ class ApiGenericTestCase(StacBaseTestCase):
         self.assertStatusCode(404, response)
 
     def test_http_error_500_exception(self):
-        with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True):
+        with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True), disableLogger('stac_api.apps'):
             response = self.client.get("/tests/test_http_500")
             self.assertStatusCode(500, response)
             self.assertEqual(response.json()['description'], "AttributeError('test exception')")

--- a/app/tests/utils.py
+++ b/app/tests/utils.py
@@ -169,3 +169,30 @@ def client_login(client):
         username, 'test_e_mail1234@some_fantasy_domainname.com', password
     )
     client.login(username=username, password=password)
+
+
+class disableLogger:  # pylint: disable=invalid-name
+    """Disable temporarily a logger with a with statement
+
+    Args:
+        logger_name: str | None
+            logger name to disable, by default use the root logger (None)
+
+    Example:
+        with disableLogger('stac_api.apps'):
+            # the stac_api.apps logger is totally disable within the with statement
+            logger = logging.getLogger('stac_api.apps')
+            logger.critical('This log will not be printed anywhere')
+    """
+
+    def __init__(self, logger_name=None):
+        if logger_name:
+            self.logger = logging.getLogger(logger_name)
+        else:
+            self.logger = logging.getLogger()
+
+    def __enter__(self):
+        self.logger.disabled = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logger.disabled = False


### PR DESCRIPTION
We also make use of the DB atomic transaction to do proper DB rollback
in case of errors.

The get_object() of the views have been removed in order to use the
default implementation using the lookup_field.

Also made all endpoints atomic to assure proper db rollback in case of
error.