### PR TITLE
Bug_fix BGDIINF_SB-1850 large file upload via admin GUI

### DIFF
--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -23,7 +23,11 @@ class RequestResponseLoggingMiddleware:
             "request.query": request.GET.urlencode(RequestResponseLoggingMiddleware.url_safe)
         }
 
-        if request.method.upper() in ["PATCH", "POST", "PUT"]:
+        if request.method.upper() in [
+            "PATCH", "POST", "PUT"
+        ] and request.content_type == "application/json" and not request.path.startswith(
+            '/api/stac/admin'
+        ):
             extra["request.payload"] = str(request.body[:200])
 
         logger.info(

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -224,11 +224,11 @@ class AdminBaseTestCase(TestCase):
         start = time.time()
         filecontent = b'mybinarydata'
         filelike = BytesIO(filecontent)
-        filelike.name = 'testname.tiff'
+        filelike.name = 'testname.zip'
 
         data = {
             "item": item.id,
-            "name": "test_asset.zip",
+            "name": filelike.name,
             "description": "This is a description",
             "eo_gsd": 10,
             "geoadmin_lang": "en",


### PR DESCRIPTION
Currently uploading assets files, which are larger than the default 2.5 MB, which is the default for `DATA_UPLOAD_MAX_MEMORY_SIZE`  fails when using the admin GUI.

The `RequestDataTooBig` exception was raised, when the middleware logging tried to access the `request.body` and hence Djangos `request.py` evaluated the `content_length` against the `DATA_UPLOAD_MAX_MEMORY_SIZE`.
This is now fixed by NOT adding the first 200 characters of the request.body in the middleware logging in case the request.path starts with /api/stac/admin (thanks @ltshb ;-)).

In addition a minor change in `test_admin_page.py`'s `_create_asset()` was done in order to have a more consistent file naming.

Once this PR is merged, I'll deploy the changes toDEV and test to upload a large asset file (probably 60 GB?). If this works, it should also work on INT and probably no need for adding an `emptyDir` in the k8s repo then.