### PR TITLE
BGDIINF_SB-1746: Removed the Item renaming functionality

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -114,6 +114,7 @@ class ItemAdmin(admin.GeoModelAdmin):
     inlines = [ItemLinkInline]
     autocomplete_fields = ['collection']
     search_fields = ['name', 'collection__name']
+    readonly_fields = ['collection_name']
     fieldsets = (
         (None, {
             'fields': ('name', 'collection', 'geometry')
@@ -167,6 +168,30 @@ class ItemAdmin(admin.GeoModelAdmin):
                 queryset &= self.model.objects.filter(collection__name__exact=collection_name)
         return queryset, use_distinct
 
+    # Here we use a special field for read only to avoid adding the extra help text for search
+    # functionality
+    def collection_name(self, obj):
+        return obj.collection.name
+
+    collection_name.admin_order_field = 'collection__name'
+    collection_name.short_description = 'Collection Id'
+
+    # We don't want to move the assets on S3
+    # That's why some fields like the name of the item and the collection name are set readonly here
+    # for update operations. Those fields value are used as key on S3 that's why renaming them
+    # would mean that the Asset on S3 should be moved.
+    def get_fieldsets(self, request, obj=None):
+        fields = super().get_fieldsets(request, obj)
+        if obj is None:
+            # In case a new Item is added use the normal field 'collection' from model that have
+            # a help text fort the search functionality.
+            fields[0][1]['fields'] = ('name', 'collection')
+            return fields
+        # Otherwise if this is an update operation only display the read only field
+        # without help text
+        fields[0][1]['fields'] = ('name', 'collection_name')
+        return fields
+
 
 @admin.register(Asset)
 class AssetAdmin(admin.ModelAdmin):
@@ -177,11 +202,11 @@ class AssetAdmin(admin.ModelAdmin):
 
     autocomplete_fields = ['item']
     search_fields = ['name', 'item__name', 'item__collection__name']
-    readonly_fields = ['item_name', 'collection', 'href', 'checksum_multihash']
-    list_display = ['name', 'item_name', 'collection']
+    readonly_fields = ['item_name', 'collection_name', 'href', 'checksum_multihash']
+    list_display = ['name', 'item_name', 'collection_name']
     fieldsets = (
         (None, {
-            'fields': ('name', 'item', 'item_name', 'collection')
+            'fields': ('name', 'item')
         }),
         ('File', {
             'fields': ('file', 'media_type', 'href', 'checksum_multihash')
@@ -221,11 +246,11 @@ class AssetAdmin(admin.ModelAdmin):
                 queryset &= self.model.objects.filter(item__collection__name__exact=collection_name)
         return queryset, use_distinct
 
-    def collection(self, instance):
+    def collection_name(self, instance):
         return instance.item.collection
 
-    collection.admin_order_field = 'item__collection'
-    collection.short_description = 'Collection Id'
+    collection_name.admin_order_field = 'item__collection'
+    collection_name.short_description = 'Collection Id'
 
     def item_name(self, instance):
         return instance.item.name
@@ -255,8 +280,14 @@ class AssetAdmin(admin.ModelAdmin):
     # We don't want to move the assets on S3
     # That's why some fields like the name of the asset are set readonly here
     # for update operations
-    def change_view(self, request, object_id, form_url='', extra_context=None):
-        self.readonly_fields = self.get_readonly_fields(request)
-        self.readonly_fields.extend(['name', 'item'])
-
-        return super().change_view(request, object_id, form_url, extra_context)
+    def get_fieldsets(self, request, obj=None):
+        fields = super().get_fieldsets(request, obj)
+        if obj is None:
+            # In case a new Asset is added use the normal field 'item' from model that have
+            # a help text fort the search functionality.
+            fields[0][1]['fields'] = ('name', 'item')
+            return fields
+        # Otherwise if this is an update operation only display the read only fields
+        # without help text
+        fields[0][1]['fields'] = ('name', 'item_name', 'collection_name')
+        return fields

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -66,6 +66,7 @@ class CollectionAdmin(admin.ModelAdmin):
     class Media:
         js = ('js/admin/collection_help_search.js',)
         css = {'all': ('style/hover.css',)}
+
     fields = [
         'name',
         'title',

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -247,9 +247,9 @@ class AssetAdmin(admin.ModelAdmin):
         return queryset, use_distinct
 
     def collection_name(self, instance):
-        return instance.item.collection
+        return instance.item.collection.name
 
-    collection_name.admin_order_field = 'item__collection'
+    collection_name.admin_order_field = 'item__collection__name'
     collection_name.short_description = 'Collection Id'
 
     def item_name(self, instance):

--- a/app/stac_api/validators_view.py
+++ b/app/stac_api/validators_view.py
@@ -78,26 +78,26 @@ def validate_asset(kwargs):
         )
 
 
-def validate_renaming(serializer, id_field='', original_id='', extra_log=None):
-    '''Validate that the asset name is not different from the one defined in
+def validate_renaming(serializer, original_id, id_field='name', extra_log=None):
+    '''Validate that the object name is not different from the one defined in
        the data.
 
     Args:
         serializer: serializer object
             The serializer to derive the data from
-        id_field: string
-            The key to get the name/id in the data dict
         original_id: string
             The id/name derived from the request kwargs
-        extra: djangoHttpRequest object
-            The request object for logging purposes
+        id_field: string
+            The key to get the name/id in the data dict (default 'name')
+        extra_log: dict
+            Dictionary to pass to the log extra in case of error
 
     Raises:
-        Http400: when the asset will be renamed/moved
+        Http400: when the object will be renamed/moved
     '''
     data = serializer.validated_data
     if id_field in data.keys():
         if data[id_field] != original_id:
-            message = 'Renaming object is not allowed'
-            logger.error(message, extra={'request': extra_log})
-            raise ValidationError(_(message), code='invalid')
+            message = 'Renaming is not allowed'
+            logger.error(message, extra=extra_log)
+            raise ValidationError({'id': _(message)}, code='invalid')

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -422,10 +422,28 @@ class ItemDetail(
 
     def perform_update(self, serializer):
         collection = get_object_or_404(Collection, name=self.kwargs['collection_name'])
+        validate_renaming(
+            serializer,
+            self.kwargs['item_name'],
+            extra_log={
+                'request': self.request,
+                'collection': self.kwargs['collection_name'],
+                'item': self.kwargs['item_name']
+            }
+        )
         serializer.save(collection=collection)
 
     def perform_upsert(self, serializer, lookup):
         collection = get_object_or_404(Collection, name=self.kwargs['collection_name'])
+        validate_renaming(
+            serializer,
+            self.kwargs['item_name'],
+            extra_log={
+                'request': self.request,
+                'collection': self.kwargs['collection_name'],
+                'item': self.kwargs['item_name']
+            }
+        )
         return serializer.upsert(lookup, collection=collection)
 
     @etag(get_item_etag)
@@ -536,9 +554,13 @@ class AssetDetail(
         )
         validate_renaming(
             serializer,
-            id_field='name',
             original_id=self.kwargs['asset_name'],
-            extra_log=self.request
+            extra_log={
+                'request': self.request,
+                'collection': self.kwargs['collection_name'],
+                'item': self.kwargs['item_name'],
+                'asset': self.kwargs['asset_name']
+            }
         )
         serializer.save(item=item, file=get_asset_path(item, self.kwargs['asset_name']))
 
@@ -548,9 +570,13 @@ class AssetDetail(
         )
         validate_renaming(
             serializer,
-            id_field='name',
             original_id=self.kwargs['asset_name'],
-            extra_log=self.request
+            extra_log={
+                'request': self.request,
+                'collection': self.kwargs['collection_name'],
+                'item': self.kwargs['item_name'],
+                'asset': self.kwargs['asset_name']
+            }
         )
         return serializer.upsert(
             lookup, item=item, file=get_asset_path(item, self.kwargs['asset_name'])

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -311,16 +311,24 @@ class CollectionDetail(
     def perform_upsert(self, serializer, lookup):
         validate_renaming(
             serializer,
-            'name',
-            self.kwargs['collection_name'], {'collection': self.kwargs['collection_name']}
+            self.kwargs['collection_name'],
+            extra_log={
+                # pylint: disable=protected-access
+                'request': self.request._request,
+                'collection': self.kwargs['collection_name']
+            }
         )
         return super().perform_upsert(serializer, lookup)
 
     def perform_update(self, serializer, *args, **kwargs):
         validate_renaming(
             serializer,
-            'name',
-            self.kwargs['collection_name'], {'collection': self.kwargs['collection_name']}
+            self.kwargs['collection_name'],
+            extra_log={
+                # pylint: disable=protected-access
+                'request': self.request._request,
+                'collection': self.kwargs['collection_name']
+            }
         )
         return super().perform_update(serializer, *args, **kwargs)
 
@@ -426,7 +434,7 @@ class ItemDetail(
             serializer,
             self.kwargs['item_name'],
             extra_log={
-                'request': self.request,
+                'request': self.request._request,  # pylint: disable=protected-access
                 'collection': self.kwargs['collection_name'],
                 'item': self.kwargs['item_name']
             }
@@ -439,7 +447,7 @@ class ItemDetail(
             serializer,
             self.kwargs['item_name'],
             extra_log={
-                'request': self.request,
+                'request': self.request._request,  # pylint: disable=protected-access
                 'collection': self.kwargs['collection_name'],
                 'item': self.kwargs['item_name']
             }
@@ -556,7 +564,7 @@ class AssetDetail(
             serializer,
             original_id=self.kwargs['asset_name'],
             extra_log={
-                'request': self.request,
+                'request': self.request._request,  # pylint: disable=protected-access
                 'collection': self.kwargs['collection_name'],
                 'item': self.kwargs['item_name'],
                 'asset': self.kwargs['asset_name']
@@ -572,7 +580,7 @@ class AssetDetail(
             serializer,
             original_id=self.kwargs['asset_name'],
             extra_log={
-                'request': self.request,
+                'request': self.request._request,  # pylint: disable=protected-access
                 'collection': self.kwargs['collection_name'],
                 'item': self.kwargs['item_name'],
                 'asset': self.kwargs['asset_name']

--- a/app/tests/test_assets_endpoint.py
+++ b/app/tests/test_assets_endpoint.py
@@ -601,7 +601,7 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             path, data=changed_asset.get_json('put'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
-        self.assertEqual(['Renaming object is not allowed'],
+        self.assertEqual({'id': 'Renaming is not allowed'},
                          response.json()['description'],
                          msg='Unexpected error message')
 
@@ -639,7 +639,7 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
             path, data=changed_asset.get_json('patch'), content_type="application/json"
         )
         self.assertStatusCode(400, response)
-        self.assertEqual(['Renaming object is not allowed'],
+        self.assertEqual({'id': 'Renaming is not allowed'},
                          response.json()['description'],
                          msg='Unexpected error message')
 

--- a/app/tests/test_collections_endpoint.py
+++ b/app/tests/test_collections_endpoint.py
@@ -247,7 +247,7 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             content_type='application/json'
         )
         self.assertStatusCode(400, response)
-        self.assertEqual(['Renaming object is not allowed'],
+        self.assertEqual({'id': 'Renaming is not allowed'},
                          response.json()['description'],
                          msg='Unexpected error message')
 

--- a/app/tests/test_items_endpoint.py
+++ b/app/tests/test_items_endpoint.py
@@ -612,12 +612,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             msg="Original item doesn't exists anymore after trying to rename it"
         )
 
-        # Make sure the rename item was done
+        # Make sure the rename item was not done
         self.assertFalse(
             Item.objects.all().filter(
                 name=sample["name"], collection__name=self.collection['name']
             ).exists(),
-            msg="Original item doesn't exists anymore after trying to rename it"
+            msg="Renamed item shouldn't exist"
         )
 
     def test_item_endpoint_patch(self):
@@ -676,11 +676,11 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             msg="Original item doesn't exists anymore after trying to rename it"
         )
 
-        # Make sure the rename item was done
+        # Make sure the rename item was not done
         self.assertFalse(
             Item.objects.all().filter(name=data["id"],
                                       collection__name=self.collection['name']).exists(),
-            msg="Original item doesn't exists anymore after trying to rename it"
+            msg="Renamed item shouldn't exist"
         )
 
     def test_item_upsert_create(self):


### PR DESCRIPTION
Also improved the Asset admin page. In this one the read only item field
still had the help text for the field search functionality which don't
make sense for read only field. To avoid this simply changed the logic,
adding extra read only fields that are only displayed in the change view
and the write item field is only display in the add view.

Also improved the logging in case off renaming.