### PR TITLE
BGDIINF_SB-1228 added a simple script for creating large asset files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .volumes
 */logs
+/scripts/xxxxxxl_asset_file.zip

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ nose2-junit.xml
 .env.*local
 .volumes
 **/logs
+/scripts/xxxxxxl_asset_file.zip
 
 # Node modules
 node_modules/*

--- a/scripts/create_large_dummy_asset_file.py
+++ b/scripts/create_large_dummy_asset_file.py
@@ -1,0 +1,6 @@
+# this will create a 60 GB dummy asset file for testing the upload via
+# the admin GUI.
+LARGE_FILE_SIZE = 60 * 1024**3  # this is 60 GB
+with open("xxxxxxl_asset_file.zip", "wb") as dummy_file:
+    dummy_file.seek(int(LARGE_FILE_SIZE) - 1)
+    dummy_file.write(b"\0")


### PR DESCRIPTION
In order to test the upload of xxxxxxl sized dummy asset files (e.g. 60 GB), a simple script has been added.