### PR TITLE
BGDIINF_SB-1898: Avoid crash if request is missing the content-type header.

### DIFF
--- a/app/stac_api/apps.py
+++ b/app/stac_api/apps.py
@@ -47,7 +47,8 @@ def custom_exception_handler(exc, context):
 
         if (
             context['request']._request.method.upper() in ["PATCH", "POST", "PUT"] and
-            'application/json' in context['request']._request.headers['content-type'].lower()
+            'application/json' in context['request']._request.headers.get('content-type',
+                                                                          '').lower()
         ):
             extra["request.payload"] = context['request'].data
 


### PR DESCRIPTION
On prod we had some non authorized requests without content-type header
that crashed the service.