### PR TITLE
BGDIINF_SB-2714: Made Gunicorn worker tmp dir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ The service is configured by Environment Variable:
 | PAGE_SIZE_LIMIT | `100` | Maximum page size allowed |
 | STAC_BROWSER_HOST | `None` | STAC Browser host (including HTTP schema). When `None` it takes the same host as the STAC API. |
 | STAC_BROWSER_BASE_PATH | `browser/index.html` | STAC Browser base path. |
+| GUNICORN_WORKERS | `2` | Number of Gunicorn workers |
+| GUNICORN_WORKER_TMP_DIR | `None` | Path to a tmpfs directory for Gunicorn. If `None` let gunicorn decide which path to use. See https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir. |
 
 #### **Database settings**
 

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -66,7 +66,9 @@ if __name__ == '__main__':
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),
         'worker_class': 'gevent',
-        'workers': 2,  # scaling horizontally is left to Kubernetes
+        'workers': int(os.environ.get('GUNICORN_WORKERS',
+                                      '2')),  # scaling horizontally is left to Kubernetes
+        'worker_tmp_dir': os.environ.get('GUNICORN_WORKER_TMP_DIR', None),
         'timeout': 60,
         'logconfig_dict': get_logging_config()
     }


### PR DESCRIPTION
This is required in order to assure that the tmp dir is on a tempfs file system
to improve performance, see https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir.