### PR TITLE
BGDIINF_SB-2210: Fixed the STAC Browser links v3

### DIFF
--- a/app/stac_api/serializers_utils.py
+++ b/app/stac_api/serializers_utils.py
@@ -66,7 +66,7 @@ view_relations = {
     },
     'collections-list': {
         'parent': 'landing-page',
-        'browser': 'browser-collection',
+        'browser': 'browser-catalog',
     },
     'collection-detail': {
         'parent': 'landing-page',
@@ -74,7 +74,7 @@ view_relations = {
     },
     'items-list': {
         'parent': 'collection-detail',
-        'browser': 'browser-item',
+        'browser': 'browser-collection',
     },
     'item-detail': {
         'parent': 'collection-detail',

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -352,12 +352,18 @@ def get_browser_url(request, view, collection=None, item=None):
         base = request.build_absolute_uri(f'/{settings.STAC_BROWSER_BASE_PATH}')
 
     if view == 'browser-catalog':
-        return f'{base}'
-    if view == 'browser-collection':
+        return f'{base}#/'
+    if view == 'browser-collection' and collection:
         return f'{base}#/collections/{collection}'
-    if view == 'browser-item':
+    if view == 'browser-item' and collection and item:
         return f'{base}#/collections/{collection}/items/{item}'
-    logger.error('Unknown view "%s", return the STAC browser base url %s', view, base)
+    logger.error(
+        'Failed to return STAC browser url for view=%s, collection=%s, item=%s, use then url=%s',
+        view,
+        collection,
+        item,
+        base
+    )
     return base
 
 

--- a/app/tests/test_collections_summaries.py
+++ b/app/tests/test_collections_summaries.py
@@ -168,7 +168,7 @@ class CollectionsSummariesTestCase(StacBaseTransactionTestCase):
 
     def test_update_collection_summaries_empty_asset_delete(self):
         # This test has been introduced due to a bug when removing an asset without eo:gsd,
-        # proj:espg and geoadmin:variant from a collections with summaries
+        # proj:epsg and geoadmin:variant from a collections with summaries
         self.assertListEqual(self.collection.summaries_proj_epsg, [])
         self.assertListEqual(self.collection.summaries_geoadmin_variant, [])
         self.assertListEqual(self.collection.summaries_geoadmin_lang, [])


### PR DESCRIPTION
For the collections page as well as the items list page, the STAC browser
links where not correct. The collection and item name where None.

With the v3 STAC browser there is no specific page for the items list.