### PR TITLE
BGDIINF_SB-2799: Fixed compression issue with Cloudfront

### DIFF
--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -395,7 +395,8 @@ def get_dynamic_max_age_value(update_interval):
     '''Get the max_age value for dynamic cache based on `update_interval` DB field
 
     -       update_interval < 0  then use default cache settings
-    -  0 <= update_interval < 10 then no cache
+    -  0 == update_interval then no cache
+    -  0 < update_interval < 10 then cache of 1s
     - 10 <= update_interval then log10(update_interval)*log9(update_interval)
     Args:
         update_interval: int
@@ -406,8 +407,11 @@ def get_dynamic_max_age_value(update_interval):
     '''
     threshold_no_cache = 10
     max_threshold = 60 * 60  # 1h
-    if 0 <= update_interval < threshold_no_cache:
+    if 0 == update_interval < threshold_no_cache:
         return 0  # means never cache
+
+    if 0 < update_interval < threshold_no_cache:
+        return 1
 
     if threshold_no_cache <= update_interval < max_threshold:
         return int(math.log(update_interval, 10) * math.log(update_interval, 9))

--- a/app/tests/test_asset_upload_endpoint.py
+++ b/app/tests/test_asset_upload_endpoint.py
@@ -413,7 +413,7 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         self.assertS3ObjectCacheControl(key, max_age=8)
 
     def test_asset_upload_no_cache(self):
-        key = self.upload_asset_with_dyn_cache(update_interval=5)
+        key = self.upload_asset_with_dyn_cache(update_interval=0)
         self.assertS3ObjectExists(key)
         self.assertS3ObjectCacheControl(key, no_cache=True)
 

--- a/app/tests/test_generic_api.py
+++ b/app/tests/test_generic_api.py
@@ -531,7 +531,7 @@ class ApiNoCacheHeaderTestCase(StacBaseTestCase, S3TestMixin):
         self.collection = self.factory.create_collection_sample(name='collection-1').model
         self.item = self.factory.create_item_sample(collection=self.collection, name='item-1').model
         self.asset = self.factory.create_asset_sample(
-            item=self.item, db_create=True, create_asset_file=True, update_interval=5
+            item=self.item, db_create=True, create_asset_file=True, update_interval=0
         ).model
 
     def test_get_no_cache_header(self):

--- a/app/tests/test_search_endpoint.py
+++ b/app/tests/test_search_endpoint.py
@@ -551,7 +551,7 @@ class SearchEndpointCacheSettingTestCase(StacBaseTestCase):
         self.assertCacheControl(response, max_age=3)
 
     def test_get_search_no_cache_setting(self):
-        self.factory.create_asset_sample(self.items[0].model, db_create=True, update_interval=5)
+        self.factory.create_asset_sample(self.items[0].model, db_create=True, update_interval=0)
         response = self.client.get(reverse('search-list'))
         self.assertStatusCode(200, response)
         self.assertCacheControl(response, no_cache=True)


### PR DESCRIPTION
Cloudfront requires at least a TTL of 1s in order to compress data.
So only set no cache when the update_interval is 0.