### PR TITLE
BGDIINF_SB-2083: Changed parent link to match STAC spec

### DIFF
--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -355,18 +355,7 @@ class CollectionSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         # We use OrderedDict, although it is not necessary, because the default serializer/model for
         # links already uses OrderedDict, this way we keep consistency between auto link and user
         # link
-        representation['links'][:0] = get_relation_links(request, 'collection-detail', [name]) + [
-            OrderedDict([
-                ('rel', 'items'),
-                ('href', get_url(request, 'items-list', [name])),
-            ]),
-            OrderedDict([
-                ("rel", "alternate"),
-                ("title", "STAC Browser"),
-                ("type", "text/html"),
-                ("href", get_browser_url(request, 'browser-collection', collection=name)),
-            ]),
-        ]
+        representation['links'][:0] = get_relation_links(request, 'collection-detail', [name])
         return representation
 
     def validate(self, attrs):
@@ -566,18 +555,9 @@ class AssetSerializer(AssetBaseSerializer):
         # We use OrderedDict, although it is not necessary, because the default serializer/model for
         # links already uses OrderedDict, this way we keep consistency between auto link and user
         # link
-        representation['links'] = \
-            get_relation_links(request, 'asset-detail', [collection, item, name]) \
-            + [
-                OrderedDict([
-                    ('rel', 'item'),
-                    ('href', get_url(request, 'item-detail', [collection, item])),
-                ]),
-                OrderedDict([
-                    ('rel', 'collection'),
-                    ('href', get_url(request, 'collection-detail', [collection])),
-                ])
-            ]
+        representation['links'] = get_relation_links(
+            request, 'asset-detail', [collection, item, name]
+        )
         return representation
 
 
@@ -661,22 +641,7 @@ class ItemSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         # We use OrderedDict, although it is not necessary, because the default serializer/model for
         # links already uses OrderedDict, this way we keep consistency between auto link and user
         # link
-        representation['links'][:0] = \
-            get_relation_links(request, 'item-detail', [collection, name]) \
-            + [
-                OrderedDict([
-                    ('rel', 'collection'),
-                    ('href', get_url(request, 'collection-detail', [collection])),
-                ]),
-                OrderedDict([
-                    ("rel", "alternate"),
-                    ("title", "STAC Browser"),
-                    ("type", "text/html"),
-                    ("href", get_browser_url(
-                        request, 'browser-item', collection=collection, item=name
-                    )),
-                ]),
-            ]
+        representation['links'][:0] = get_relation_links(request, 'item-detail', [collection, name])
         return representation
 
     def create(self, validated_data):

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -346,7 +346,7 @@ def get_url(request, view, args=None):
     return request.build_absolute_uri(reverse(view, args=args))
 
 
-def get_browser_url(request, view, collection='', item=''):
+def get_browser_url(request, view, collection=None, item=None):
     if settings.STAC_BROWSER_HOST:
         base = f'{settings.STAC_BROWSER_HOST}/{settings.STAC_BROWSER_BASE_PATH}'
     else:

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from collections import OrderedDict
 from datetime import datetime
 from operator import itemgetter
 
@@ -35,6 +34,7 @@ from stac_api.serializers import CollectionSerializer
 from stac_api.serializers import ConformancePageSerializer
 from stac_api.serializers import ItemSerializer
 from stac_api.serializers import LandingPageSerializer
+from stac_api.serializers_utils import get_relation_links
 from stac_api.utils import get_asset_path
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import utc_aware
@@ -143,6 +143,7 @@ def get_asset_upload_etag(request, *args, **kwargs):
 
 
 class LandingPageDetail(generics.RetrieveAPIView):
+    name = 'landing-page'  # this name must match the name in urls.py
     serializer_class = LandingPageSerializer
     queryset = LandingPage.objects.all()
 
@@ -151,6 +152,7 @@ class LandingPageDetail(generics.RetrieveAPIView):
 
 
 class ConformancePageDetail(generics.RetrieveAPIView):
+    name = 'conformance'  # this name must match the name in urls.py
     serializer_class = ConformancePageSerializer
     queryset = ConformancePage.objects.all()
 
@@ -159,6 +161,7 @@ class ConformancePageDetail(generics.RetrieveAPIView):
 
 
 class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
+    name = 'search-list'  # this name must match the name in urls.py
     permission_classes = [AllowAny]
     serializer_class = ItemSerializer
     pagination_class = GetPostCursorPagination
@@ -214,20 +217,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
             'type': 'FeatureCollection',
             'timeStamp': utc_aware(datetime.utcnow()),
             'features': serializer.data,
-            'links': [
-                OrderedDict([
-                    ('rel', 'self'),
-                    ('href', request.build_absolute_uri()),
-                ]),
-                OrderedDict([
-                    ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.STAC_BASE_V}/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'parent'),
-                    ('href', request.build_absolute_uri('.').rstrip('/')),
-                ])
-            ]
+            'links': get_relation_links(request, self.name)
         }
 
         if page is not None:
@@ -242,6 +232,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
 
 
 class CollectionList(generics.GenericAPIView):
+    name = 'collections-list'  # this name must match the name in urls.py
     serializer_class = CollectionSerializer
     # prefetch_related is a performance optimization to reduce the number
     # of DB queries.
@@ -257,23 +248,7 @@ class CollectionList(generics.GenericAPIView):
         else:
             serializer = self.get_serializer(queryset, many=True)
 
-        data = {
-            'collections': serializer.data,
-            'links': [
-                OrderedDict([
-                    ('rel', 'self'),
-                    ('href', request.build_absolute_uri()),
-                ]),
-                OrderedDict([
-                    ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.STAC_BASE_V}/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'parent'),
-                    ('href', request.build_absolute_uri('.')),
-                ])
-            ]
-        }
+        data = {'collections': serializer.data, 'links': get_relation_links(request, self.name)}
 
         if page is not None:
             return self.get_paginated_response(data)
@@ -286,6 +261,8 @@ class CollectionDetail(
     views_mixins.UpdateInsertModelMixin,
     views_mixins.DestroyModelMixin
 ):
+    # this name must match the name in urls.py and is used by the DestroyModelMixin
+    name = 'collection-detail'
     serializer_class = CollectionSerializer
     lookup_url_kwarg = "collection_name"
     lookup_field = "name"
@@ -338,6 +315,7 @@ class CollectionDetail(
 class ItemsList(generics.GenericAPIView):
     serializer_class = ItemSerializer
     ordering = ['name']
+    name = 'items-list'  # this name must match the name in urls.py
 
     def get_queryset(self):
         # filter based on the url
@@ -375,20 +353,7 @@ class ItemsList(generics.GenericAPIView):
             'type': 'FeatureCollection',
             'timeStamp': utc_aware(datetime.utcnow()),
             'features': serializer.data,
-            'links': [
-                OrderedDict([
-                    ('rel', 'self'),
-                    ('href', request.build_absolute_uri()),
-                ]),
-                OrderedDict([
-                    ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.STAC_BASE_V}/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'parent'),
-                    ('href', request.build_absolute_uri('.').rstrip('/')),
-                ])
-            ]
+            'links': get_relation_links(request, self.name, [self.kwargs['collection_name']])
         }
 
         if page is not None:
@@ -405,6 +370,8 @@ class ItemDetail(
     views_mixins.UpdateInsertModelMixin,
     views_mixins.DestroyModelMixin
 ):
+    # this name must match the name in urls.py and is used by the DestroyModelMixin
+    name = 'item-detail'
     serializer_class = ItemSerializer
     lookup_url_kwarg = "item_name"
     lookup_field = "name"
@@ -472,6 +439,7 @@ class ItemDetail(
 
 
 class AssetsList(generics.GenericAPIView):
+    name = 'assets-list'  # this name must match the name in urls.py
     serializer_class = AssetSerializer
     pagination_class = None
 
@@ -490,28 +458,10 @@ class AssetsList(generics.GenericAPIView):
 
         data = {
             'assets': serializer.data,
-            'links': [
-                OrderedDict([
-                    ('rel', 'self'),
-                    ('href', request.build_absolute_uri()),
-                ]),
-                OrderedDict([
-                    ('rel', 'root'),
-                    ('href', request.build_absolute_uri(f'/{settings.STAC_BASE_V}/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'parent'),
-                    ('href', request.build_absolute_uri('.').rstrip('/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'item'),
-                    ('href', request.build_absolute_uri('.').rstrip('/')),
-                ]),
-                OrderedDict([
-                    ('rel', 'collection'),
-                    ('href', request.build_absolute_uri('../..').rstrip('/')),
-                ])
-            ]
+            'links':
+                get_relation_links(
+                    request, self.name, [self.kwargs['collection_name'], self.kwargs['item_name']]
+                )
         }
         return Response(data)
 
@@ -522,6 +472,8 @@ class AssetDetail(
     views_mixins.UpdateInsertModelMixin,
     views_mixins.DestroyModelMixin
 ):
+    # this name must match the name in urls.py and is used by the DestroyModelMixin
+    name = 'asset-detail'
     serializer_class = AssetSerializer
     lookup_url_kwarg = "asset_name"
     lookup_field = "name"

--- a/app/stac_api/views_mixins.py
+++ b/app/stac_api/views_mixins.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 from rest_framework import status
 from rest_framework.response import Response
 
+from stac_api.serializers_utils import get_parent_link
 from stac_api.utils import get_link
 
 logger = logging.getLogger(__name__)
@@ -137,10 +138,13 @@ class DestroyModelMixin:
             {
                 "code": status.HTTP_200_OK,
                 "description": f"{instance} successfully deleted",
-                "links": [{
-                    "rel": "parent",
-                    "href": request.build_absolute_uri('/'.join(request.path.split('/')[:-1]))
-                }]
+                "links": [
+                    get_parent_link(
+                        request,
+                        self.get_view_name(),
+                        [self.kwargs.get('collection_name'), self.kwargs.get('item_name')]
+                    )
+                ]
             },
             status=status.HTTP_200_OK,
         )

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -145,7 +145,7 @@ class StacTestMixin:
             TEST_LINK_ROOT,
             {
                 'rel': 'parent',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections',
+                'href': f'{TEST_LINK_ROOT_HREF}/',
             },
             {
                 'rel': 'items',
@@ -198,7 +198,7 @@ class StacTestMixin:
             TEST_LINK_ROOT,
             {
                 'rel': 'parent',
-                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
             },
             {
                 'rel': 'collection',
@@ -253,7 +253,7 @@ class StacTestMixin:
                 TEST_LINK_ROOT,
                 {
                     'rel': 'parent',
-                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}/assets',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/items/{item}',
                 },
                 {
                     'rel': 'item',

--- a/app/tests/test_serializer.py
+++ b/app/tests/test_serializer.py
@@ -87,7 +87,7 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
                 ]),
                 OrderedDict([
                     ('rel', 'parent'),
-                    ('href', 'http://testserver/api/stac/v0.9/collections'),
+                    ('href', 'http://testserver/api/stac/v0.9/'),
                 ]),
                 OrderedDict([
                     ('rel', 'items'),
@@ -178,7 +178,7 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
                 ]),
                 OrderedDict([
                     ('rel', 'parent'),
-                    ('href', 'http://testserver/api/stac/v0.9/collections'),
+                    ('href', 'http://testserver/api/stac/v0.9/'),
                 ]),
                 OrderedDict([
                     ('rel', 'items'),

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -337,7 +337,7 @@ components:
                   rel: self
                 - href: https://data.geo.admin.ch/api/stac/v0.9/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+                - href: https://data.geo.admin.ch/api/stac/v0.9
                   rel: parent
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
@@ -666,7 +666,7 @@ components:
                   rel: self
                 - href: https://data.geo.admin.ch/api/stac/v0.9/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -520,7 +520,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v0.9
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: items
@@ -851,7 +851,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -1485,7 +1485,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v0.9
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: items
@@ -1816,7 +1816,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
@@ -2755,7 +2755,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
@@ -2781,7 +2781,7 @@ components:
               rel: self
             - href: https://data.geo.admin.ch/api/stac/v0.9/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
             - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
@@ -3574,7 +3574,7 @@ components:
                   The array contain at least a link to the parent resource (`rel:
                   parent`).
                 example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
             required:
             - code

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -40,7 +40,7 @@ components:
                 description: >-
                   The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                     rel: parent
             required:
               - code

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -77,7 +77,7 @@ components:
                   rel: self
                 - href: https://data.geo.admin.ch/api/stac/v0.9/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
                   rel: parent
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
                   rel: item
@@ -103,7 +103,7 @@ components:
                   rel: self
                 - href: https://data.geo.admin.ch/api/stac/v0.9/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
                   rel: parent
                 - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
                   rel: item


### PR DESCRIPTION
The parent link for a Collection or an Item, based on the STAC
spec should be respectively the landing page `/` (catalog) and the
collection `/<collection>` instead of the `/collections` and
`/collections/<collection>/items`. This is also required by the STAC
Browser, see (https://github.com/radiantearth/stac-browser/issues/105)

The generated links have also been consolidated in one method to
simplify the maintenance. For this simplification we base the generation
of the links based on the route name given in the urls.py. For the
DestroyMixin as it is used by several vues we could not use directly the
route name, therefore we added the route name to every view as name.