### PR TITLE
BGDIINF_SB-1765: Clean up unittest stac_extension

### DIFF
--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -262,8 +262,7 @@ class StacTestMixin:
         for key, value in expected.items():
             path = f'{parent_path}.{key}'
 
-            # We need to remove the stac_extensions from here when BGDIINF_SB-1410 is implemented
-            if (ignore and key in ignore) or key in ['stac_extensions']:
+            if (ignore and key in ignore):
                 if key not in ['item', 'created', 'updated']:
                     logger.warning('Ignoring key %s in %s', key, path)
                 else:

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -120,12 +120,6 @@ class CollectionSerializationTestCase(StacBaseTestCase):
                     'name': 'provider-3',
                 },
             ],
-            'stac_extensions': [
-                'eo',
-                'proj',
-                'view',
-                'https://data.geo.admin.ch/stac/geoadmin-extension/1.0/schema.json'
-            ],
             'stac_version': settings.STAC_VERSION,
             'summaries': {
                 'eo:gsd': [3.4],
@@ -281,12 +275,6 @@ class ItemSerializationTestCase(StacBaseTestCase):
                 self.asset['name']: expected_asset
             },
             'bbox': (5.644711, 46.775054, 7.602408, 49.014995),
-            'stac_extensions': [
-                'eo',
-                'proj',
-                'view',
-                'https://data.geo.admin.ch/stac/geoadmin-extension/1.0/schema.json'
-            ],
             'stac_version': settings.STAC_VERSION,
             'type': 'Feature'
         })


### PR DESCRIPTION
We don't use stac_extension (see BGDIINF_SB-1410) there remove them from
unittest.