### PR TITLE
BGDIINF_SB-1827: Readded item geometry field in admin page

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -125,7 +125,10 @@ class ItemAdmin(admin.GeoModelAdmin):
     readonly_fields = ['collection_name']
     fieldsets = (
         (None, {
-            'fields': ('name', 'collection', 'geometry')
+            'fields': ('name', 'collection')
+        }),
+        ('geometry', {
+            'fields': ('geometry',)
         }),
         (
             'Properties',


### PR DESCRIPTION
The item geometry field was missing in the admin page. This was due to
the ItemAdmin.get_fieldsets() method which removed the geometry from the
first fieldset.

Now the geometry field has its own fieldset which is also a preparation
for further improvement in geometry field (see BGDIINF_SB-1650)