### PR TITLE
BGDIINF_SB-1826: Fixed HTTP 500 in Item Admin page

### DIFF
--- a/app/stac_api/templates/admin/ol_swisstopo.html
+++ b/app/stac_api/templates/admin/ol_swisstopo.html
@@ -1,7 +1,4 @@
 {% load static %}
-{% block bootstrap_theme %}
-    <link rel="stylesheet" href="{% static 'style/css/admin.css' %}" type="text/css">
-{% endblock %}
 {% block extrahead %}
     <link rel="shortcut icon"href="{% static 'style/img/ico/favicon.ico' %}">
 {% endblock %}


### PR DESCRIPTION
When we opened the Item admin page (change or create view) the backend
crashed and returned a HTTP 500 Internal error.

This was due to the fact that the Item Geometry field template still did
a reference to the admin.css style that was removed.