### PR TITLE
BGDIINF_SB-2827: Fixed asset upload integrity crash

### DIFF
--- a/app/stac_api/s3_multipart_upload.py
+++ b/app/stac_api/s3_multipart_upload.py
@@ -29,6 +29,10 @@ class MultipartUpload:
     def __init__(self):
         self.s3 = get_s3_client()
 
+    @property
+    def client(self):
+        return self.s3
+
     def list_multipart_uploads(self, key=None, limit=100, start=None):
         '''List all in progress multipart uploads
 


### PR DESCRIPTION
Allow to have at least two consecutive/parallel call to create asset upload.

This solution works but one of the call will be invalid although it returns
HTTP 201 ! This is not very user friendly.