### PR TITLE
BGDIINF_SB-2714: Dockerfile now sets worker_tmp_dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,14 @@ ENV USER=geoadmin
 ENV GROUP=geoadmin
 ENV INSTALL_DIR=/opt/service-stac
 ENV SRC_DIR=/usr/local/src/service-stac
+# K8S mounts a memory fs on this location to increase performance
+ENV GUNICORN_WORKER_TMP_DIR=/tmp/gunicorn-workers
 ENV PIPENV_VENV_IN_PROJECT=1
 
 RUN groupadd -r ${GROUP} \
     && useradd -r -s /bin/false -g ${GROUP} ${USER} \
-    && mkdir -p ${INSTALL_DIR}/logs && chown ${USER}:${GROUP} ${INSTALL_DIR}/logs
+    && mkdir -p ${INSTALL_DIR}/logs && chown ${USER}:${GROUP} ${INSTALL_DIR}/logs \
+    && mkdir -p ${GUNICORN_WORKER_TMP_DIR} && chown ${USER}:${GROUP} ${GUNICORN_WORKER_TMP_DIR}
 
 EXPOSE $HTTP_PORT
 # entrypoint is the manage command

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -19,6 +19,9 @@ services:
     command: test --verbosity=2 --parallel=10 --no-input
     depends_on:
       - db
+    volumes:
+      - type: tmpfs
+        target: /tmp/gunicorn-workers
     environment:
       - DEBUG=True
       - LOGGING_CFG=/opt/service-stac/app/config/logging-cfg-unittest-ci.yml


### PR DESCRIPTION
Fixed the worker tmp dir to a known directory in Dockerfile so that k8s can then mount a memory file system on that dir. This should increase performance at least by a factor 2.

Already deployed on dev last Friday.