### PR TITLE
BGDIINF_SB-2835: Added content_encoding in spec for asset upload

### DIFF
--- a/spec/components/headers.yaml
+++ b/spec/components/headers.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   headers:
     ETag:

--- a/spec/components/parameters.yaml
+++ b/spec/components/parameters.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   parameters:
     assetQuery:

--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   responses:
     Collection:

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   schemas:
     assetQuery:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 info:
   contact:
     name: API Specification (based on STAC)

--- a/spec/static/spec/v0.9/openapi.yaml
+++ b/spec/static/spec/v0.9/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 info:
   contact:
     name: API Specification (based on STAC)

--- a/spec/static/spec/v0.9/openapitransactional.yaml
+++ b/spec/static/spec/v0.9/openapitransactional.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 info:
   contact:
     name: API Specification (based on STAC)
@@ -3708,6 +3708,8 @@ components:
           $ref: "#/components/schemas/md5_parts"
         update_interval:
           $ref: "#/components/schemas/update_interval"
+        content_encoding:
+          $ref: "#/components/schemas/content_encoding"
         urls:
           type: array
           description: |
@@ -3891,6 +3893,19 @@ components:
       minimum: -1
       maximum: 604800
       example: 30
+    content_encoding:
+      description: |
+        Content Encoding of the asset if compressed.
+
+        Tell the backend that the Asset data is compressed, this will add the `Content-Encoding` header
+        on the asset requests.
+
+        *NOTE:*
+         - *when uploading compressed data: the `checksum:multihash` refers to the checksum of the
+           uncompressed data, while the md5 checksum must be calculated of the compressed data*
+      type: string
+      pattern: (gzip|br|deflate|compress)
+      example: gzip
     part_number:
       description: Number of the part.
       type: integer

--- a/spec/transaction/components/examples.yaml
+++ b/spec/transaction/components/examples.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   examples:
     inprogress:

--- a/spec/transaction/components/parameters.yaml
+++ b/spec/transaction/components/parameters.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   parameters:
     assetId:

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -1,4 +1,4 @@
-# openapi: 3.0.1
+# openapi: 3.0.3
 components:
   responses:
     Assets:

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 components:
   schemas:
     assetId:
@@ -313,6 +313,8 @@ components:
           $ref: "#/components/schemas/md5_parts"
         update_interval:
           $ref: "#/components/schemas/update_interval"
+        content_encoding:
+          $ref: "#/components/schemas/content_encoding"
         urls:
           type: array
           description: |
@@ -495,6 +497,19 @@ components:
       minimum: -1
       maximum: 604800
       example: 30
+    content_encoding:
+      description: |
+        Content Encoding of the asset if compressed.
+
+        Tell the backend that the Asset data is compressed, this will add the `Content-Encoding` header
+        on the asset requests.
+
+        *NOTE:*
+         - *when uploading compressed data: the `checksum:multihash` refers to the checksum of the
+           uncompressed data, while the md5 checksum must be calculated of the compressed data*
+      type: string
+      pattern: (gzip|br|deflate|compress)
+      example: gzip
     part_number:
       description: Number of the part.
       type: integer

--- a/spec/transaction/paths.yaml
+++ b/spec/transaction/paths.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 paths:
   "/collections/{collectionId}":
     put:

--- a/spec/transaction/tags.yaml
+++ b/spec/transaction/tags.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 tags:
   - name: Capabilities
   - name: Data


### PR DESCRIPTION
This allow a user to upload data already compressed. This means that asset
compressed can only be in compressed form served.