### PR TITLE
BGDIINF_SB-1983: `md5_parts` is now a mandatory parameter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,7 +63,6 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=missing-docstring,
-    fixme, # TODO BGDIINF_SB-1983 remove once all the todos have been done
     missing-module-docstring,
     unused-argument,
     unused-variable,

--- a/app/stac_api/apps.py
+++ b/app/stac_api/apps.py
@@ -5,7 +5,7 @@ import django.core.exceptions
 from django.apps import AppConfig
 from django.conf import settings
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
@@ -33,7 +33,7 @@ def custom_exception_handler(exc, context):
         message = exc.message
         if exc.params:
             message %= exc.params
-        exc = ValidationError(exc.message, exc.code)
+        exc = serializers.ValidationError(exc.message, exc.code)
 
     # Then call REST framework's default exception handler, to get the standard error response.
     response = exception_handler(exc, context)

--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -570,11 +570,7 @@ class AssetUpload(models.Model):
     number_parts = models.IntegerField(
         validators=[MinValueValidator(1), MaxValueValidator(100)], null=False, blank=False
     )  # S3 doesn't support more that 10'000 parts
-    # TODO BGDIINF_SB-1983 make the md5_parts mandatory by setting blank=False and removing
-    # the default=list
-    md5_parts = models.JSONField(
-        encoder=DjangoJSONEncoder, blank=True, default=list, editable=False
-    )
+    md5_parts = models.JSONField(encoder=DjangoJSONEncoder, editable=False)
     urls = models.JSONField(default=list, encoder=DjangoJSONEncoder, blank=True)
     created = models.DateTimeField(auto_now_add=True)
     ended = models.DateTimeField(blank=True, null=True, default=None)

--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -6,7 +6,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import pagination
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param
@@ -75,9 +75,8 @@ def validate_page_size(size_string, max_page_size, log_extra=None):
         logger.error(
             'Invalid query parameter limit=%s: must be an integer', size_string, extra=log_extra
         )
-        raise ValidationError(
-            _('invalid limit query parameter: must be an integer'),
-            code='limit'
+        raise serializers.ValidationError(
+            _('Invalid limit query parameter: must be an integer'),
         ) from None
 
     if page_size <= 0:
@@ -86,9 +85,8 @@ def validate_page_size(size_string, max_page_size, log_extra=None):
             page_size,
             extra=log_extra
         )
-        raise ValidationError(
+        raise serializers.ValidationError(
             _('limit query parameter too small, must be in range 1..%d') % (max_page_size),
-            code='limit'
         )
     if max_page_size and page_size > max_page_size:
         logger.error(
@@ -97,9 +95,8 @@ def validate_page_size(size_string, max_page_size, log_extra=None):
             max_page_size,
             extra=log_extra
         )
-        raise ValidationError(
-            _('limit query parameter too big, must be in range 1..%d') % (max_page_size),
-            code='limit'
+        raise serializers.ValidationError(
+            _('limit query parameter too big, must be in range 1..%d') % (max_page_size)
         )
     return page_size
 
@@ -125,9 +122,8 @@ def validate_offset(offset_string, log_extra=None):
         logger.error(
             'Invalid query parameter offset=%s: must be an integer', offset_string, extra=log_extra
         )
-        raise ValidationError(
-            _('invalid offset query parameter: must be an integer'),
-            code='invalid'
+        raise serializers.ValidationError(
+            _('Invalid offset query parameter: must be an integer')
         ) from None
 
     if offset < 0:
@@ -136,9 +132,8 @@ def validate_offset(offset_string, log_extra=None):
             offset,
             extra=log_extra
         )
-        raise ValidationError(
-            _('offset query parameter too small, must be positive'),
-            code='invalid'
+        raise serializers.ValidationError(
+            _('offset query parameter too small, must be positive')
         )
     return offset
 

--- a/app/stac_api/s3_multipart_upload.py
+++ b/app/stac_api/s3_multipart_upload.py
@@ -117,11 +117,9 @@ class MultipartUpload:
             'Bucket': settings.AWS_STORAGE_BUCKET_NAME,
             'Key': key,
             'UploadId': upload_id,
-            'PartNumber': part
+            'PartNumber': part,
+            'ContentMD5': part_md5,
         }
-        # TODO BGDIINF_SB-1983 part_md5 should be mandatory
-        if part_md5:
-            params['ContentMD5'] = part_md5
         url = self.call_s3_api(
             self.s3.generate_presigned_url,
             'upload_part',

--- a/app/stac_api/s3_multipart_upload.py
+++ b/app/stac_api/s3_multipart_upload.py
@@ -9,7 +9,7 @@ from multihash import to_hex_string
 
 from django.conf import settings
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 
 from stac_api.utils import get_s3_client
 from stac_api.utils import isoformat
@@ -178,7 +178,7 @@ class MultipartUpload:
                 }
             )
         except ClientError as error:
-            raise ValidationError(str(error), code='invalid') from None
+            raise serializers.ValidationError(str(error)) from None
 
         if 'Location' not in response:
             logger.error(

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
-from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.utils.serializer_helpers import ReturnDict
@@ -807,8 +807,9 @@ class AssetUploadSerializer(NonNullModelSerializer):
         if attrs.get('md5_parts') is not None:
             validate_md5_parts(attrs['md5_parts'], attrs['number_parts'])
         elif not self.partial:
-            raise ValidationError('md5_parts parameter not set')
-
+            raise serializers.ValidationError(
+                detail={'md5_parts': _('md5_parts parameter is missing')}, code='missing'
+            )
         return attrs
 
     def get_completed(self, obj):

--- a/app/stac_api/validators_view.py
+++ b/app/stac_api/validators_view.py
@@ -3,7 +3,7 @@ import logging
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 
 from stac_api.models import Asset
 from stac_api.models import Collection
@@ -100,4 +100,4 @@ def validate_renaming(serializer, original_id, id_field='name', extra_log=None):
         if data[id_field] != original_id:
             message = 'Renaming is not allowed'
             logger.error(message, extra=extra_log)
-            raise ValidationError({'id': _(message)}, code='invalid')
+            raise serializers.ValidationError({'id': _(message)})

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -623,17 +623,8 @@ class AssetUploadBase(generics.GenericAPIView):
             key, asset, validated_data['checksum_multihash']
         )
         urls = []
-        # TODO BGDIINF_SB-1983 md5_parts should be mandatory
-        if 'md5_parts' in validated_data:
-            sorted_md5_parts = sorted(validated_data['md5_parts'], key=itemgetter('part_number'))
-        else:
-            # dummy parts md5
-            sorted_md5_parts = map(
-                lambda i: {
-                    'part_number': i, 'md5': None
-                },
-                range(1, validated_data['number_parts'] + 1)
-            )
+        sorted_md5_parts = sorted(validated_data['md5_parts'], key=itemgetter('part_number'))
+
         for part in sorted_md5_parts:
             urls.append(
                 executor.create_presigned_url(

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import generics
 from rest_framework import mixins
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -666,11 +666,13 @@ class AssetUploadBase(generics.GenericAPIView):
         key = get_asset_path(asset.item, asset.name)
         parts = validated_data.get('parts', None)
         if parts is None:
-            raise ValidationError({'parts': _("Missing required field")}, code='missing')
+            raise serializers.ValidationError({
+                'parts': _("Missing required field")
+            }, code='missing')
         if len(parts) > asset_upload.number_parts:
-            raise ValidationError({'parts': [_("Too many parts")]}, code='invalid')
+            raise serializers.ValidationError({'parts': [_("Too many parts")]}, code='invalid')
         if len(parts) < asset_upload.number_parts:
-            raise ValidationError({'parts': [_("Too few parts")]}, code='invalid')
+            raise serializers.ValidationError({'parts': [_("Too few parts")]}, code='invalid')
         executor.complete_multipart_upload(key, asset, parts, asset_upload.upload_id)
         asset_upload.update_asset_checksum_multihash()
         asset_upload.status = AssetUpload.Status.COMPLETED

--- a/app/stac_api/views_mixins.py
+++ b/app/stac_api/views_mixins.py
@@ -4,8 +4,8 @@ from django.db import transaction
 from django.db.models.deletion import ProtectedError
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import serializers
 from rest_framework import status
-from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from stac_api.utils import get_link
@@ -160,6 +160,6 @@ class DestroyModelMixin:
                 child_name = 'items'
             elif instance.__class__.__name__ == 'Item':
                 child_name = 'assets'
-            raise ValidationError(
+            raise serializers.ValidationError(
                 _(f'Deleting {instance.__class__.__name__} with {child_name} not allowed')
             ) from None

--- a/app/tests/test_asset_upload_model.py
+++ b/app/tests/test_asset_upload_model.py
@@ -26,6 +26,7 @@ class AssetUploadTestCaseMixin:
             upload_id=upload_id,
             checksum_multihash=get_sha256_multihash(b'Test'),
             number_parts=1,
+            md5_parts=["this is an mad5 value"],
             **kwargs
         )
         asset_upload.full_clean()
@@ -129,7 +130,8 @@ class AssetUploadModelTestCase(TestCase, AssetUploadTestCaseMixin):
                 asset=self.asset_1,
                 upload_id='my-upload-id',
                 checksum_multihash=get_sha256_multihash(b'Test'),
-                number_parts=-1
+                number_parts=-1,
+                md5_parts=['fake_md5']
             )
             asset_upload.full_clean()
             asset_upload.save()

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -115,7 +115,8 @@ class ApiPaginationTestCase(StacBaseTestCase):
                 status=AssetUpload.Status.ABORTED,
                 checksum_multihash=get_sha256_multihash(b'upload-%d' % i),
                 number_parts=2,
-                ended=utc_aware(datetime.utcnow())
+                ended=utc_aware(datetime.utcnow()),
+                md5_parts=['md5-%d-1' % i, 'md5-%d-2' % i]
             )
         for endpoint, result_attribute in [
             ('collections', 'collections'),

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -87,7 +87,7 @@ class ApiPaginationTestCase(StacBaseTestCase):
 
                 response = self.client.get(f"/{STAC_BASE_V}/{endpoint}?limit=test")
                 self.assertStatusCode(400, response)
-                self.assertEqual(['invalid limit query parameter: must be an integer'],
+                self.assertEqual(['Invalid limit query parameter: must be an integer'],
                                  response.json()['description'],
                                  msg='Unexpected error message')
 

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -8,7 +8,7 @@ from pprint import pformat
 
 from django.conf import settings
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory
 
@@ -292,7 +292,7 @@ class CollectionDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = CollectionSerializer(data=data)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_collection_deserialization_invalid_link(self):
@@ -301,7 +301,7 @@ class CollectionDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = CollectionSerializer(data=data)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_collection_deserialization_invalid_provider(self):
@@ -310,7 +310,7 @@ class CollectionDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = CollectionSerializer(data=data)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
 
@@ -528,7 +528,7 @@ class ItemDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = ItemSerializer(data=data)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_item_deserialization_invalid_data(self):
@@ -539,7 +539,7 @@ class ItemDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = ItemSerializer(data=data)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_item_deserialization_end_date_before_start_date(self):
@@ -556,7 +556,7 @@ class ItemDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = ItemSerializer(data=sample.get_json('deserialize'))
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_item_deserialization_invalid_link(self):
@@ -567,7 +567,7 @@ class ItemDeserializationTestCase(StacBaseTestCase):
 
         # translate to Python native:
         serializer = ItemSerializer(data=sample.get_json('deserialize'))
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
 
@@ -706,7 +706,7 @@ class AssetDeserializationTestCase(StacBaseTestCase):
         serializer = AssetSerializer(
             data=sample.get_json('deserialize'), context={'request': request_mocker}
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_asset_deserialization_invalid_proj_epsg(self):
@@ -722,7 +722,7 @@ class AssetDeserializationTestCase(StacBaseTestCase):
         serializer = AssetSerializer(
             data=sample.get_json('deserialize'), context={'request': request_mocker}
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_asset_deserialization_missing_required_item(self):
@@ -740,5 +740,5 @@ class AssetDeserializationTestCase(StacBaseTestCase):
         serializer = AssetSerializer(
             data=sample.get_json('deserialize'), context={'request': request_mocker}
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/app/tests/test_serializer_asset_upload.py
+++ b/app/tests/test_serializer_asset_upload.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import uuid4
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 
 from stac_api.models import AssetUpload
 from stac_api.serializers import AssetUploadSerializer
@@ -31,11 +31,11 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
 
     def test_asset_upload_deserialization_invalid(self):
         serializer = AssetUploadSerializer(data={})
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(data={'checksum:multihash': ''})
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -43,7 +43,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 'checksum:multihash': get_sha256_multihash(b'Test'), 'number_parts': 0
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -51,7 +51,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 'checksum:multihash': get_sha256_multihash(b'Test'), 'number_parts': 10001
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
     def test_asset_upload_serialization_with_md5_parts(self):
@@ -128,7 +128,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -140,7 +140,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -152,7 +152,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -164,7 +164,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -176,7 +176,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -188,7 +188,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -200,7 +200,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -214,7 +214,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -228,7 +228,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -242,7 +242,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -252,7 +252,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 "md5_parts": ['yLLiDqX2OL7mcIMTjob60A==', 'yLLiDqX2OL7mcIMTjob60A==']
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -264,7 +264,7 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
         serializer = AssetUploadSerializer(
@@ -276,5 +276,5 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
                 }]
             }
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/app/tests/test_serializer_asset_upload.py
+++ b/app/tests/test_serializer_asset_upload.py
@@ -1,8 +1,6 @@
 # pylint: disable=too-many-lines
 
 import logging
-from datetime import datetime
-from datetime import timedelta
 from uuid import uuid4
 
 from rest_framework.exceptions import ValidationError
@@ -10,8 +8,6 @@ from rest_framework.exceptions import ValidationError
 from stac_api.models import AssetUpload
 from stac_api.serializers import AssetUploadSerializer
 from stac_api.utils import get_sha256_multihash
-from stac_api.utils import isoformat
-from stac_api.utils import utc_aware
 
 from tests.base_test import StacBaseTestCase
 from tests.data_factory import Factory
@@ -32,77 +28,6 @@ class AssetUploadSerializationTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         self.maxDiff = None  # pylint: disable=invalid-name
-
-    def test_asset_upload_serialization(self):
-        upload_id = str(uuid4())
-        checksum = get_sha256_multihash(b'Test')
-        asset_upload = AssetUpload(
-            asset=self.asset, upload_id=upload_id, checksum_multihash=checksum, number_parts=1
-        )
-        asset_upload.full_clean()
-        asset_upload.save()
-
-        serializer = AssetUploadSerializer(asset_upload)
-        data = serializer.data
-        self.assertEqual(data['upload_id'], upload_id)
-        self.assertEqual(data['checksum:multihash'], checksum)
-        self.assertEqual(data['status'], 'in-progress')
-        self.assertEqual(data['number_parts'], 1)
-        self.assertNotIn('urls', data)
-        self.assertNotIn('started', data)
-        self.assertNotIn('completed', data)
-        self.assertNotIn('aborted', data)
-
-        urls = [['http://example.com', 3600]]
-        started = utc_aware(datetime.utcnow())
-        ended = utc_aware(datetime.utcnow() + timedelta(seconds=5))
-        asset_upload.started = started
-        asset_upload.number_parts = 1
-        asset_upload.urls = urls
-        asset_upload.ended = ended
-        asset_upload.status = AssetUpload.Status.COMPLETED
-        asset_upload.full_clean()
-        asset_upload.save()
-
-        serializer = AssetUploadSerializer(asset_upload)
-        data = serializer.data
-        self.assertEqual(data['status'], 'completed')
-        self.assertEqual(data['urls'], urls)
-        self.assertEqual(data['completed'], isoformat(ended))
-        self.assertNotIn('aborted', data)
-        self.assertEqual(data['number_parts'], 1)
-
-        asset_upload.status = AssetUpload.Status.ABORTED
-        asset_upload.full_clean()
-        asset_upload.save()
-        serializer = AssetUploadSerializer(asset_upload)
-        data = serializer.data
-        self.assertEqual(data['status'], 'aborted')
-        self.assertEqual(data['aborted'], isoformat(ended))
-
-    def test_asset_upload_deserialization(self):
-        checksum = get_sha256_multihash(b'Test')
-        serializer = AssetUploadSerializer(data={'checksum:multihash': checksum, "number_parts": 1})
-        serializer.is_valid(raise_exception=True)
-        asset_upload = serializer.save(asset=self.asset)
-        self.assertEqual(asset_upload.checksum_multihash, checksum)
-        self.assertEqual(asset_upload.status, AssetUpload.Status.IN_PROGRESS)
-        self.assertEqual(asset_upload.ended, None)
-
-        ended = utc_aware(datetime.utcnow())
-        serializer = AssetUploadSerializer(
-            instance=asset_upload,
-            data={
-                'status': 'completed',
-                'checksum:multihash': asset_upload.checksum_multihash,
-                'ended': isoformat(ended),
-                "number_parts": 1
-            }
-        )
-        serializer.is_valid(raise_exception=True)
-        asset_upload = serializer.save(asset=asset_upload.asset)
-        self.assertEqual(asset_upload.ended, ended)
-        self.assertEqual(asset_upload.status, AssetUpload.Status.COMPLETED)
 
     def test_asset_upload_deserialization_invalid(self):
         serializer = AssetUploadSerializer(data={})

--- a/app/tests/test_validators.py
+++ b/app/tests/test_validators.py
@@ -1,7 +1,7 @@
-from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers
 
 from stac_api.validators import validate_item_properties_datetimes_dependencies
 from stac_api.validators_serializer import validate_asset_href_path
@@ -36,7 +36,8 @@ class TestValidators(TestCase):
             )
 
         with self.assertRaises(
-            ValidationError, msg="Invalid Asset href path did not raises ValidationError"
+            serializers.ValidationError,
+            msg="Invalid Asset href path did not raises serializers.ValidationError"
         ):
             validate_asset_href_path(item, 'asset-test', 'asset-test')
             validate_asset_href_path(item, 'asset-test', 'item-test/asset-test')
@@ -46,7 +47,7 @@ class TestValidators(TestCase):
             )
 
     def test_validate_function_invalid_datetime_string(self):
-        with self.assertRaises(DjangoValidationError):
+        with self.assertRaises(ValidationError):
             properties_datetime = None
             properties_start_datetime = "2001-22-66T08:00:00+00:00"
             properties_end_datetime = "2001-11-11T08:00:00+00:00"


### PR DESCRIPTION
Issue : md5_parts was an optional parameter while waiting for the users to adapt their scripts.
Fix: Now that those scripts are adapted, md5_parts is required for all uploads.

TODO: 
I'll check the tests, and ensure they work. 
I'll add a test that verifies that sending an upload request without the md5 fails