### PR TITLE
BGDIINF_SB-2707: Now serializer is more permissive with mime types

### DIFF
--- a/app/stac_api/management/commands/write_perftests.py
+++ b/app/stac_api/management/commands/write_perftests.py
@@ -8,7 +8,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.core.management.base import BaseCommand
 
 from stac_api.utils import CommandHandler
-from stac_api.validators import MEDIA_TYPES_BY_TYPE
+from stac_api.validators import get_media_type
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class Handler(CommandHandler):
             return self.get_data_item(i, name=name)
         # else assets
         if init_data:
-            return self.get_data_asset(i, name=name, media_type=init_data['type'])
+            return self.get_data_asset(i, name=name, media_type_str=init_data['type'])
         return self.get_data_asset(i, name=name)
 
     def get_data_item(self, i, name=None):
@@ -173,21 +173,21 @@ class Handler(CommandHandler):
             'properties': self.get_item_properties(i)
         }
 
-    def get_data_asset(self, i, name=None, media_type=None):
-        media_types = ['text/plain', 'application/json', 'image/tiff; application=geotiff']
+    def get_data_asset(self, i, name=None, media_type_str=None):
+        media_type_strings = ['text/plain', 'application/json', 'image/tiff; application=geotiff']
         variants = [None, 'krel', 'komb', 'geoadmin']
         eo_gsds = [None, 1, 0.3, None, 4, 3.2, None]
         proj_epsgs = [None, 2056, None, 4326, 21726]
 
-        if media_type is None:
-            media_type = media_types[i % len(media_types)]
+        if media_type_str is None:
+            media_type_str = media_type_strings[i % len(media_type_strings)]
         variant = variants[i % len(variants)]
         eo_gsd = eo_gsds[i % len(eo_gsds)]
         proj_epsg = proj_epsgs[i % len(proj_epsgs)]
-        ext = MEDIA_TYPES_BY_TYPE[media_type][2][0]
+        ext = get_media_type(media_type_str)[2][0]
         data = {
             'id': name if name else f'{ self.get_name(i)}.{ext}',
-            'type': media_type,
+            'type': media_type_str,
         }
         if variant is not None:
             data['geoadmin:variant'] = variant

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -468,8 +468,8 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         required=False, max_length=255, allow_null=True, allow_blank=False
     )
     description = serializers.CharField(required=False, allow_blank=False, allow_null=True)
-    # Can't be a ChoiceField, as  the validate method normalizes the MIME string only after it
-    # is read. Consistency is nevertheless guaranteed by the validate method.
+    # Can't be a ChoiceField, as the validate method normalizes the MIME string only after it
+    # is read. Consistency is nevertheless guaranteed by the validate() and validate_type() methods.
     type = serializers.CharField(
         source='media_type', required=True, allow_null=False, allow_blank=False
     )
@@ -519,6 +519,8 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         return asset, created
 
     def validate_type(self, value):
+        ''' Validates the the field "type"
+        '''
         return normalize_and_validate_media_type(value)
 
     def validate(self, attrs):

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -30,7 +30,7 @@ from stac_api.utils import build_asset_href
 from stac_api.utils import get_browser_url
 from stac_api.utils import get_url
 from stac_api.utils import isoformat
-from stac_api.validators import MEDIA_TYPES_MIMES
+from stac_api.validators import normalize_and_validate_media_type
 from stac_api.validators import validate_asset_name
 from stac_api.validators import validate_asset_name_with_media_type
 from stac_api.validators import validate_checksum_multihash_sha256
@@ -468,12 +468,10 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         required=False, max_length=255, allow_null=True, allow_blank=False
     )
     description = serializers.CharField(required=False, allow_blank=False, allow_null=True)
-    type = serializers.ChoiceField(
-        source='media_type',
-        required=True,
-        choices=MEDIA_TYPES_MIMES,
-        allow_null=False,
-        allow_blank=False
+    # Can't be a ChoiceField, as  the validate method normalizes the MIME string only after it
+    # is read. Consistency is nevertheless guaranteed by the validate method.
+    type = serializers.CharField(
+        source='media_type', required=True, allow_null=False, allow_blank=False
     )
     # Here we need to explicitely define these fields with the source, because they are renamed
     # in the get_fields() method
@@ -520,14 +518,15 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         asset, created = Asset.objects.update_or_create(**look_up, defaults=validated_data)
         return asset, created
 
+    def validate_type(self, value):
+        return normalize_and_validate_media_type(value)
+
     def validate(self, attrs):
-        if not self.partial:
-            validate_asset_name_with_media_type(attrs.get('name'), attrs.get('media_type'))
-        if self.partial and ('name' in attrs or 'media_type' in attrs):
-            validate_asset_name_with_media_type(
-                attrs.get('name', self.instance.name),
-                attrs.get('media_type', self.instance.media_type)
-            )
+        name = attrs['name'] if not self.partial else attrs.get('name', self.instance.name)
+        media_type = attrs['media_type'] if not self.partial else attrs.get(
+            'media_type', self.instance.media_type
+        )
+        validate_asset_name_with_media_type(name, media_type)
 
         validate_json_payload(self)
 

--- a/app/tests/data_factory.py
+++ b/app/tests/data_factory.py
@@ -105,7 +105,7 @@ from stac_api.models import ItemLink
 from stac_api.models import Provider
 from stac_api.utils import get_s3_resource
 from stac_api.utils import isoformat
-from stac_api.validators import MEDIA_TYPES_BY_TYPE
+from stac_api.validators import get_media_type
 
 from tests.sample_data.asset_samples import assets as asset_samples
 from tests.sample_data.collection_samples import collections as collection_samples
@@ -1140,9 +1140,10 @@ class AssetFactory(FactoryBase):
                 raise KeyError(f'Unknown {sample_name} sample: {error}') from None
             if 'media_type' in sample:
                 media = sample['media_type']
-        if media not in MEDIA_TYPES_BY_TYPE:
-            media = 'text/plain'
-        return MEDIA_TYPES_BY_TYPE[media][2][0]
+        try:
+            return get_media_type(media).extensions[0]
+        except KeyError:
+            return get_media_type('text/plain').extensions[0]
 
 
 class Factory:

--- a/app/tests/sample_data/asset_samples.py
+++ b/app/tests/sample_data/asset_samples.py
@@ -4,6 +4,9 @@ FILE_CONTENT_1 = b'Asset 1 file content'
 FILE_CONTENT_2 = b'Asset 2 file content'
 FILE_CONTENT_3 = b'Asset 3 file content'
 
+# The keys here are the attribute keys of the model. They are translated to
+# json keys when the api is called. (e.g. "name" will be translated to "id" when
+# making an api call)
 assets = {
     'asset-1': {
         'name': 'asset-1.tiff',
@@ -72,6 +75,18 @@ assets = {
         'proj_epsg': 'should be an int',
         'media_type': "dummy",
         'file': b'Asset 3 file content'
+    },
+    'asset-invalid-type': {
+        'name': 'asset-invalid-type.tiff',
+        'title': 'Asset invalid type Title',
+        'description': 'This is a full description of asset-invalid-type',
+        'eo_gsd': 3.4,
+        'geoadmin_lang': 'fr',
+        'geoadmin_variant': 'kgrs',
+        'proj_epsg': 2056,
+        'media_type': "image/tiff; application=Geotiff; profile=cloud-optimized",
+        'checksum_multihash': get_sha256_multihash(FILE_CONTENT_1),
+        'file': FILE_CONTENT_1
     },
     'asset-missing-required': {
         'name': 'asset-missing-required',

--- a/app/tests/test_asset_model.py
+++ b/app/tests/test_asset_model.py
@@ -116,7 +116,7 @@ class AssetsModelTestCase(StacBaseTransactionTestCase):
             exception.messages
         )
         self.assertIn(
-            'Invalid media type application/vnd.oai.openapi+yaml;version=3.0', exception.messages
+            'Invalid media type "application/vnd.oai.openapi+yaml;version=3.0"', exception.messages
         )
 
         with self.assertRaises(


### PR DESCRIPTION
Before, the serializer only accepted exact matches. Now it accepts any
equivalent media types, i.e.:
- Optional spaces between the parameters
- Types, subtypes and parameter names are case insensitive
- Order of parameters not important

The database however still only accepts the "normalized" variant.