### PR TITLE
BGDIINF_SB-1864: Order API collections/items/assets by name

### DIFF
--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -153,7 +153,7 @@ class CursorPagination(pagination.CursorPagination):
     def get_ordering(self, request, queryset, view):
         '''Get the ordering for the pagination.
 
-        The base class doesn't not allowed to use the view configuration for
+        The base class doesn't allow to use the view configuration for
         ordering, therefore it is here implemented.
         '''
         if hasattr(view, 'ordering'):

--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -150,6 +150,19 @@ class CursorPagination(pagination.CursorPagination):
     page_size_query_param = 'limit'
     max_page_size = settings.REST_FRAMEWORK['PAGE_SIZE_LIMIT']
 
+    def get_ordering(self, request, queryset, view):
+        '''Get the ordering for the pagination.
+
+        The base class doesn't not allowed to use the view configuration for
+        ordering, therefore it is here implemented.
+        '''
+        if hasattr(view, 'ordering'):
+            ordering = getattr(view, 'ordering')
+            if isinstance(ordering, str):
+                return (ordering,)
+            return tuple(ordering)
+        return super().get_ordering(request, queryset, view)
+
     def get_paginated_response(self, data):
         update_links_with_pagination(data, self.get_previous_link(), self.get_next_link())
         return Response(data)

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -229,34 +229,42 @@ class StacTestMixin:
 
         # check required fields
         for key in ['links', 'id', 'type', 'href']:
+            if key in ignore:
+                logger.info('Ignoring key %s in asset', key)
+                continue
             self.assertIn(key, current, msg=f'Asset {key} is missing')
         for date_field in ['created', 'updated']:
+            if key in ignore:
+                logger.info('Ignoring key %s in asset', key)
+                continue
             self.assertIn(date_field, current, msg=f'Asset {date_field} is missing')
             self.assertTrue(
                 fromisoformat(current[date_field]),
                 msg=f"The asset field {date_field} has an invalid date"
             )
-        name = current['id']
-        links = [
-            {
-                'rel': 'self',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets/{name}'
-            },
-            TEST_LINK_ROOT,
-            {
-                'rel': 'parent',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets',
-            },
-            {
-                'rel': 'item',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}',
-            },
-            {
-                'rel': 'collection',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
-            },
-        ]
-        self._check_stac_links('asset.links', links, current['links'])
+        if 'links' not in ignore:
+            name = current['id']
+            links = [
+                {
+                    'rel': 'self',
+                    'href':
+                        f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets/{name}'
+                },
+                TEST_LINK_ROOT,
+                {
+                    'rel': 'parent',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets',
+                },
+                {
+                    'rel': 'item',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}',
+                },
+                {
+                    'rel': 'collection',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
+                },
+            ]
+            self._check_stac_links('asset.links', links, current['links'])
 
     def _check_stac_dictsubset(self, parent_path, expected, current, ignore=None):
         for key, value in expected.items():


### PR DESCRIPTION
For the view using pagination, the ordering is done in the pagination class.
This one did not had the ability to easily configure different ordering
per view. This has been added via the get_ordering() method which checks
for ordering attribute in the view.

For the assets ordering within items, we needed to do the ordering in
the prefetch related and in the get_queryset() because assets don't uses
pagination.

I don't think this have a big impact on performance but those needs definitely to be tested with k6.io.

NOTE: to avoid conflict with migrations files with the PR #299  this PR is based on feature_BGDIINF_SB-1863_publish_flag. Once #299 is merged I'll set the branch to `develop` before merging this one.