### PR TITLE
PB-409: fix broken health check and collections endpoint

### DIFF
--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -54,7 +54,7 @@ class RequestResponseLoggingMiddleware:
         # HttpResponse and JSONResponse sure have
         # (e.g. WhiteNoiseFileResponse doesn't)
         if isinstance(response, (HttpResponse, JsonResponse)):
-            extra["response"]["payload"] = response.content[:200].decode()
+            extra["response"]["payload"] = response.content.decode()[:200]
 
         logger.info("Response %s", response.status_code, extra=extra)
         # Code to be executed for each request/response after


### PR DESCRIPTION
Since this morning, the collections and health check endpoint are returning 500. This is most likely caused by a special character in a newly updated collection description or ID field. The error is, decode cannot decode a byte 0xc3 in position 199: unexpected end of data. To prevent this, we now first decode the whole response.content and strip it afterwards, rather than the other way round.

This is the exact error message:
```json
  "exc_text": "Traceback (most recent call last):\n  File \"/opt/service-stac/.venv/lib/python3.9/site-packages/django/core/handlers/exception.py\", line 56, in inner\n    response = get_response(request)\n  File \"/opt/service-stac/app/middleware/logging.py\", line 57, in __call__\n    extra[\"response\"][\"payload\"] = response.content[:200].decode()\nUnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 199: unexpected end of data"
```

@rebert @ltflb-bgdi @ltshb : Thanks for your time and support in debuging this issue!