### PR TITLE
Fixed gunicorn tmp dir worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,11 @@ ENV USER=geoadmin
 ENV GROUP=geoadmin
 ENV INSTALL_DIR=/opt/service-stac
 ENV SRC_DIR=/usr/local/src/service-stac
-# K8S mounts a memory fs on this location to increase performance
-ENV GUNICORN_WORKER_TMP_DIR=/tmp/gunicorn-workers
 ENV PIPENV_VENV_IN_PROJECT=1
 
 RUN groupadd -r ${GROUP} \
     && useradd -r -s /bin/false -g ${GROUP} ${USER} \
-    && mkdir -p ${INSTALL_DIR}/logs && chown ${USER}:${GROUP} ${INSTALL_DIR}/logs \
-    && mkdir -p ${GUNICORN_WORKER_TMP_DIR} && chown ${USER}:${GROUP} ${GUNICORN_WORKER_TMP_DIR}
+    && mkdir -p ${INSTALL_DIR}/logs && chown ${USER}:${GROUP} ${INSTALL_DIR}/logs
 
 EXPOSE $HTTP_PORT
 # entrypoint is the manage command


### PR DESCRIPTION
The gunicorn temporary dir for worker should not be created and set by the
docker image but left to the deployment (aka k8s) which needs to ensure to have
it on tmpfs.

See also https://github.com/geoadmin/infra-kubernetes/pull/315