### PR TITLE
BGDIINF_SB-2713: Fixed CORS headers for landing page (STAC Browser)

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -94,6 +94,7 @@ MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'middleware.logging.RequestResponseLoggingMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'middleware.cors.CORSHeadersMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -102,7 +103,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'middleware.cache_headers.CacheHeadersMiddleware',
-    'middleware.cors.CORSHeadersMiddleware',
     'middleware.exception.ExceptionLoggingMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -101,6 +101,15 @@ class StacTestMixin:
             expected_path, urlparse(response['Location']).path, msg="Wrong location path"
         )
 
+    def check_header_cors(self, response):
+        for header, value in {
+            'Access-Control-Allow-Headers': 'Content-Type,Accept',
+            'Access-Control-Allow-Methods': 'GET,HEAD',
+            'Access-Control-Allow-Origin': '*'
+        }.items():
+            self.assertTrue(response.has_header(header), msg=f"{header}: header is missing")
+            self.assertEqual(response[header], value)
+
     def check_stac_collection(self, expected, current, ignore=None):
         '''Check a STAC Collection data
 

--- a/app/tests/test_landing_page.py
+++ b/app/tests/test_landing_page.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from django.test import Client
-from django.test import TestCase
+
+from tests.base_test import StacBaseTestCase
 
 
-class IndexTestCase(TestCase):
+class IndexTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
@@ -27,3 +28,9 @@ class IndexTestCase(TestCase):
                 set(),
                 msg="missing required attribute in the answer['links'] array"
             )
+
+    def test_landing_page_redirect(self):
+        response = self.client.get(f"/{settings.STAC_BASE_V}")
+        self.assertEqual(response.status_code, 301)
+        self.check_header_location(f"/{settings.STAC_BASE_V}/", response)
+        self.check_header_cors(response)


### PR DESCRIPTION
The STAC browser might tries to access the landing page without trailing slash:

`/api/stac/v0.9`

Which would be automatically redirected to `/api/stac/v0.9/` by the
`django.middleware.common.CommonMiddleware`.

Due to this we need to put the CORS header middleware before the `CommonMiddleware`
otherwise the redirect would not have the correct CORS headers and the STAC
Browser would not be able to access our API from another origin.