### PR TITLE
BGDIINF_SB-2827: Removed auto abort asset upload on duplicate upload to fix integrity crash

### DIFF
--- a/app/stac_api/s3_multipart_upload.py
+++ b/app/stac_api/s3_multipart_upload.py
@@ -29,10 +29,6 @@ class MultipartUpload:
     def __init__(self):
         self.s3 = get_s3_client()
 
-    @property
-    def client(self):
-        return self.s3
-
     def list_multipart_uploads(self, key=None, limit=100, start=None):
         '''List all in progress multipart uploads
 

--- a/app/stac_api/s3_multipart_upload.py
+++ b/app/stac_api/s3_multipart_upload.py
@@ -29,6 +29,10 @@ class MultipartUpload:
     def __init__(self):
         self.s3 = get_s3_client()
 
+    @property
+    def client(self):
+        return self.s3
+
     def list_multipart_uploads(self, key=None, limit=100, start=None):
         '''List all in progress multipart uploads
 

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -602,28 +602,11 @@ class AssetUploadBase(generics.GenericAPIView):
             item__collection__name=self.kwargs['collection_name']
         )
 
-    def create_multipart_upload(self, executor, serializer, validated_data, asset):
-        key = get_asset_path(asset.item, asset.name)
-        upload_id = executor.create_multipart_upload(
-            key, asset, validated_data['checksum_multihash'], validated_data['update_interval']
-        )
-        urls = []
-        sorted_md5_parts = sorted(validated_data['md5_parts'], key=itemgetter('part_number'))
-
-        for part in sorted_md5_parts:
-            urls.append(
-                executor.create_presigned_url(
-                    key, asset, part['part_number'], upload_id, part['md5']
-                )
-            )
-
-        clean_up_required = False
+    def _save_asset_upload(self, executor, serializer, key, asset, upload_id, urls):
         try:
             with transaction.atomic():
                 serializer.save(asset=asset, upload_id=upload_id, urls=urls)
         except IntegrityError as error:
-            exception_handled = False
-            clean_up_required = True
             logger.error(
                 'Failed to create asset upload multipart: %s',
                 error,
@@ -633,19 +616,32 @@ class AssetUploadBase(generics.GenericAPIView):
                     'asset': asset.name
                 }
             )
-            in_progress = self.get_in_progress_queryset()
-            if bool(in_progress):
-                # Abort the last upload in progress and retry
-                self.abort_multipart_upload(executor, in_progress.get(), asset)
-                # And retry to save the new upload
-                serializer.save(asset=asset, upload_id=upload_id, urls=urls)
-                exception_handled = True
-                clean_up_required = False
-            if not exception_handled:
-                raise
-        finally:
-            if clean_up_required:
-                executor.abort_multipart_upload(key, asset, upload_id)
+            if bool(self.get_in_progress_queryset()):
+                raise serializers.ValidationError(
+                    code='unique', detail=_('Upload already in progress')
+                ) from None
+            raise
+
+    def create_multipart_upload(self, executor, serializer, validated_data, asset):
+        key = get_asset_path(asset.item, asset.name)
+        upload_id = executor.create_multipart_upload(
+            key, asset, validated_data['checksum_multihash'], validated_data['update_interval']
+        )
+        urls = []
+        sorted_md5_parts = sorted(validated_data['md5_parts'], key=itemgetter('part_number'))
+
+        try:
+            for part in sorted_md5_parts:
+                urls.append(
+                    executor.create_presigned_url(
+                        key, asset, part['part_number'], upload_id, part['md5']
+                    )
+                )
+
+            self._save_asset_upload(executor, serializer, key, asset, upload_id, urls)
+        except serializers.ValidationError as err:
+            executor.abort_multipart_upload(key, asset, upload_id)
+            raise
 
     def complete_multipart_upload(self, executor, validated_data, asset_upload, asset):
         key = get_asset_path(asset.item, asset.name)

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -439,7 +439,7 @@ class StacTestMixin:
             self.assertAlmostEqual(
                 fromisoformat(value),
                 fromisoformat(current[key]),
-                delta=timedelta(seconds=1),
+                delta=timedelta(seconds=2),
                 msg=f'{path}: current datetime value is not equal to the expected'
             )
         elif key == 'href':

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -54,8 +54,8 @@ class StacTestMixin:
                 return msg
             return 'Wrong status code'
 
-        code = code if isinstance(code, list) else [code]
-        self.assertIn(response.status_code, code, msg=get_error_msg(response.status_code))
+        codes = code if isinstance(code, list) else [code]
+        self.assertIn(response.status_code, codes, msg=get_error_msg(response.status_code))
         if response.status_code in [412, 304]:
             # HTTP 412 Precondition Failed and 304 Not Modified doesn't have a body.
             self.assertEqual(b'', response.content)

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -35,8 +35,8 @@ class StacTestMixin:
         against the `code` and `description` keys.
 
         Args:
-            code: int
-                Expected HTTP code
+            code: int | [int]
+                Expected HTTP code(s)
             response: HttpResponse
                 HTTP Response object to check
 			msg: string
@@ -54,11 +54,12 @@ class StacTestMixin:
                 return msg
             return 'Wrong status code'
 
-        self.assertEqual(code, response.status_code, msg=get_error_msg(response.status_code))
-        if code in [412, 304]:
+        code = code if isinstance(code, list) else [code]
+        self.assertIn(response.status_code, code, msg=get_error_msg(response.status_code))
+        if response.status_code in [412, 304]:
             # HTTP 412 Precondition Failed and 304 Not Modified doesn't have a body.
             self.assertEqual(b'', response.content)
-        elif code >= 400:
+        elif response.status_code >= 400:
             self.assertIn('code', json_data.keys(), msg="'code' is missing from response")
             self.assertIn(
                 'description', json_data.keys(), msg="'description' is missing from response"
@@ -67,7 +68,7 @@ class StacTestMixin:
                 isinstance(json_data['description'], (list, str, dict)),
                 msg=f"Description wrong type: {type(json_data['description'])}"
             )
-            self.assertEqual(code, json_data['code'], msg="invalid response code")
+            self.assertEqual(response.status_code, json_data['code'], msg="invalid response code")
 
     def assertCacheControl(self, response, max_age=None, no_cache=False):  # pylint: disable=invalid-name
         '''Assert that Cache-Control header is present and correct
@@ -470,7 +471,7 @@ class StacBaseTransactionTestCase(TransactionTestCase, StacTestMixin):
 
     def run_parallel(self, workers, func):
         errors = []
-        responses = []
+        results = []
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = {}
             for worker in range(workers):
@@ -483,15 +484,15 @@ class StacBaseTransactionTestCase(TransactionTestCase, StacTestMixin):
                 except Exception as exc:  # pylint: disable=broad-except
                     errors.append((futures[future], str(exc)))
                 else:
-                    responses.append((futures[future], response))
+                    results.append((futures[future], response))
 
         self.assertEqual(
-            len(responses) + len(errors),
+            len(results) + len(errors),
             workers,
-            msg='Number of responses/errors doesn\'t match the number of worker'
+            msg='Number of results/errors doesn\'t match the number of worker'
         )
 
         for worker, error in errors:
             self.fail(msg=f'Worker {worker} failed: {error}')
 
-        return responses, errors
+        return results, errors

--- a/app/tests/utils.py
+++ b/app/tests/utils.py
@@ -1,6 +1,7 @@
 import functools
 import hashlib
 import logging
+import os
 import time
 from io import BytesIO
 
@@ -218,3 +219,18 @@ class disableLogger:  # pylint: disable=invalid-name
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.logger.disabled = False
+
+
+def get_file_like_object(size):
+    '''Get a random file like object of size with its sha256 checksum
+
+    Args:
+        size: int
+            size of the file like object to retrieve
+
+    Returns: obj, str
+        Random file like object and its sha256 multihash checksum
+    '''
+    file_like = os.urandom(size)
+    checksum_multihash = get_sha256_multihash(file_like)
+    return file_like, checksum_multihash


### PR DESCRIPTION
Only one asset upload is allowed at a time, before it used to automatically
abort ongoing upload when creating a new upload. The implementation had an
issue when multiple create upload happened on parallel, it crashed the service
due to race condition.

Making parallel or multiple create upload doesn't make sense as only one call
will be valid and the user will not know which one. E.g. if a user do two
requests in a row, both would have return 201 but only one of it would have
been valid and we could not ensure which one, could be the first or the second !

To avoid such random cases, we removed the auto abort mechanism. This means
that if multiple requests are sent at a time it is guarantied that only one
would be successful with 201 and valid. The others will returns 400 Bad Request
- Asset upload already in progress.

Improved a bit the test code.