### PR TITLE
#patch, BGDIINF_SB-1826, BGDIINF_SB-1827: Hotfix Item Admin page - v1.4.1

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -125,7 +125,10 @@ class ItemAdmin(admin.GeoModelAdmin):
     readonly_fields = ['collection_name']
     fieldsets = (
         (None, {
-            'fields': ('name', 'collection', 'geometry')
+            'fields': ('name', 'collection')
+        }),
+        ('geometry', {
+            'fields': ('geometry',)
         }),
         (
             'Properties',

--- a/app/stac_api/templates/admin/ol_swisstopo.html
+++ b/app/stac_api/templates/admin/ol_swisstopo.html
@@ -1,7 +1,4 @@
 {% load static %}
-{% block bootstrap_theme %}
-    <link rel="stylesheet" href="{% static 'style/css/admin.css' %}" type="text/css">
-{% endblock %}
 {% block extrahead %}
     <link rel="shortcut icon"href="{% static 'style/img/ico/favicon.ico' %}">
 {% endblock %}


### PR DESCRIPTION
The item geometry field was missing in the admin page. This was due to
the ItemAdmin.get_fieldsets() method which removed the geometry from the
first fieldset.

Now the geometry field has its own fieldset which is also a preparation
for further improvement in geometry field (see BGDIINF_SB-1650)