### PR TITLE
BGDIINF_SB-1739, BGDIINF_SB-1764: SPEC corrections and added asset upload in SPEC

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -5,6 +5,7 @@
 SPEC_HTTP_PORT ?= 8090
 
 PARTS = base.yml \
+		components/headers.yml \
 		components/parameters.yml \
 		components/responses.yml \
 		components/schemas.yml \

--- a/spec/components/headers.yml
+++ b/spec/components/headers.yml
@@ -1,0 +1,13 @@
+components:
+  headers:
+    ETag:
+      schema:
+        type: string
+      description: >-
+        The RFC7232 ETag header field in a response provides the current entity-
+        tag for the selected resource. An entity-tag is an opaque identifier for
+        different versions of a resource over time, regardless whether multiple
+        versions are valid at the same time. An entity-tag consists of an opaque
+        quoted string, possibly prefixed by a weakness indicator.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+      required: true

--- a/spec/components/responses.yml
+++ b/spec/components/responses.yml
@@ -3,7 +3,7 @@ components:
     Collection:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
@@ -89,7 +89,7 @@ components:
     Feature:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:

--- a/spec/components/responses.yml
+++ b/spec/components/responses.yml
@@ -191,6 +191,15 @@ components:
           example:
             code: 404
             description: "Resource not found"
+    BadRequest:
+      description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/exception"
+          example:
+            code: 400
+            description: "Invalid parameter"
     PreconditionFailed:
       description: Some condition specified by the request could not be met in the server
       # Currently the 412 Precondition not met is handled by django and we cannot give a body

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -69,6 +69,39 @@ components:
     #          type: string
     #      type: object
     #  description: Apply query operations to a specific property
+    assetBase:
+      title: Asset
+      description: The `property name` defines the ID of the Asset.
+      type: object
+      required:
+        - type
+        - created
+        - updated
+      properties:
+        title:
+          $ref: "#/components/schemas/title"
+        description:
+          $ref: "#/components/schemas/description"
+        type:
+          $ref: "#/components/schemas/type"
+        href:
+          $ref: "#/components/schemas/href"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihashReadOnly"
+        # roles:
+        #   $ref: '#/components/schemas/roles'
+        "geoadmin:variant":
+          $ref: "#/components/schemas/geoadmin:variant"
+        "geoadmin:lang":
+          $ref: "#/components/schemas/geoadmin:lang"
+        "proj:epsg":
+          $ref: "#/components/schemas/proj:epsg"
+        "eo:gsd":
+          $ref: "#/components/schemas/eo:gsd"
+        created:
+          $ref: "#/components/schemas/created"
+        updated:
+          $ref: "#/components/schemas/updated"
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -163,7 +196,16 @@ components:
       example: 90e402107a7f2588a85362b9beea2a12d4514d45
       pattern: ^[a-f0-9]+$
       title: Multihash
-      type: string,
+      type: string
+    checksumMultihashReadOnly:
+      description: |
+        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/) format.
+
+      example: 90e402107a7f2588a85362b9beea2a12d4514d45
+      pattern: ^[a-f0-9]+$
+      title: Multihash
+      type: string
+      readOnly: true
     created:
       description: RFC 3339 compliant datetime string, time when the object was created
       example: 2018-02-12T23:20:50Z
@@ -356,6 +398,7 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+      format: date-time
     datetimeQuery:
       description: >-
         Either a date-time or an interval, open or closed. Date and time expressions
@@ -680,54 +723,10 @@ components:
         - type
       type: object
     itemAssets:
+      title: Assets
+      description: List of Assets attached to this feature.
       additionalProperties:
-        properties:
-          created:
-            $ref: "#/components/schemas/created"
-          description:
-            description: >-
-              Multi-line description to explain the asset.
-
-
-              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
-              rich text representation.
-            example: Small 256x256px PNG thumbnail for a preview.
-            type: string
-          href:
-            description: Link to the asset object
-            example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
-            format: url
-            type: string
-          # roles:
-          #   description: Purposes of the asset
-          #   example:
-          #     - thumbnail
-          #   items:
-          #     type: string
-          #   type: array
-          title:
-            description: Displayed title
-            example: Thumbnail
-            type: string
-          type:
-            description: Media type of the asset
-            example: image/tiff; application=geotiff
-            type: string
-          proj:epsg:
-            $ref: "#/components/schemas/proj:epsg"
-          geoadmin:variant:
-            $ref: "#/components/schemas/geoadmin:variant"
-          eo:gsd:
-            $ref: "#/components/schemas/eo:gsd"
-          updated:
-            $ref: "#/components/schemas/created"
-        required:
-          - "checksum:multihash"
-          - href
-          - type
-          - created
-          - updated
-        type: object
+        $ref: "#/components/schemas/assetBase"
       type: object
       readOnly: true
       example:
@@ -817,10 +816,12 @@ components:
         $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
-      description: Item identifier (unique per collection)
+      title: ID
+      description: Feature identifier (unique per collection)
       example: smr200-200-4-2019
       type: string
     itemProperties:
+      title: Properties
       description: >-
         Provides the core metadata fields plus extensions
 
@@ -853,6 +854,7 @@ components:
         - updated
       type: object
     itemType:
+      title: type
       description: The GeoJSON type
       enum:
         - Feature

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -225,8 +225,6 @@ components:
           type: array
           readOnly: true
         description:
-          schema:
-            $ref: "#/components/schemas/description"
           description: A description of the features in the collection
           example: >-
             Swiss Map Raster are a conversion of the map image into a digital form

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -477,7 +477,7 @@ components:
         Information about the exception: an error code plus an optional description.
       properties:
         code:
-          type: int
+          type: integer
           example: 500
         description:
           anyOf:
@@ -1154,9 +1154,7 @@ components:
 
       example: 2056
       title: EPSG code.
-      type:
-        - integer
-        - null
+      type: integer
     providers:
       description: >-
         A list of providers, which may include all organizations capturing or processing the data

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -212,7 +212,7 @@ components:
       type: string
       format: date-time
       readOnly: true
-    collection:
+    collectionBase:
       properties:
         crs:
           default:
@@ -253,24 +253,6 @@ components:
           readOnly: true
         license:
           $ref: "#/components/schemas/license"
-        links:
-          example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
-              rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
-              rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-              rel: items
-            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-              rel: license
-              title: Licence for the free geodata of the Federal Office of Topography swisstopo
-            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-              rel: describedby
-          items:
-            $ref: "#/components/schemas/link"
-          type: array
         providers:
           $ref: "#/components/schemas/providers"
         stac_version:
@@ -338,7 +320,6 @@ components:
           $ref: "#/components/schemas/updated"
       required:
         - id
-        - links
         - stac_version
         - description
         - license
@@ -346,6 +327,47 @@ components:
         - created
         - updated
       type: object
+    collection:
+      allOf:
+        - $ref: "#/components/schemas/collectionBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              type: array
+              items:
+                $ref: "#/components/schemas/link"
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                  rel: items
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
+    collectionWrite:
+      title: collection
+      allOf:
+        - $ref: "#/components/schemas/collectionBase"
+        - type: object
+          properties:
+            links:
+              type: array
+              items:
+                $ref: "#/components/schemas/link"
+              example:
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
     collections:
       properties:
         collections:

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -91,13 +91,13 @@ components:
         # roles:
         #   $ref: '#/components/schemas/roles'
         "geoadmin:variant":
-          $ref: "#/components/schemas/geoadmin:variant"
+          $ref: "#/components/schemas/geoadminVariant"
         "geoadmin:lang":
-          $ref: "#/components/schemas/geoadmin:lang"
+          $ref: "#/components/schemas/geoadminLang"
         "proj:epsg":
-          $ref: "#/components/schemas/proj:epsg"
+          $ref: "#/components/schemas/projEpsg"
         "eo:gsd":
-          $ref: "#/components/schemas/eo:gsd"
+          $ref: "#/components/schemas/eoGsd"
         created:
           $ref: "#/components/schemas/created"
         updated:
@@ -188,7 +188,7 @@ components:
       properties:
         bbox:
           $ref: "#/components/schemas/bboxfilter"
-    checksum:multihash:
+    checksumMultihash:
       description: >-
         `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
         format.
@@ -456,7 +456,7 @@ components:
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
         text representation.
       type: string
-    eo:gsd:
+    eoGsd:
       description: >-
         GSD is the nominal Ground Sample Distance for the data, as measured in meters on the ground.
 
@@ -586,7 +586,7 @@ components:
         - temporal
       type: object
       readOnly: true
-    geoadmin:lang:
+    geoadminLang:
       enum:
         - de
         - it
@@ -595,7 +595,7 @@ components:
         - en
       title: Product language
       type: string
-    geoadmin:variant:
+    geoadminVariant:
       example: komb
       title: Product variants
       type: string
@@ -1145,7 +1145,7 @@ components:
             - - 7.242974548172171
               - 46.57310580640624
         type: Polygon
-    proj:epsg:
+    projEpsg:
       description: >-
         A Coordinate Reference System (CRS) is the data reference system
         (sometimes called a 'projection') used by the asset data, and can

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -557,6 +557,13 @@ components:
         - type
         - geometries
       type: object
+    href:
+      type: string
+      format: url
+      description: Link to the asset object
+      readOnly: true
+      example: |
+        http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     ids:
       description: >-
         Array of Item ids to return. All other filter parameters that further
@@ -1289,6 +1296,13 @@ components:
       description: >-
         Apply query operations to a specific property. The following properties
         are currently supported: `created`, `updated`, `title`.
+    roles:
+      type: array
+      items:
+        type: string
+      description: Purposes of the asset
+      example:
+        - thumbnail
     searchBody:
       allOf:
         #        - $ref: "#/components/schemas/assetQueryFilter"
@@ -1311,6 +1325,14 @@ components:
       example: "2017-08-17T08:05:32Z"
       format: date-time
       type: string
+    title:
+      type: string
+      description: Displayed title
+      example: Thumbnail
+    type:
+      type: string
+      description: Media type of the asset
+      example: image/tiff; application=geotiff
     updated:
       description: RFC 3339 compliant datetime string, time when the object was updated
       example: 2018-02-12T23:20:50Z

--- a/spec/components/schemas.yml
+++ b/spec/components/schemas.yml
@@ -1341,14 +1341,3 @@ components:
       type: string
       format: date-time
       readOnly: true
-    ETag:
-      schema:
-        type: string
-      description: >-
-        The RFC7232 ETag header field in a response provides the current entity-
-        tag for the selected resource. An entity-tag is an opaque identifier for
-        different versions of a resource over time, regardless whether multiple
-        versions are valid at the same time. An entity-tag consists of an opaque
-        quoted string, possibly prefixed by a weakness indicator.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-      required: true

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -22,6 +22,18 @@ tags:
     search API
   name: STAC
 components:
+  headers:
+    ETag:
+      schema:
+        type: string
+      description: >-
+        The RFC7232 ETag header field in a response provides the current entity- tag
+        for the selected resource. An entity-tag is an opaque identifier for different
+        versions of a resource over time, regardless whether multiple versions are
+        valid at the same time. An entity-tag consists of an opaque quoted string,
+        possibly prefixed by a weakness indicator.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+      required: true
   parameters:
     bbox:
       explode: false
@@ -116,7 +128,7 @@ components:
     Collection:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
@@ -199,7 +211,7 @@ components:
     Feature:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
@@ -286,6 +298,15 @@ components:
           example:
             code: 404
             description: "Resource not found"
+    BadRequest:
+      description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/exception"
+          example:
+            code: 400
+            description: "Invalid parameter"
     PreconditionFailed:
       description: Some condition specified by the request could not be met in the
         server
@@ -301,6 +322,37 @@ components:
             code: 500
             description: "Internal server error"
   schemas:
+    assetBase:
+      title: Asset
+      description: The `property name` defines the ID of the Asset.
+      type: object
+      required:
+      - type
+      - created
+      - updated
+      properties:
+        title:
+          $ref: "#/components/schemas/title"
+        description:
+          $ref: "#/components/schemas/description"
+        type:
+          $ref: "#/components/schemas/type"
+        href:
+          $ref: "#/components/schemas/href"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihashReadOnly"
+        geoadmin:variant:
+          $ref: "#/components/schemas/geoadminVariant"
+        geoadmin:lang:
+          $ref: "#/components/schemas/geoadminLang"
+        proj:epsg:
+          $ref: "#/components/schemas/projEpsg"
+        eo:gsd:
+          $ref: "#/components/schemas/eoGsd"
+        created:
+          $ref: "#/components/schemas/created"
+        updated:
+          $ref: "#/components/schemas/updated"
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -383,21 +435,29 @@ components:
       properties:
         bbox:
           $ref: "#/components/schemas/bboxfilter"
-    checksum:multihash:
+    checksumMultihash:
       description: >-
         `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
         format.
       example: 90e402107a7f2588a85362b9beea2a12d4514d45
       pattern: ^[a-f0-9]+$
       title: Multihash
-      type: string,
+      type: string
+    checksumMultihashReadOnly:
+      description: |
+        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/) format.
+      example: 90e402107a7f2588a85362b9beea2a12d4514d45
+      pattern: ^[a-f0-9]+$
+      title: Multihash
+      type: string
+      readOnly: true
     created:
       description: RFC 3339 compliant datetime string, time when the object was created
       example: 2018-02-12T23:20:50Z
       type: string
       format: date-time
       readOnly: true
-    collection:
+    collectionBase:
       properties:
         crs:
           default:
@@ -410,8 +470,6 @@ components:
           type: array
           readOnly: true
         description:
-          schema:
-            $ref: "#/components/schemas/description"
           description: A description of the features in the collection
           example: >-
             Swiss Map Raster are a conversion of the map image into a digital form
@@ -440,25 +498,6 @@ components:
           readOnly: true
         license:
           $ref: "#/components/schemas/license"
-        links:
-          example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-            rel: items
-          - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-            rel: license
-            title: Licence for the free geodata of the Federal Office of Topography
-              swisstopo
-          - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-            rel: describedby
-          items:
-            $ref: "#/components/schemas/link"
-          type: array
         providers:
           $ref: "#/components/schemas/providers"
         stac_version:
@@ -524,7 +563,6 @@ components:
           $ref: "#/components/schemas/updated"
       required:
       - id
-      - links
       - stac_version
       - description
       - license
@@ -532,6 +570,49 @@ components:
       - created
       - updated
       type: object
+    collection:
+      allOf:
+      - $ref: "#/components/schemas/collectionBase"
+      - type: object
+        required:
+        - links
+        properties:
+          links:
+            type: array
+            items:
+              $ref: "#/components/schemas/link"
+            example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+              rel: items
+            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+              rel: license
+              title: Licence for the free geodata of the Federal Office of Topography
+                swisstopo
+            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+              rel: describedby
+    collectionWrite:
+      title: collection
+      allOf:
+      - $ref: "#/components/schemas/collectionBase"
+      - type: object
+        properties:
+          links:
+            type: array
+            items:
+              $ref: "#/components/schemas/link"
+            example:
+            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+              rel: license
+              title: Licence for the free geodata of the Federal Office of Topography
+                swisstopo
+            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+              rel: describedby
     collections:
       properties:
         collections:
@@ -584,6 +665,7 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+      format: date-time
     datetimeQuery:
       description: >-
         Either a date-time or an interval, open or closed. Date and time expressions
@@ -618,7 +700,7 @@ components:
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text
         representation.
       type: string
-    eo:gsd:
+    eoGsd:
       description: >-
         GSD is the nominal Ground Sample Distance for the data, as measured in meters
         on the ground.
@@ -644,7 +726,7 @@ components:
         Information about the exception: an error code plus an optional description.
       properties:
         code:
-          type: int
+          type: integer
           example: 500
         description:
           anyOf:
@@ -752,7 +834,7 @@ components:
       - temporal
       type: object
       readOnly: true
-    geoadmin:lang:
+    geoadminLang:
       enum:
       - de
       - it
@@ -761,7 +843,7 @@ components:
       - en
       title: Product language
       type: string
-    geoadmin:variant:
+    geoadminVariant:
       example: komb
       title: Product variants
       type: string
@@ -782,6 +864,13 @@ components:
       - type
       - geometries
       type: object
+    href:
+      type: string
+      format: url
+      description: Link to the asset object
+      readOnly: true
+      example: |
+        http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     ids:
       description: >-
         Array of Item ids to return. All other filter parameters that further restrict
@@ -894,47 +983,10 @@ components:
       - type
       type: object
     itemAssets:
+      title: Assets
+      description: List of Assets attached to this feature.
       additionalProperties:
-        properties:
-          created:
-            $ref: "#/components/schemas/created"
-          description:
-            description: >-
-              Multi-line description to explain the asset.
-
-
-              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
-              text representation.
-            example: Small 256x256px PNG thumbnail for a preview.
-            type: string
-          href:
-            description: Link to the asset object
-            example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
-            format: url
-            type: string
-          title:
-            description: Displayed title
-            example: Thumbnail
-            type: string
-          type:
-            description: Media type of the asset
-            example: image/tiff; application=geotiff
-            type: string
-          proj:epsg:
-            $ref: "#/components/schemas/proj:epsg"
-          geoadmin:variant:
-            $ref: "#/components/schemas/geoadmin:variant"
-          eo:gsd:
-            $ref: "#/components/schemas/eo:gsd"
-          updated:
-            $ref: "#/components/schemas/created"
-        required:
-        - "checksum:multihash"
-        - href
-        - type
-        - created
-        - updated
-        type: object
+        $ref: "#/components/schemas/assetBase"
       type: object
       readOnly: true
       example:
@@ -1024,10 +1076,12 @@ components:
         $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
-      description: Item identifier (unique per collection)
+      title: ID
+      description: Feature identifier (unique per collection)
       example: smr200-200-4-2019
       type: string
     itemProperties:
+      title: Properties
       description: >-
         Provides the core metadata fields plus extensions
 
@@ -1060,6 +1114,7 @@ components:
       - updated
       type: object
     itemType:
+      title: type
       description: The GeoJSON type
       enum:
       - Feature
@@ -1326,7 +1381,7 @@ components:
           - - 7.242974548172171
             - 46.57310580640624
         type: Polygon
-    proj:epsg:
+    projEpsg:
       description: >-
         A Coordinate Reference System (CRS) is the data reference system (sometimes
         called a 'projection') used by the asset data, and can usually be referenced
@@ -1336,9 +1391,7 @@ components:
         there is no valid EPSG code.
       example: 2056
       title: EPSG code.
-      type:
-      - integer
-      - null
+      type: integer
     providers:
       description: >-
         A list of providers, which may include all organizations capturing or processing
@@ -1509,6 +1562,13 @@ components:
       description: >-
         Apply query operations to a specific property. The following properties are
         currently supported: `created`, `updated`, `title`.
+    roles:
+      type: array
+      items:
+        type: string
+      description: Purposes of the asset
+      example:
+      - thumbnail
     searchBody:
       allOf:
       - $ref: "#/components/schemas/queryFilter"
@@ -1531,23 +1591,20 @@ components:
       example: "2017-08-17T08:05:32Z"
       format: date-time
       type: string
+    title:
+      type: string
+      description: Displayed title
+      example: Thumbnail
+    type:
+      type: string
+      description: Media type of the asset
+      example: image/tiff; application=geotiff
     updated:
       description: RFC 3339 compliant datetime string, time when the object was updated
       example: 2018-02-12T23:20:50Z
       type: string
       format: date-time
       readOnly: true
-    ETag:
-      schema:
-        type: string
-      description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag
-        for the selected resource. An entity-tag is an opaque identifier for different
-        versions of a resource over time, regardless whether multiple versions are
-        valid at the same time. An entity-tag consists of an opaque quoted string,
-        possibly prefixed by a weakness indicator.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-      required: true
 paths:
   /:
     get:

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -21,21 +21,86 @@ tags:
 - description: Extension to OGC API - Features to support STAC metadata model and
     search API
   name: STAC
-- description: |
-    All write requests require authentication. The currently available options for a user to
-    authenticate himself are described below.
+- name: Data Management
+  description: |
+    Metadata management requests. Theses requests are used to create, update or delete the STAC
+    metadata.
 
-    # Session authentication
+    *NOTE: these requests requires authentication as described in [here](#tag/Authentication).*
+- name: Asset Upload Management
+  description: |
+    Asset file can be uploaded via the STAC API using the following requests.
+
+    *NOTE: the POST requests requires authentication as described in [here](#tag/Authentication).*
+
+    ### Example
+
+    ```python
+    import os
+    import hashlib
+
+    import requests
+    import multihash
+
+    # variables
+    scheme = 'https'
+    hostname = 'data.geo.admin.ch'
+    collection = 'ch.swisstopo.pixelkarte-farbe-pk200.noscale'
+    item = 'smr200-200-4-2016'
+    asset = 'smr200-200-4-2016-2056-kgrs-10.tiff'
+    asset_path = f'collections/{collection}/items/{item}/assets/{asset}'
+    user = os.environ.get('STAC_USER', 'unknown-user')
+    password = os.environ.get('STAC_PASSWORD', 'unknown-password')
+
+    with open('smr200-200-4-2016-2056-kgrs-10.tiff', 'rb') as fd:
+      data = fd.read()
+
+    checksum_multihash = multihash.to_hex_string(multihash.encode(hashlib.sha256(data).digest(), 'sha2-256'))
+
+    # 1. Create a multipart upload
+    response = requests.post(
+      f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads",
+      auth=(user, password),
+      json={
+        "number_parts": 1,
+        "checksum:multihash": checksum_multihash
+      }
+    )
+    upload_id = response.json()['upload_id']
+
+    # 2. Upload the part using the presigned url
+    response = requests.put(response.json()['urls'][0]['url'], data=data)
+    etag = response.headers['ETag']
+
+    # 3. Complete the upload
+    response = requests.post(
+      f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads/{upload_id}/complete",
+      auth=(user, password),
+      json={'parts': [{'etag': etag, 'part_number': 1}]}
+    )
+    ```
+- name: Authentication
+  description: |
+    All write requests require authentication. There is currently three type of supported authentications:
+
+    * [Session authentication](#section/Session-authentication)
+    * [Basic authentication](#section/Basic-authentication)
+    * [Token authentication](#section/Token-authentication)
+
+    ## Session authentication
+
     When using the browsable API the user can simply use the admin interface for logging in.
     Once logged in, the browsable API can be used to perform write requests.
 
-    # Basic authentication
+    ## Basic authentication
+
     The username and password for authentication can be added to every write request the user wants to perform.
     Here is an example of posting an asset using curl (_username_="MickeyMouse", _password_="I_love_Minnie_Mouse"):
+
     ```
     curl --request POST \
       --user MickeyMouse:I_love_Minnie_Mouse \
-      --url https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+      --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
       --header 'Content-Type: application/json' \
       --data '{
         "id": "fancy_unique_id",
@@ -48,12 +113,14 @@ tags:
     }'
     ```
 
-    # Token authentication
+    ## Token authentication
+
     A user specific token for authentication can be added to every write request the user wants to perform.
     Here is an example of posting an asset using curl:
+
     ```
     curl --request POST \
-      --url https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+      --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
       --header 'Authorization: Token ccecf40693bfc52ba090cd46eb7f19e723fe831f' \
       --header 'Content-Type: application/json' \
       --data '{
@@ -66,18 +133,30 @@ tags:
         "checksum:multihash": "01205c3fd6978a7d0b051efaa4263a04"
     }'
     ```
+
     Tokens can either be generated in the admin interface or existing users can perform a POST request
-    on the get-token endpoint to request a token (also see description of the get-token POST endpoint
-    at the bottom).
+    on the get-token endpoint to request a token (also see [Request token for token authentication](#operation/getToken)).
     Here is an example using curl:
+
     ```
     curl --request POST \
-      --url https://service-stac.dev.bgdi.ch/api/stac/get-token \
+      --url https://data.geoadmin.ch/api/stac/get-token \
       --header 'Content-Type: application/json' \
       --data '{"username": "MickeyMouse", "password": "I_love_Minnie_Mouse"}'
     ```
-  name: Data Management
 components:
+  headers:
+    ETag:
+      schema:
+        type: string
+      description: >-
+        The RFC7232 ETag header field in a response provides the current entity- tag
+        for the selected resource. An entity-tag is an opaque identifier for different
+        versions of a resource over time, regardless whether multiple versions are
+        valid at the same time. An entity-tag consists of an opaque quoted string,
+        possibly prefixed by a weakness indicator.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+      required: true
   parameters:
     bbox:
       explode: false
@@ -171,7 +250,21 @@ components:
     assetId:
       name: assetId
       in: path
-      description: Local identifier of a asset
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
+    uploadId:
+      name: uploadId
+      in: path
+      description: Local identifier of an asset's upload.
+      required: true
+      schema:
+        type: string
+    presignedUrl:
+      name: presignedUrl
+      in: path
+      description: Presigned url returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
       required: true
       schema:
         type: string
@@ -195,7 +288,7 @@ components:
     Collection:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
@@ -278,7 +371,7 @@ components:
     Feature:
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
@@ -365,6 +458,15 @@ components:
           example:
             code: 404
             description: "Resource not found"
+    BadRequest:
+      description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/exception"
+          example:
+            code: 400
+            description: "Invalid parameter"
     PreconditionFailed:
       description: Some condition specified by the request could not be met in the
         server
@@ -391,11 +493,11 @@ components:
         The response is a document consisting of one asset of the feature.
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/itemAsset"
+            $ref: "#/components/schemas/readUpdateAsset"
     DeletedResource:
       description: Status of the delete resource
       content:
@@ -406,7 +508,7 @@ components:
             type: object
             properties:
               code:
-                type: int
+                type: integer
                 example: 200
               description:
                 type: string
@@ -424,15 +526,6 @@ components:
             required:
             - code
             - links
-    BadRequest:
-      description: The request was malformed or semantically invalid
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/exception"
-          example:
-            code: 400
-            description: "Invalid parameter"
     PermissionDenied:
       description: No Permission for this request
       content:
@@ -443,6 +536,37 @@ components:
             code: 403
             description: "Permission denied"
   schemas:
+    assetBase:
+      title: Asset
+      description: The `property name` defines the ID of the Asset.
+      type: object
+      required:
+      - type
+      - created
+      - updated
+      properties:
+        title:
+          $ref: "#/components/schemas/title"
+        description:
+          $ref: "#/components/schemas/description"
+        type:
+          $ref: "#/components/schemas/type"
+        href:
+          $ref: "#/components/schemas/href"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihashReadOnly"
+        geoadmin:variant:
+          $ref: "#/components/schemas/geoadminVariant"
+        geoadmin:lang:
+          $ref: "#/components/schemas/geoadminLang"
+        proj:epsg:
+          $ref: "#/components/schemas/projEpsg"
+        eo:gsd:
+          $ref: "#/components/schemas/eoGsd"
+        created:
+          $ref: "#/components/schemas/created"
+        updated:
+          $ref: "#/components/schemas/updated"
     bbox:
       description: >-
         Only features that have a geometry that intersects the bounding box are selected.
@@ -525,21 +649,29 @@ components:
       properties:
         bbox:
           $ref: "#/components/schemas/bboxfilter"
-    checksum:multihash:
+    checksumMultihash:
       description: >-
         `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
         format.
       example: 90e402107a7f2588a85362b9beea2a12d4514d45
       pattern: ^[a-f0-9]+$
       title: Multihash
-      type: string,
+      type: string
+    checksumMultihashReadOnly:
+      description: |
+        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/) format.
+      example: 90e402107a7f2588a85362b9beea2a12d4514d45
+      pattern: ^[a-f0-9]+$
+      title: Multihash
+      type: string
+      readOnly: true
     created:
       description: RFC 3339 compliant datetime string, time when the object was created
       example: 2018-02-12T23:20:50Z
       type: string
       format: date-time
       readOnly: true
-    collection:
+    collectionBase:
       properties:
         crs:
           default:
@@ -552,8 +684,6 @@ components:
           type: array
           readOnly: true
         description:
-          schema:
-            $ref: "#/components/schemas/description"
           description: A description of the features in the collection
           example: >-
             Swiss Map Raster are a conversion of the map image into a digital form
@@ -582,25 +712,6 @@ components:
           readOnly: true
         license:
           $ref: "#/components/schemas/license"
-        links:
-          example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-            rel: items
-          - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-            rel: license
-            title: Licence for the free geodata of the Federal Office of Topography
-              swisstopo
-          - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-            rel: describedby
-          items:
-            $ref: "#/components/schemas/link"
-          type: array
         providers:
           $ref: "#/components/schemas/providers"
         stac_version:
@@ -666,7 +777,6 @@ components:
           $ref: "#/components/schemas/updated"
       required:
       - id
-      - links
       - stac_version
       - description
       - license
@@ -674,6 +784,49 @@ components:
       - created
       - updated
       type: object
+    collection:
+      allOf:
+      - $ref: "#/components/schemas/collectionBase"
+      - type: object
+        required:
+        - links
+        properties:
+          links:
+            type: array
+            items:
+              $ref: "#/components/schemas/link"
+            example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+              rel: items
+            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+              rel: license
+              title: Licence for the free geodata of the Federal Office of Topography
+                swisstopo
+            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+              rel: describedby
+    collectionWrite:
+      title: collection
+      allOf:
+      - $ref: "#/components/schemas/collectionBase"
+      - type: object
+        properties:
+          links:
+            type: array
+            items:
+              $ref: "#/components/schemas/link"
+            example:
+            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+              rel: license
+              title: Licence for the free geodata of the Federal Office of Topography
+                swisstopo
+            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+              rel: describedby
     collections:
       properties:
         collections:
@@ -726,6 +879,7 @@ components:
       description: RFC 3339 compliant datetime string
       example: 2018-02-12T23:20:50Z
       type: string
+      format: date-time
     datetimeQuery:
       description: >-
         Either a date-time or an interval, open or closed. Date and time expressions
@@ -754,13 +908,13 @@ components:
           $ref: "#/components/schemas/datetimeQuery"
     description:
       description: >-
-        Detailed multi-line description to fully explain the object (collection, item,
-        asset, ...).
+        Detailed multi-line description to fully explain the catalog or collection.
+
 
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text
         representation.
       type: string
-    eo:gsd:
+    eoGsd:
       description: >-
         GSD is the nominal Ground Sample Distance for the data, as measured in meters
         on the ground.
@@ -786,7 +940,7 @@ components:
         Information about the exception: an error code plus an optional description.
       properties:
         code:
-          type: int
+          type: integer
           example: 500
         description:
           anyOf:
@@ -894,7 +1048,7 @@ components:
       - temporal
       type: object
       readOnly: true
-    geoadmin:lang:
+    geoadminLang:
       enum:
       - de
       - it
@@ -903,7 +1057,7 @@ components:
       - en
       title: Product language
       type: string
-    geoadmin:variant:
+    geoadminVariant:
       example: komb
       title: Product variants
       type: string
@@ -924,6 +1078,13 @@ components:
       - type
       - geometries
       type: object
+    href:
+      type: string
+      format: url
+      description: Link to the asset object
+      readOnly: true
+      example: |
+        http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     ids:
       description: >-
         Array of Item ids to return. All other filter parameters that further restrict
@@ -1036,47 +1197,10 @@ components:
       - type
       type: object
     itemAssets:
+      title: Assets
+      description: List of Assets attached to this feature.
       additionalProperties:
-        properties:
-          created:
-            $ref: "#/components/schemas/created"
-          description:
-            description: >-
-              Multi-line description to explain the asset.
-
-
-              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
-              text representation.
-            example: Small 256x256px PNG thumbnail for a preview.
-            type: string
-          href:
-            description: Link to the asset object
-            example: http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
-            format: url
-            type: string
-          title:
-            description: Displayed title
-            example: Thumbnail
-            type: string
-          type:
-            description: Media type of the asset
-            example: image/tiff; application=geotiff
-            type: string
-          proj:epsg:
-            $ref: "#/components/schemas/proj:epsg"
-          geoadmin:variant:
-            $ref: "#/components/schemas/geoadmin:variant"
-          eo:gsd:
-            $ref: "#/components/schemas/eo:gsd"
-          updated:
-            $ref: "#/components/schemas/created"
-        required:
-        - "checksum:multihash"
-        - href
-        - type
-        - created
-        - updated
-        type: object
+        $ref: "#/components/schemas/assetBase"
       type: object
       readOnly: true
       example:
@@ -1166,10 +1290,12 @@ components:
         $ref: "#/components/schemas/linkPostSearch"
       type: array
     itemId:
-      description: Item identifier (unique per collection)
+      title: ID
+      description: Feature identifier (unique per collection)
       example: smr200-200-4-2019
       type: string
     itemProperties:
+      title: Properties
       description: >-
         Provides the core metadata fields plus extensions
 
@@ -1202,6 +1328,7 @@ components:
       - updated
       type: object
     itemType:
+      title: type
       description: The GeoJSON type
       enum:
       - Feature
@@ -1468,7 +1595,7 @@ components:
           - - 7.242974548172171
             - 46.57310580640624
         type: Polygon
-    proj:epsg:
+    projEpsg:
       description: >-
         A Coordinate Reference System (CRS) is the data reference system (sometimes
         called a 'projection') used by the asset data, and can usually be referenced
@@ -1478,9 +1605,7 @@ components:
         there is no valid EPSG code.
       example: 2056
       title: EPSG code.
-      type:
-      - integer
-      - null
+      type: integer
     providers:
       description: >-
         A list of providers, which may include all organizations capturing or processing
@@ -1655,6 +1780,13 @@ components:
       description: >-
         Apply query operations to a specific property. The following properties are
         currently supported: `created`, `updated`, `title`.
+    roles:
+      type: array
+      items:
+        type: string
+      description: Purposes of the asset
+      example:
+      - thumbnail
     searchBody:
       allOf:
       - $ref: "#/components/schemas/queryFilter"
@@ -1677,51 +1809,37 @@ components:
       example: "2017-08-17T08:05:32Z"
       format: date-time
       type: string
+    title:
+      type: string
+      description: Displayed title
+      example: Thumbnail
+    type:
+      type: string
+      description: Media type of the asset
+      example: image/tiff; application=geotiff
     updated:
       description: RFC 3339 compliant datetime string, time when the object was updated
       example: 2018-02-12T23:20:50Z
       type: string
       format: date-time
       readOnly: true
-    ETag:
-      schema:
-        type: string
-      description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag
-        for the selected resource. An entity-tag is an opaque identifier for different
-        versions of a resource over time, regardless whether multiple versions are
-        valid at the same time. An entity-tag consists of an opaque quoted string,
-        possibly prefixed by a weakness indicator.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-      required: true
     assetId:
       type: string
       pattern: ^[a-z0-9.-_]+$
-      title: asset id
+      title: ID
       description: >-
         The asset id uniquely identifies the asset for an item
 
 
         **Note**: `id` must be unique for the item and must be identical to the filename.
-      example: smr50-263-2016-2056-kgrs-2.5.tiff
-    updateAssetId:
-      type: string
-      pattern: ^[a-z0-9.-_]+$
-      title: asset id
-      description: >-
-        The asset id uniquely identifies the asset for an item
-
-
-        **Note**: `id` must be unique for the item and must be identical to the filename.
-        When the `id` doesn't match the parameter `assetId`, the asset is renamed,
-        renaming also the object itself on S3.
       example: smr50-263-2016-2056-kgrs-2.5.tiff
     assets:
+      title: Assets
       type: object
       properties:
         assets:
           items:
-            $ref: "#/components/schemas/itemAsset"
+            $ref: "#/components/schemas/readUpdateAsset"
           type: array
         links:
           items:
@@ -1738,51 +1856,21 @@ components:
             rel: item
           - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
             rel: collection
-    assetBase:
-      type: object
-      required:
-      - created
-      - updated
-      properties:
-        id:
-          $ref: "#/components/schemas/assetId"
-        title:
-          $ref: "#/components/schemas/title"
-        description:
-          $ref: "#/components/schemas/description"
-        type:
-          $ref: "#/components/schemas/type"
-        geoadmin:variant:
-          $ref: "#/components/schemas/geoadmin:variant"
-        geoadmin:lang:
-          $ref: "#/components/schemas/geoadmin:lang"
-        proj:epsg:
-          $ref: "#/components/schemas/proj:epsg"
-        eo:gsd:
-          $ref: "#/components/schemas/eo:gsd"
-        created:
-          $ref: "#/components/schemas/created"
-        updated:
-          $ref: "#/components/schemas/updated"
-    itemAsset:
+    createAsset:
       allOf:
       - $ref: "#/components/schemas/assetBase"
       - type: object
         required:
         - id
-        - type
-        - href
-        - checksum:multihash
         - links
         properties:
-          checksum:multihash:
-            $ref: "#/components/schemas/checksum:multihash"
-          href:
-            $ref: "#/components/schemas/href"
+          id:
+            $ref: "#/components/schemas/assetId"
           links:
             items:
               $ref: "#/components/schemas/link"
             type: array
+            readOnly: true
             example:
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
@@ -1794,66 +1882,32 @@ components:
               rel: item
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
-    itemAssetWrite:
+    readUpdateAsset:
       allOf:
       - $ref: "#/components/schemas/assetBase"
       - type: object
         required:
         - id
-        - type
-    itemAssetUpdate:
-      allOf:
-      - $ref: "#/components/schemas/assetBase"
-      - type: object
-        required:
-        - id
-        - type
+        - links
         properties:
           id:
-            $ref: "#/components/schemas/updateAssetId"
-    itemAssetPartialUpdate:
-      allOf:
-      - $ref: "#/components/schemas/assetBase"
-      - type: object
-        properties:
-          id:
-            $ref: "#/components/schemas/updateAssetId"
-    writeChecksumMultihash:
-      description: >-
-        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
-        format.
-
-
-        When provided the asset Object located at href will be checked against this
-        checksum and the request is rejected if the checksum don't match.
-      example: 90e402107a7f2588a85362b9beea2a12d4514d45
-      pattern: ^[a-f0-9]+$
-      title: Multihash
-      type: string,
-    writeHref:
-      type: string
-      format: url
-      description: >-
-        URL of the current location of the asset object.
-
-
-        The url must be publicly accessible. If the URL corresponds already to the
-        correct location of the asset object on s3, the checksum of the payload and
-        the object on s3 are compared and if matching the request will be accepted.
-
-
-        If the URL is different from the location that the asset object should have
-        according to the the pattern `/<collection_id>/<item_id>/<asset_id>`, the
-        service will move the asset from this temporary location to the correct one.
-      default: https://data.geo.admin.ch/<collection-id>/<item-id>/<asset-id>
-      example: >-
-        http://data.geo.admin.ch/tmp/gdwh/ch.swisstopo.swissimage/CS3-20160503_132130_04.png
-    href:
-      type: string
-      format: url
-      description: Link to the asset object
-      example: >-
-        http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
+            $ref: "#/components/schemas/assetId"
+          links:
+            items:
+              $ref: "#/components/schemas/link"
+            type: array
+            readOnly: true
+            example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: item
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     writeItem:
       allOf:
       - $ref: "#/components/schemas/itemBase"
@@ -1950,27 +2004,318 @@ components:
           - http://www.opengis.net/def/crs/EPSG/0/4326
         example:
           title: The new title of the collection
-    roles:
-      type: array
-      items:
-        type: string
-      description: Purposes of the asset
-      example:
-      - thumbnail
-    title:
-      type: string
-      description: Displayed title
-      example: Thumbnail
-    type:
-      type: string
-      description: Media type of the asset
-      example: image/tiff; application=geotiff
     itemIdUpdate:
       description: >-
         Item identifier (unique per collection. If it doesn't match the `featureId`
         in path parameters, then the Item is renamed.
       example: smr200-200-4-2019
       type: string
+    uploadId:
+      title: ID
+      type: string
+      description: Unique Asset upload identifier
+      example: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+      readOnly: true
+    dtUploadCreated:
+      title: created
+      description: Date time when the Asset's upload has been created/started.
+      type: string
+      format: date-time
+      readOnly: true
+    dtUploadCompleted:
+      title: completed
+      description: |
+        Date time when the Asset's upload has been completed.
+
+        *Note: this property is mutually exclusive with `aborted`*
+      type: string
+      format: date-time
+      readOnly: true
+    dtUploadAborted:
+      title: aborted
+      description: |
+        Date time when the Asset's upload has been aborted.
+
+        *Note: this property is mutually exclusive with `completed`*
+      type: string
+      format: date-time
+      readOnly: true
+    assetUploads:
+      title: AssetUploads
+      type: object
+      required:
+      - uploads
+      - links
+      properties:
+        uploads:
+          description: List of uploads that are within the asset.
+          type: array
+          items:
+            $ref: "#/components/schemas/assetUpload"
+        links:
+          description: Next and/or previous links for the pagination.
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+          example:
+          - rel: next
+            href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+    assetUpload:
+      title: AssetUpload
+      type: object
+      required:
+      - upload_id
+      - status
+      - created
+      - "checksum:multihash"
+      - number_parts
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          $ref: "#/components/schemas/status"
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        urls:
+          type: array
+          description: |
+            Note: As soon as the multipart upload is completed or aborted, the `urls` property is removed.
+          items:
+            $ref: "#/components/schemas/multipartUploadUrl"
+          readOnly: true
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        completed:
+          $ref: "#/components/schemas/dtUploadCompleted"
+        aborted:
+          $ref: "#/components/schemas/dtUploadAborted"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadCreate:
+      title: AssetUpload
+      type: object
+      required:
+      - upload_id
+      - status
+      - created
+      - "checksum:multihash"
+      - number_parts
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          $ref: "#/components/schemas/status"
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        urls:
+          type: array
+          description: |
+            Note: As soon as the multipart upload is completed or aborted, the `urls` property is removed.
+          items:
+            $ref: "#/components/schemas/multipartUploadUrl"
+          readOnly: true
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihash"
+    assetCompleteUpload:
+      title: CompleteUpload
+      type: object
+      required:
+      - parts
+      properties:
+        parts:
+          type: array
+          description: Parts that have been uploaded
+          items:
+            title: File part that have been uploaded
+            type: object
+            required:
+            - etag
+            - part_number
+            properties:
+              etag:
+                title: ETag
+                type: string
+                description: >-
+                  ETag of the uploaded file part (returned in the header of the answer
+                  of [Upload asset file part](#operation/uploadAssetFilePart)).
+                example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+              part_number:
+                $ref: "#/components/schemas/part_number"
+    assetUploadCompleted:
+      title: UploadCompleted
+      type: object
+      required:
+      - upload_id
+      - status
+      - number_parts
+      - created
+      - completed
+      - "checksum:multihash"
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          title: Status
+          description: Status of the Asset's multipart upload.
+          type: string
+          enum:
+          - completed
+          example: completed
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        completed:
+          $ref: "#/components/schemas/dtUploadCompleted"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadAborted:
+      title: UploadCompleted
+      type: object
+      required:
+      - upload_id
+      - status
+      - number_parts
+      - created
+      - aborted
+      - "checksum:multihash"
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          title: Status
+          description: Status of the Asset's multipart upload.
+          type: string
+          enum:
+          - aborted
+          example: aborted
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        aborted:
+          $ref: "#/components/schemas/dtUploadAborted"
+        checksum:multihash:
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadParts:
+      title: Parts
+      type: object
+      required:
+      - parts
+      - links
+      properties:
+        parts:
+          type: object
+          description: List of uploaded parts
+          required:
+          - etag
+          - part_number
+          - modified
+          - size
+          properties:
+            etag:
+              $ref: "#/components/schemas/uploadEtag"
+            part_number:
+              $ref: "#/components/schemas/part_number"
+            modified:
+              type: string
+              format: date-time
+              description: Date time when the part was added/modified
+            size:
+              type: integer
+              description: Part size in bytes
+              minimum: 0
+              example: 1024
+        links:
+          description: Next and/or previous links for the pagination.
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+          example:
+          - rel: next
+            href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+    status:
+      title: Status
+      description: Status of the Asset's multipart upload.
+      type: string
+      enum:
+      - in-progress
+      - aborted
+      - completed
+      readOnly: true
+    number_parts:
+      description: Number of parts for the Asset's multipart upload.
+      type: integer
+      minimum: 1
+      maximum: 100
+    part_number:
+      description: Number of the part.
+      type: integer
+      minimum: 1
+      maximum: 100
+    multipartUploadUrl:
+      title: MultipartUploadUrl
+      description: Multipart upload url.
+      type: object
+      required:
+      - url
+      - part
+      - expires
+      properties:
+        url:
+          description: Presigned URL to use to upload the Asset File part using the
+            PUT method.
+          type: string
+          format: url
+          example: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+        part:
+          description: Part number assigned to this presigned URL.
+          type: integer
+          minimum: 1
+          maximum: 100
+        expires:
+          description: Date time when this presigned URL expires and is not valid
+            anymore.
+          type: string
+          format: date-time
+    uploadEtag:
+      title: ETag
+      type: string
+      description: The RFC7232 ETag for the specified uploaded part.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+  examples:
+    inprogress:
+      summary: In progress upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: in-progress
+        number_parts: 1
+        urls:
+        - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+          part: 1
+          expires: '2019-08-24T14:15:22Z'
+        created: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+    completed:
+      summary: Completed upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: completed
+        number_parts: 1
+        created: '2019-08-24T14:15:22Z'
+        completed: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+    aborted:
+      summary: Aborted upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: completed
+        number_parts: 1
+        created: '2019-08-24T14:15:22Z'
+        aborted: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
 paths:
   /:
     get:
@@ -2042,7 +2387,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/collection"
+                $ref: "#/components/schemas/collectionWrite"
         "403":
           $ref: "#/components/responses/PermissionDenied"
         "404":
@@ -2086,7 +2431,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/collection"
+              $ref: "#/components/schemas/collectionWrite"
             example:
               description: The National Map 1:200,000 is a topographic map giving
                 an overview of Switzerland.
@@ -2148,7 +2493,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/collection"
+              $ref: "#/components/schemas/collectionWrite"
             example:
               id: ch.swisstopo.pixelkarte-farbe-pk200.noscale
               license: proprietary
@@ -2509,15 +2854,10 @@ paths:
       - Data
     post:
       summary: Add a new asset to a feature
-      description: >-
+      description: |
         Create a new asset for a specific feature.
 
-
-        When creating a new asset for a feature, the metadata of the asset is posted
-        to the API. The Asset object itself must be already publicly available at
-        the following URL: https://data.geo.admin.ch/{collectionId}/{featureId}/{assetId}
-
-        Optionally the Asset object multihash can be given for sanity check.
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: postAsset
       tags:
       - Data Management
@@ -2528,7 +2868,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetWrite"
+              $ref: "#/components/schemas/createAsset"
       responses:
         "201":
           description: Return the created Asset
@@ -2541,7 +2881,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/createAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         5XX:
@@ -2573,10 +2913,13 @@ paths:
       tags:
       - Data
     put:
-      summary: Update or  create an asset
+      summary: Update or create an asset
       description: >-
         Update or create an asset with Id `assetId` with a complete asset definition.
         If the asset doesn't exists it is then created.
+
+
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: putAsset
       tags:
       - Data Management
@@ -2589,14 +2932,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetUpdate"
+              $ref: "#/components/schemas/readUpdateAsset"
       responses:
         "200":
-          description: Status of the update request.
+          description: Asset has been successfully updated.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/readUpdateAsset"
+        "201":
+          description: Asset has been newly created.
+          headers:
+            Location:
+              description: A link to the asset
+              schema:
+                type: string
+                format: url
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/createAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -2610,6 +2965,9 @@ paths:
       description: >-
         Use this method to update an existing asset. Requires a JSON fragment (containing
         the fields to be updated) be submitted.
+
+
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: patchAsset
       tags:
       - Data Management
@@ -2622,26 +2980,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetPartialUpdate"
+              $ref: "#/components/schemas/readUpdateAsset"
       responses:
         "200":
           description: Returns the updated Asset.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
-        "201":
-          description: Returns the created Asset
-          headers:
-            Location:
-              description: A link to the asset
-              schema:
-                type: string
-                format: url
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/readUpdateAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -2676,12 +3022,289 @@ paths:
           $ref: "#/components/responses/PreconditionFailed"
         5XX:
           $ref: "#/components/responses/ServerError"
+  /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads:
+    parameters:
+    - $ref: "#/components/parameters/collectionId"
+    - $ref: "#/components/parameters/featureId"
+    - $ref: "#/components/parameters/assetId"
+    get:
+      tags:
+      - Asset Upload Management
+      summary: List all Asset's multipart uploads
+      description: >-
+        Return a list of all Asset's multipart uploads that are in progress and have
+        been completed or aborted.
+      operationId: getAssetUploads
+      parameters:
+      - name: status
+        in: query
+        description: Filter the list by status.
+        schema:
+          $ref: "#/components/schemas/status"
+      responses:
+        "200":
+          description: List of Asset's uploads
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploads"
+              example:
+                uploads:
+                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnusebaJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                  status: in-progress
+                  number_parts: 1
+                  urls:
+                  - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+                    part: 1
+                    expires: '2019-08-24T14:15:22Z'
+                  created: '2019-08-24T14:15:22Z'
+                  checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YaaegJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                  status: completed
+                  number_parts: 1
+                  created: '2019-08-24T14:15:22Z'
+                  completed: '2019-08-24T14:15:22Z'
+                  checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                  status: aborted
+                  number_parts: 1
+                  created: '2019-08-24T14:15:22Z'
+                  aborted: '2019-08-24T14:15:22Z'
+                  checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                links:
+                - rel: next
+                  href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        5XX:
+          $ref: "#/components/responses/ServerError"
+    post:
+      tags:
+      - Asset Upload Management
+      summary: Create a new Asset's multipart upload
+      description: |
+        Create a new Asset's multipart upload.
+      operationId: createAssetUpload
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetUploadCreate"
+      responses:
+        "201":
+          description: Created Asset's multipart upload
+          headers:
+            Location:
+              description: A link to the Asset's multipart upload object
+              schema:
+                type: string
+                format: url
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadCreate"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        5XX:
+          $ref: "#/components/responses/ServerError"
+  /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}:
+    parameters:
+    - $ref: "#/components/parameters/collectionId"
+    - $ref: "#/components/parameters/featureId"
+    - $ref: "#/components/parameters/assetId"
+    - $ref: "#/components/parameters/uploadId"
+    get:
+      tags:
+      - Asset Upload Management
+      summary: Get an Asset's multipart upload
+      description: |
+        Return an Asset's multipart upload.
+      operationId: getAssetUpload
+      parameters:
+      - $ref: "#/components/parameters/IfMatch"
+      - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          description: Asset's multipart upload description.
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUpload"
+              examples:
+                inprogress:
+                  $ref: "#/components/examples/inprogress"
+                completed:
+                  $ref: "#/components/examples/completed"
+                aborted:
+                  $ref: "#/components/examples/aborted"
+        "304":
+          $ref: "#/components/responses/NotModified"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /{presignedUrl}:
+    servers:
+    - url: http://data.geo.admin.ch/
+    put:
+      tags:
+      - Asset Upload Management
+      summary: Upload asset file part
+      description: >-
+        Upload an Asset file part using the presigned url(s) returned by [Create a
+        new Asset's multipart upload](#operation/createAssetUpload).
+
+
+        Parts that have been uploaded but not completed can be checked using [Get
+        an Asset's multipart upload](#operation/getAssetUpload)
+
+
+        A file part must be at least 5 MB except for the last one and at most 5 GB,
+        otherwise the complete operation will fail.
+
+
+        *Note: this endpoint doesn't require any authentication as it is already part
+        of the presigned url*
+      operationId: uploadAssetFilePart
+      parameters:
+      - $ref: "#/components/parameters/presignedUrl"
+      - name: Content-MD5
+        in: header
+        description: Asset file part content MD5.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Asset file uploaded part successfully
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: >-
+                The RFC7232 ETag header field in a response provides the current entity-
+                tag for the selected resource.
+
+
+                This ETag is required in the complete multipart upload payload.
+
+
+                An entity-tag is an opaque identifier for different versions of a
+                resource over time, regardless whether multiple versions are valid
+                at the same time. An entity-tag consists of an opaque quoted string.
+              example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+              required: true
+  /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/complete:
+    parameters:
+    - $ref: "#/components/parameters/collectionId"
+    - $ref: "#/components/parameters/featureId"
+    - $ref: "#/components/parameters/assetId"
+    - $ref: "#/components/parameters/uploadId"
+    post:
+      tags:
+      - Asset Upload Management
+      summary: Complete multipart upload
+      operationId: completeMultipartUpload
+      description: >-
+        Complete the multipart upload process. After completion, the Asset metadata
+        are updated with the new `checksum:multihash` from the upload and the parts
+        are automatically deleted. The Asset `href` field is also set if it was the
+        first upload.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetCompleteUpload"
+      responses:
+        "200":
+          description: Asset multipart upload completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadCompleted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        5XX:
+          $ref: "#/components/responses/ServerError"
+  /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/abort:
+    parameters:
+    - $ref: "#/components/parameters/collectionId"
+    - $ref: "#/components/parameters/featureId"
+    - $ref: "#/components/parameters/assetId"
+    - $ref: "#/components/parameters/uploadId"
+    post:
+      tags:
+      - Asset Upload Management
+      summary: Abort multipart upload
+      operationId: abortMultipartUpload
+      description: >-
+        Abort the multipart upload process. All already uploaded parts are automatically
+        deleted.
+      responses:
+        "200":
+          description: Asset multipart upload aborted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadAborted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        5XX:
+          $ref: "#/components/responses/ServerError"
+  /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/parts:
+    parameters:
+    - $ref: "#/components/parameters/collectionId"
+    - $ref: "#/components/parameters/featureId"
+    - $ref: "#/components/parameters/assetId"
+    - $ref: "#/components/parameters/uploadId"
+    get:
+      tags:
+      - Asset Upload Management
+      summary: Get upload parts
+      operationId: getUploadParts
+      description: >-
+        Return the list of already uploaded parts.
+
+
+        ### Pagination
+
+        By default all parts are returned (maximum number of parts being 100). The
+        user can use pagination to reduce the number of returned parts. Pagination
+        is done via the `limit` query parameter (see below).
+      parameters:
+      - $ref: "#/components/parameters/limit"
+      responses:
+        "200":
+          description: List of parts already uploaded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadParts"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        5XX:
+          $ref: "#/components/responses/ServerError"
   /get-token:
     servers:
     - url: http://data.geo.admin.ch/api/stac/
     post:
       tags:
-      - Data Management
+      - Authentication
       summary: >-
         Request token for token authentication.
       operationId: getToken
@@ -2694,7 +3317,7 @@ paths:
               properties:
                 username:
                   type: string
-                  decscription: name of user for whom token is requested
+                  description: name of user for whom token is requested
                 password:
                   type: string
                   description: password of user for whom token is requested

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -368,15 +368,7 @@ paths:
         - Data
     post:
       summary: Add a new asset to a feature
-      description: >-
-        Create a new asset for a specific feature.
-
-
-        When creating a new asset for a feature, the metadata of
-        the asset is posted to the API. The Asset object itself must be already publicly
-        available at the following URL: https://data.geo.admin.ch/{collectionId}/{featureId}/{assetId}
-
-        Optionally the Asset object multihash can be given for sanity check.
+      description: Create a new asset for a specific feature.
       operationId: postAsset
       tags:
         - Data Management
@@ -387,7 +379,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetWrite"
+              $ref: "#/components/schemas/createAsset"
       responses:
         "201":
           description: Return the created Asset
@@ -400,7 +392,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/createAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         "5XX":
@@ -449,14 +441,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetUpdate"
+              $ref: "#/components/schemas/readUpdateAsset"
       responses:
         "200":
-          description: Status of the update request.
+          description: Asset has been successfully updated.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/readUpdateAsset"
+        "201":
+          description: Asset has been newly created.
+          headers:
+            Location:
+              description: A link to the asset
+              schema:
+                type: string
+                format: url
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/createAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -482,7 +486,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/itemAssetPartialUpdate"
+              $ref: "#/components/schemas/readUpdateAsset"
       responses:
         "200":
           description: Returns the updated Asset.
@@ -607,7 +611,7 @@ components:
     assetId:
       type: string
       pattern: ^[a-z0-9.-_]+$
-      title: asset id
+      title: ID
       description: >-
         The asset id uniquely identifies the asset for an item
 
@@ -615,24 +619,13 @@ components:
         **Note**: `id` must be unique for the item and must be identical to the
         filename.
       example: smr50-263-2016-2056-kgrs-2.5.tiff
-    updateAssetId:
-      type: string
-      pattern: ^[a-z0-9.-_]+$
-      title: asset id
-      description: >-
-        The asset id uniquely identifies the asset for an item
-
-
-        **Note**: `id` must be unique for the item and must be identical to the
-        filename. When the `id` doesn't match the parameter `assetId`, the asset is renamed,
-        renaming also the object itself on S3.
-      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assets:
+      title: Assets
       type: object
       properties:
         assets:
           items:
-            $ref: "#/components/schemas/itemAsset"
+            $ref: "#/components/schemas/readUpdateAsset"
           type: array
         links:
           items:
@@ -649,54 +642,21 @@ components:
               rel: item
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
-    assetBase:
-      type: object
-      required:
-        - created
-        - updated
-      properties:
-        id:
-          $ref: "#/components/schemas/assetId"
-        title:
-          $ref: "#/components/schemas/title"
-        description:
-          $ref: "#/components/schemas/description"
-        type:
-          $ref: "#/components/schemas/type"
-        # roles:
-        #   $ref: '#/components/schemas/roles'
-        "geoadmin:variant":
-          $ref: "#/components/schemas/geoadmin:variant"
-        "geoadmin:lang":
-          $ref: "#/components/schemas/geoadmin:lang"
-        "proj:epsg":
-          $ref: "#/components/schemas/proj:epsg"
-        "eo:gsd":
-          $ref: "#/components/schemas/eo:gsd"
-        created:
-          $ref: "#/components/schemas/created"
-        updated:
-          $ref: "#/components/schemas/updated"
-    # overwrites the STAC definition of itemAsset
-    itemAsset:
+    createAsset:
       allOf:
         - $ref: "#/components/schemas/assetBase"
         - type: object
           required:
             - id
-            - type
-            - href
-            - checksum:multihash
             - links
           properties:
-            "checksum:multihash":
-              $ref: "#/components/schemas/checksum:multihash"
-            href:
-              $ref: "#/components/schemas/href"
+            id:
+              $ref: "#/components/schemas/assetId"
             links:
               items:
                 $ref: "#/components/schemas/link"
               type: array
+              readOnly: true
               example:
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
@@ -708,60 +668,33 @@ components:
                   rel: item
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
-    itemAssetWrite:
+    readUpdateAsset:
       allOf:
         - $ref: "#/components/schemas/assetBase"
         - type: object
           required:
             - id
-            - type
-    itemAssetUpdate:
-      allOf:
-        - $ref: "#/components/schemas/assetBase"
-        - type: object
-          required:
-            - id
-            - type
+            - links
           properties:
             id:
-              $ref: "#/components/schemas/updateAssetId"
-    itemAssetPartialUpdate:
-      allOf:
-        - $ref: "#/components/schemas/assetBase"
-        - type: object
-          properties:
-            id:
-              $ref: "#/components/schemas/updateAssetId"
-    writeChecksumMultihash:
-      description: >-
-        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
-        format.
+              $ref: "#/components/schemas/assetId"
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              readOnly: true
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+                  rel: item
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
 
-
-        When provided the asset Object located at href will be checked against this checksum and the
-        request is rejected if the checksum don't match.
-      example: 90e402107a7f2588a85362b9beea2a12d4514d45
-      pattern: ^[a-f0-9]+$
-      title: Multihash
-      type: string,
-    writeHref:
-      type: string
-      format: url
-      description: >-
-        URL of the current location of the asset object.
-
-
-        The url must be publicly accessible. If the URL corresponds already to the correct location
-        of the asset object on s3, the checksum of the payload and the object on s3 are compared
-        and if matching the request will be accepted.
-
-
-        If the URL is different from the location that the asset object should have according to the
-        the pattern `/<collection_id>/<item_id>/<asset_id>`, the service will move the asset from this
-        temporary location to the correct one.
-      default: https://data.geo.admin.ch/<collection-id>/<item-id>/<asset-id>
-      example: >-
-        http://data.geo.admin.ch/tmp/gdwh/ch.swisstopo.swissimage/CS3-20160503_132130_04.png
     writeItem:
       allOf:
         - $ref: "#/components/schemas/itemBase"
@@ -879,7 +812,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/itemAsset"
+            $ref: "#/components/schemas/readUpdateAsset"
     DeletedResource:
       description: Status of the delete resource
       content:

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -368,7 +368,10 @@ paths:
         - Data
     post:
       summary: Add a new asset to a feature
-      description: Create a new asset for a specific feature.
+      description: |
+        Create a new asset for a specific feature.
+
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: postAsset
       tags:
         - Data Management
@@ -429,6 +432,9 @@ paths:
       description: >-
         Update or create an asset with Id `assetId` with a complete asset definition.
         If the asset doesn't exists it is then created.
+
+
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: putAsset
       tags:
         - Data Management
@@ -474,6 +480,9 @@ paths:
       description: >-
         Use this method to update an existing asset. Requires a JSON
         fragment (containing the fields to be updated) be submitted.
+
+
+        *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: patchAsset
       tags:
         - Data Management
@@ -528,6 +537,286 @@ paths:
           $ref: "#/components/responses/PreconditionFailed"
         "5XX":
           $ref: "#/components/responses/ServerError"
+
+
+  "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads":
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+    get:
+      tags:
+        - Asset Upload Management
+      summary: List all Asset's multipart uploads
+      description: >-
+        Return a list of all Asset's multipart uploads that are in progress and have been completed
+        or aborted.
+      operationId: getAssetUploads
+      parameters:
+        - name: status
+          in: query
+          description: Filter the list by status.
+          schema:
+            $ref: "#/components/schemas/status"
+      responses:
+        200:
+          description: List of Asset's uploads
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploads"
+              example:
+                uploads:
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnusebaJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: in-progress
+                    number_parts: 1
+                    urls:
+                    - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+                      part: 1
+                      expires: '2019-08-24T14:15:22Z'
+                    created: '2019-08-24T14:15:22Z'
+                    checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YaaegJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: completed
+                    number_parts: 1
+                    created: '2019-08-24T14:15:22Z'
+                    completed: '2019-08-24T14:15:22Z'
+                    checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: aborted
+                    number_parts: 1
+                    created: '2019-08-24T14:15:22Z'
+                    aborted: '2019-08-24T14:15:22Z'
+                    checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+                links:
+                  - rel: next
+                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "5XX":
+          $ref: "#/components/responses/ServerError"
+    post:
+      tags:
+        - Asset Upload Management
+      summary: Create a new Asset's multipart upload
+      description: |
+        Create a new Asset's multipart upload.
+      operationId: createAssetUpload
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetUploadCreate"
+      responses:
+        201:
+          description: Created Asset's multipart upload
+          headers:
+            Location:
+              description: A link to the Asset's multipart upload object
+              schema:
+                type: string
+                format: url
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadCreate"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "5XX":
+          $ref: "#/components/responses/ServerError"
+  "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}":
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
+    get:
+      tags:
+        - Asset Upload Management
+      summary: Get an Asset's multipart upload
+      description: |
+        Return an Asset's multipart upload.
+      operationId: getAssetUpload
+      parameters:
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          description: Asset's multipart upload description.
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUpload"
+              examples:
+                inprogress:
+                  $ref: "#/components/examples/inprogress"
+                completed:
+                  $ref: "#/components/examples/completed"
+                aborted:
+                  $ref: "#/components/examples/aborted"
+        "304":
+          $ref: "#/components/responses/NotModified"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  "/{presignedUrl}":
+    servers:
+      - url: http://data.geo.admin.ch/
+    put:
+      tags:
+        - Asset Upload Management
+      summary: Upload asset file part
+      description: >-
+        Upload an Asset file part using the presigned url(s) returned by
+        [Create a new Asset's multipart upload](#operation/createAssetUpload).
+
+
+        Parts that have been uploaded but not completed can be checked using
+        [Get an Asset's multipart upload](#operation/getAssetUpload)
+
+
+        A file part must be at least 5 MB except for the last one and at most 5 GB, otherwise the
+        complete operation will fail.
+
+
+        *Note: this endpoint doesn't require any authentication as it is already part of the
+        presigned url*
+      operationId: uploadAssetFilePart
+      parameters:
+        - $ref: "#/components/parameters/presignedUrl"
+        - name: Content-MD5
+          in: header
+          description: Asset file part content MD5.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Asset file uploaded part successfully
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: >-
+                The RFC7232 ETag header field in a response provides the current entity-
+                tag for the selected resource.
+
+
+                This ETag is required in the complete multipart upload payload.
+
+
+                An entity-tag is an opaque identifier for
+                different versions of a resource over time, regardless whether multiple
+                versions are valid at the same time. An entity-tag consists of an opaque
+                quoted string.
+              example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+              required: true
+  "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/complete":
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
+    post:
+      tags:
+        - Asset Upload Management
+      summary: Complete multipart upload
+      operationId: completeMultipartUpload
+      description: >-
+        Complete the multipart upload process. After completion, the Asset metadata are updated
+        with the new `checksum:multihash` from the upload and the parts are automatically deleted.
+        The Asset `href` field is also set if it was the first upload.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetCompleteUpload"
+      responses:
+        "200":
+          description: Asset multipart upload completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadCompleted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "5XX":
+          $ref: "#/components/responses/ServerError"
+  "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/abort":
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
+    post:
+      tags:
+        - Asset Upload Management
+      summary: Abort multipart upload
+      operationId: abortMultipartUpload
+      description: >-
+        Abort the multipart upload process. All already uploaded parts are automatically deleted.
+      responses:
+        "200":
+          description: Asset multipart upload aborted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadAborted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "5XX":
+          $ref: "#/components/responses/ServerError"
+  "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/parts":
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
+    get:
+      tags:
+        - Asset Upload Management
+      summary: Get upload parts
+      operationId: getUploadParts
+      description: >-
+        Return the list of already uploaded parts.
+
+
+        ### Pagination
+
+        By default all parts are returned (maximum number of parts being 100). The user can
+        use pagination to reduce the number of returned parts. Pagination is done via the `limit`
+        query parameter (see below).
+      parameters:
+        - $ref: "#/components/parameters/limit"
+      responses:
+        "200":
+          description: List of parts already uploaded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetUploadParts"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "5XX":
+          $ref: "#/components/responses/ServerError"
+
+
   "/get-token":
     servers:
       - url: http://data.geo.admin.ch/api/stac/
@@ -583,12 +872,58 @@ paths:
               example:
                 code: 400
                 description: "Unable to log in with provided credentials."
+
 components:
+  examples:
+    inprogress:
+      summary: In progress upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: in-progress
+        number_parts: 1
+        urls:
+        - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+          part: 1
+          expires: '2019-08-24T14:15:22Z'
+        created: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+    completed:
+      summary: Completed upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: completed
+        number_parts: 1
+        created: '2019-08-24T14:15:22Z'
+        completed: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
+    aborted:
+      summary: Aborted upload example
+      value:
+        upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+        status: completed
+        number_parts: 1
+        created: '2019-08-24T14:15:22Z'
+        aborted: '2019-08-24T14:15:22Z'
+        checksum:multihash: 90e402107a7f2588a85362b9beea2a12d4514d45
   parameters:
     assetId:
       name: assetId
       in: path
-      description: Local identifier of a asset
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
+    uploadId:
+      name: uploadId
+      in: path
+      description: Local identifier of an asset's upload.
+      required: true
+      schema:
+        type: string
+    presignedUrl:
+      name: presignedUrl
+      in: path
+      description: Presigned url returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
       required: true
       schema:
         type: string
@@ -795,6 +1130,282 @@ components:
         parameters, then the Item is renamed.
       example: smr200-200-4-2019
       type: string
+    uploadId:
+      title: ID
+      type: string
+      description: Unique Asset upload identifier
+      example: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+      readOnly: true
+    dtUploadCreated:
+      title: created
+      description: Date time when the Asset's upload has been created/started.
+      type: string
+      format: date-time
+      readOnly: true
+    dtUploadCompleted:
+      title: completed
+      description: |
+        Date time when the Asset's upload has been completed.
+
+        *Note: this property is mutually exclusive with `aborted`*
+      type: string
+      format: date-time
+      readOnly: true
+    dtUploadAborted:
+      title: aborted
+      description: |
+        Date time when the Asset's upload has been aborted.
+
+        *Note: this property is mutually exclusive with `completed`*
+      type: string
+      format: date-time
+      readOnly: true
+    assetUploads:
+      title: AssetUploads
+      type: object
+      required:
+        - uploads
+        - links
+      properties:
+        uploads:
+          description: List of uploads that are within the asset.
+          type: array
+          items:
+            $ref: "#/components/schemas/assetUpload"
+        links:
+          description: Next and/or previous links for the pagination.
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+          example:
+            - rel: next
+              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+    assetUpload:
+      title: AssetUpload
+      type: object
+      required:
+        - upload_id
+        - status
+        - created
+        - "checksum:multihash"
+        - number_parts
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          $ref: "#/components/schemas/status"
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        urls:
+          type: array
+          description: |
+            Note: As soon as the multipart upload is completed or aborted, the `urls` property is removed.
+          items:
+            $ref: "#/components/schemas/multipartUploadUrl"
+          readOnly: true
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        completed:
+          $ref: "#/components/schemas/dtUploadCompleted"
+        aborted:
+          $ref: "#/components/schemas/dtUploadAborted"
+        "checksum:multihash":
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadCreate:
+      title: AssetUpload
+      type: object
+      required:
+        - upload_id
+        - status
+        - created
+        - "checksum:multihash"
+        - number_parts
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          $ref: "#/components/schemas/status"
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        urls:
+          type: array
+          description: |
+            Note: As soon as the multipart upload is completed or aborted, the `urls` property is removed.
+          items:
+            $ref: "#/components/schemas/multipartUploadUrl"
+          readOnly: true
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        "checksum:multihash":
+          $ref: "#/components/schemas/checksumMultihash"
+    assetCompleteUpload:
+      title: CompleteUpload
+      type: object
+      required:
+        - parts
+      properties:
+        parts:
+          type: array
+          description: Parts that have been uploaded
+          items:
+            title: File part that have been uploaded
+            type: object
+            required:
+              - etag
+              - part_number
+            properties:
+              etag:
+                title: ETag
+                type: string
+                description: >-
+                  ETag of the uploaded file part (returned in the header of the answer of
+                  [Upload asset file part](#operation/uploadAssetFilePart)).
+                example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+              part_number:
+                $ref: "#/components/schemas/part_number"
+    assetUploadCompleted:
+      title: UploadCompleted
+      type: object
+      required:
+        - upload_id
+        - status
+        - number_parts
+        - created
+        - completed
+        - "checksum:multihash"
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          title: Status
+          description: Status of the Asset's multipart upload.
+          type: string
+          enum:
+            - completed
+          example:
+            completed
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        completed:
+          $ref: "#/components/schemas/dtUploadCompleted"
+        "checksum:multihash":
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadAborted:
+      title: UploadCompleted
+      type: object
+      required:
+        - upload_id
+        - status
+        - number_parts
+        - created
+        - aborted
+        - "checksum:multihash"
+      properties:
+        upload_id:
+          $ref: "#/components/schemas/uploadId"
+        status:
+          title: Status
+          description: Status of the Asset's multipart upload.
+          type: string
+          enum:
+            - aborted
+          example:
+            aborted
+        number_parts:
+          $ref: "#/components/schemas/number_parts"
+        created:
+          $ref: "#/components/schemas/dtUploadCreated"
+        aborted:
+          $ref: "#/components/schemas/dtUploadAborted"
+        "checksum:multihash":
+          $ref: "#/components/schemas/checksumMultihash"
+    assetUploadParts:
+      title: Parts
+      type: object
+      required:
+        - parts
+        - links
+      properties:
+        parts:
+          type: object
+          description: List of uploaded parts
+          required:
+            - etag
+            - part_number
+            - modified
+            - size
+          properties:
+            etag:
+              $ref: "#/components/schemas/uploadEtag"
+            part_number:
+              $ref: "#/components/schemas/part_number"
+            modified:
+              type: string
+              format: date-time
+              description: Date time when the part was added/modified
+            size:
+              type: integer
+              description: Part size in bytes
+              minimum: 0
+              example: 1024
+        links:
+          description: Next and/or previous links for the pagination.
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
+          example:
+            - rel: next
+              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+    status:
+      title: Status
+      description: Status of the Asset's multipart upload.
+      type: string
+      enum:
+        - in-progress
+        - aborted
+        - completed
+      readOnly: true
+    number_parts:
+      description: Number of parts for the Asset's multipart upload.
+      type: integer
+      minimum: 1
+      maximum: 100
+    part_number:
+      description: Number of the part.
+      type: integer
+      minimum: 1
+      maximum: 100
+    multipartUploadUrl:
+      title: MultipartUploadUrl
+      description: Multipart upload url.
+      type: object
+      required:
+        - url
+        - part
+        - expires
+      properties:
+        url:
+          description: Presigned URL to use to upload the Asset File part using the PUT method.
+          type: string
+          format: url
+          example: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff?uploadId=d77UbNnEVTaqCAyAz61AVqy7uuTGJ_YOUyPOklcRMr4ZPBthON9p6cpMREx683yQ_oeGVmGE_yTg4cmnEz3mTErEPKn0_m.3LBjo6A88Qxlj4vFrAdU6YBuourb.IqFF&partNumber=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4HDUVYWAM6ZB6SWO%2F20210414%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210414T112742Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d12763467eaffa0c69d601297a661a05c9f414d4008b4148fa6ba604f203be01
+        part:
+          description: Part number assigned to this presigned URL.
+          type: integer
+          minimum: 1
+          maximum: 100
+        expires:
+          description: Date time when this presigned URL expires and is not valid anymore.
+          type: string
+          format: date-time
+    uploadEtag:
+      title: ETag
+      type: string
+      description: The RFC7232 ETag for the specified uploaded part.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+
   responses:
     Assets:
       description: >-
@@ -868,6 +1479,53 @@ tags:
       Asset file can be uploaded via the STAC API using the following requests.
 
       *NOTE: the POST requests requires authentication as described in [here](#tag/Authentication).*
+
+      ### Example
+
+      ```python
+      import os
+      import hashlib
+
+      import requests
+      import multihash
+
+      # variables
+      scheme = 'https'
+      hostname = 'data.geo.admin.ch'
+      collection = 'ch.swisstopo.pixelkarte-farbe-pk200.noscale'
+      item = 'smr200-200-4-2016'
+      asset = 'smr200-200-4-2016-2056-kgrs-10.tiff'
+      asset_path = f'collections/{collection}/items/{item}/assets/{asset}'
+      user = os.environ.get('STAC_USER', 'unknown-user')
+      password = os.environ.get('STAC_PASSWORD', 'unknown-password')
+
+      with open('smr200-200-4-2016-2056-kgrs-10.tiff', 'rb') as fd:
+        data = fd.read()
+
+      checksum_multihash = multihash.to_hex_string(multihash.encode(hashlib.sha256(data).digest(), 'sha2-256'))
+
+      # 1. Create a multipart upload
+      response = requests.post(
+        f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads",
+        auth=(user, password),
+        json={
+          "number_parts": 1,
+          "checksum:multihash": checksum_multihash
+        }
+      )
+      upload_id = response.json()['upload_id']
+
+      # 2. Upload the part using the presigned url
+      response = requests.put(response.json()['urls'][0]['url'], data=data)
+      etag = response.headers['ETag']
+
+      # 3. Complete the upload
+      response = requests.post(
+        f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads/{upload_id}/complete",
+        auth=(user, password),
+        json={'parts': [{'etag': etag, 'part_number': 1}]}
+      )
+      ```
   - name: Authentication
     description: |
       All write requests require authentication. There is currently three type of supported authentications:

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -604,14 +604,6 @@ components:
         he would overwrite another changes of the resource.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
   schemas:
-    description:
-      type: string
-      description: >-
-        Detailed multi-line description to fully explain the object (collection,
-        item, asset, ...).
-
-        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
-        text representation.
     assetId:
       type: string
       pattern: ^[a-z0-9.-_]+$
@@ -770,12 +762,6 @@ components:
       default: https://data.geo.admin.ch/<collection-id>/<item-id>/<asset-id>
       example: >-
         http://data.geo.admin.ch/tmp/gdwh/ch.swisstopo.swissimage/CS3-20160503_132130_04.png
-    href:
-      type: string
-      format: url
-      description: Link to the asset object
-      example: >-
-        http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     writeItem:
       allOf:
         - $ref: "#/components/schemas/itemBase"
@@ -825,10 +811,6 @@ components:
       example:
         properties:
           datetime: "2016-05-03T13:22:30.040Z"
-        # assets:
-        #   analytic:
-        #     title: 1-Band Analytic
-        #     href: http://cool-sat.com/catalog/collections/cs/items/CS3-201605XX_132130_04/analytic-1.tif
     partialCollection:
       type: object
       description: Allows for a set of partial metadata fields for a collection
@@ -874,34 +856,6 @@ components:
             - http://www.opengis.net/def/crs/EPSG/0/4326
         example:
           title: The new title of the collection
-    roles:
-      type: array
-      items:
-        type: string
-      description: Purposes of the asset
-      example:
-        - thumbnail
-    title:
-      type: string
-      description: Displayed title
-      example: Thumbnail
-    type:
-      type: string
-      description: Media type of the asset
-      example: image/tiff; application=geotiff
-    # Overwrite the collection links examples
-    # collection:
-    #   properties:
-    #     links:
-    #       example:
-    #         - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-    #           rel: license
-    #           title: Licence for the free geodata of the Federal Office of Topography swisstopo
-    #         - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-    #           rel: describedby
-    #       items:
-    #         $ref: "#/components/schemas/link"
-    #       type: array
     itemIdUpdate:
       description: >-
         Item identifier (unique per collection. If it doesn't match the `featureId` in path
@@ -953,15 +907,6 @@ components:
             required:
               - code
               - links
-    BadRequest:
-      description: The request was malformed or semantically invalid
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/exception"
-          example:
-            code: 400
-            description: "Invalid parameter"
     PermissionDenied:
       description: No Permission for this request
       content:

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -533,7 +533,7 @@ paths:
       - url: http://data.geo.admin.ch/api/stac/
     post:
       tags:
-        - Data Management
+        - Authentication
       summary: >-
         Request token for token authentication.
       operationId: getToken
@@ -546,7 +546,7 @@ paths:
               properties:
                 username:
                   type: string
-                  decscription: name of user for whom token is requested
+                  description: name of user for whom token is requested
                 password:
                   type: string
                   description: password of user for whom token is requested
@@ -849,28 +849,47 @@ components:
           example:
             code: 403
             description: "Permission denied"
-tags:
-  - description: Essential characteristics of this API
-    name: Capabilities
-  - description: Access to data (features)
-    name: Data
-  - description: Extension to OGC API - Features to support STAC metadata model and search API
-    name: STAC
-  - description: |
-      All write requests require authentication. The currently available options for a user to
-      authenticate himself are described below.
 
-      # Session authentication
+tags:
+  - name: Capabilities
+    description: Essential characteristics of this API
+  - name: Data
+    description: Access to data (features)
+  - name: STAC
+    description: Extension to OGC API - Features to support STAC metadata model and search API
+  - name: Data Management
+    description: |
+      Metadata management requests. Theses requests are used to create, update or delete the STAC
+      metadata.
+
+      *NOTE: these requests requires authentication as described in [here](#tag/Authentication).*
+  - name: Asset Upload Management
+    description: |
+      Asset file can be uploaded via the STAC API using the following requests.
+
+      *NOTE: the POST requests requires authentication as described in [here](#tag/Authentication).*
+  - name: Authentication
+    description: |
+      All write requests require authentication. There is currently three type of supported authentications:
+
+      * [Session authentication](#section/Session-authentication)
+      * [Basic authentication](#section/Basic-authentication)
+      * [Token authentication](#section/Token-authentication)
+
+      ## Session authentication
+
       When using the browsable API the user can simply use the admin interface for logging in.
       Once logged in, the browsable API can be used to perform write requests.
 
-      # Basic authentication
+      ## Basic authentication
+
       The username and password for authentication can be added to every write request the user wants to perform.
       Here is an example of posting an asset using curl (_username_="MickeyMouse", _password_="I_love_Minnie_Mouse"):
+
       ```
       curl --request POST \
         --user MickeyMouse:I_love_Minnie_Mouse \
-        --url https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+        --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
         --header 'Content-Type: application/json' \
         --data '{
           "id": "fancy_unique_id",
@@ -883,12 +902,14 @@ tags:
       }'
       ```
 
-      # Token authentication
+      ## Token authentication
+
       A user specific token for authentication can be added to every write request the user wants to perform.
       Here is an example of posting an asset using curl:
+
       ```
       curl --request POST \
-        --url https://service-stac.dev.bgdi.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+        --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
         --header 'Authorization: Token ccecf40693bfc52ba090cd46eb7f19e723fe831f' \
         --header 'Content-Type: application/json' \
         --data '{
@@ -901,14 +922,14 @@ tags:
           "checksum:multihash": "01205c3fd6978a7d0b051efaa4263a04"
       }'
       ```
+
       Tokens can either be generated in the admin interface or existing users can perform a POST request
-      on the get-token endpoint to request a token (also see description of the get-token POST endpoint
-      at the bottom).
+      on the get-token endpoint to request a token (also see [Request token for token authentication](#operation/getToken)).
       Here is an example using curl:
+
       ```
       curl --request POST \
-        --url https://service-stac.dev.bgdi.ch/api/stac/get-token \
+        --url https://data.geoadmin.ch/api/stac/get-token \
         --header 'Content-Type: application/json' \
         --data '{"username": "MickeyMouse", "password": "I_love_Minnie_Mouse"}'
       ```
-    name: Data Management

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -808,7 +808,7 @@ components:
         The response is a document consisting of one asset of the feature.
       headers:
         ETag:
-          $ref: "#/components/schemas/ETag"
+          $ref: "#/components/headers/ETag"
       content:
         application/json:
           schema:

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -1138,14 +1138,14 @@ components:
       readOnly: true
     dtUploadCreated:
       title: created
-      description: Date time when the Asset's upload has been created/started.
+      description: Date and time when the Asset's upload has been created/started.
       type: string
       format: date-time
       readOnly: true
     dtUploadCompleted:
       title: completed
       description: |
-        Date time when the Asset's upload has been completed.
+        Date and time when the Asset's upload has been completed.
 
         *Note: this property is mutually exclusive with `aborted`*
       type: string
@@ -1154,7 +1154,7 @@ components:
     dtUploadAborted:
       title: aborted
       description: |
-        Date time when the Asset's upload has been aborted.
+        Date and time when the Asset's upload has been aborted.
 
         *Note: this property is mutually exclusive with `completed`*
       type: string
@@ -1248,7 +1248,7 @@ components:
           type: array
           description: Parts that have been uploaded
           items:
-            title: File part that have been uploaded
+            title: File parts that have been uploaded
             type: object
             required:
               - etag
@@ -1473,12 +1473,12 @@ tags:
       Metadata management requests. Theses requests are used to create, update or delete the STAC
       metadata.
 
-      *NOTE: these requests requires authentication as described in [here](#tag/Authentication).*
+      *NOTE: these requests require authentication as described in [here](#tag/Authentication).*
   - name: Asset Upload Management
     description: |
       Asset file can be uploaded via the STAC API using the following requests.
 
-      *NOTE: the POST requests requires authentication as described in [here](#tag/Authentication).*
+      *NOTE: the POST requests require authentication as described in [here](#tag/Authentication).*
 
       ### Example
 

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -41,7 +41,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/collection"
+                $ref: "#/components/schemas/collectionWrite"
         "403":
           $ref: "#/components/responses/PermissionDenied"
         "404":
@@ -65,7 +65,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/collection"
+              $ref: "#/components/schemas/collectionWrite"
             example:
               description: The National Map 1:200,000 is a topographic map giving an overview of Switzerland.
               id: ch.swisstopo.pixelkarte-farbe-pk200.noscale
@@ -124,7 +124,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/collection"
+              $ref: "#/components/schemas/collectionWrite"
             example:
               id: ch.swisstopo.pixelkarte-farbe-pk200.noscale
               license: proprietary

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -433,7 +433,7 @@ paths:
       tags:
         - Data
     put:
-      summary: Update or  create an asset
+      summary: Update or create an asset
       description: >-
         Update or create an asset with Id `assetId` with a complete asset definition.
         If the asset doesn't exists it is then created.
@@ -489,19 +489,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/itemAsset"
-        "201":
-          description: Returns the created Asset
-          headers:
-            Location:
-              description: A link to the asset
-              schema:
-                type: string
-                format: url
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/itemAsset"
+                $ref: "#/components/schemas/readUpdateAsset"
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":

--- a/spec/transaction/transaction.yml
+++ b/spec/transaction/transaction.yml
@@ -823,7 +823,7 @@ components:
             type: object
             properties:
               code:
-                type: int
+                type: integer
                 example: 200
               description:
                 type: string


### PR DESCRIPTION
Added asset upload in spec.

Also did some corrections:

- Removed wrong openapi response in PATCH asset
- Moved SPEC generic response and schemas
- Removed the checksum:multihash from write Assets requests + clean ups
- Reorganized the requests by adding two new tags
- Moved the ETag definition from schemas to headers
- Made the collection links optional in write request

I suggest to do the review commit by commit, this will be easier to understands the changes. See also commit messages.