### PR TITLE
PB-613: adapt spec for item geometry

### DIFF
--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -841,13 +841,13 @@ components:
       example: smr200-200-4-2019
       type: string
     itemGeometry:
-      # oneOf:
-        # - $ref: "#/components/schemas/geoJsonPoint"
-        # - $ref: "#/components/schemas/geoJsonLineString"
-      $ref: "#/components/schemas/geoJsonPolygon"
-        # - $ref: "#/components/schemas/geoJsonMultiPoint"
-        # - $ref: "#/components/schemas/geoJsonMultiLineString"
-        # - $ref: "#/components/schemas/geoJsonMultiPolygon"
+      oneOf:
+        - $ref: "#/components/schemas/geoJsonPoint"
+        - $ref: "#/components/schemas/geoJsonLineString"
+        - $ref: "#/components/schemas/geoJsonPolygon"
+        - $ref: "#/components/schemas/geoJsonMultiPoint"
+        - $ref: "#/components/schemas/geoJsonMultiLineString"
+        - $ref: "#/components/schemas/geoJsonMultiPolygon"
     geoJsonPoint:
       title: GeoJSON Point
       type: object

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -1383,7 +1383,13 @@ components:
       example: smr200-200-4-2019
       type: string
     itemGeometry:
-      $ref: "#/components/schemas/geoJsonPolygon"
+      oneOf:
+      - $ref: "#/components/schemas/geoJsonPoint"
+      - $ref: "#/components/schemas/geoJsonLineString"
+      - $ref: "#/components/schemas/geoJsonPolygon"
+      - $ref: "#/components/schemas/geoJsonMultiPoint"
+      - $ref: "#/components/schemas/geoJsonMultiLineString"
+      - $ref: "#/components/schemas/geoJsonMultiPolygon"
     geoJsonPoint:
       title: GeoJSON Point
       type: object

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -2500,7 +2500,13 @@ components:
       example: smr200-200-4-2019
       type: string
     itemGeometry:
-      $ref: "#/components/schemas/geoJsonPolygon"
+      oneOf:
+      - $ref: "#/components/schemas/geoJsonPoint"
+      - $ref: "#/components/schemas/geoJsonLineString"
+      - $ref: "#/components/schemas/geoJsonPolygon"
+      - $ref: "#/components/schemas/geoJsonMultiPoint"
+      - $ref: "#/components/schemas/geoJsonMultiLineString"
+      - $ref: "#/components/schemas/geoJsonMultiPolygon"
     geoJsonPoint:
       title: GeoJSON Point
       type: object


### PR DESCRIPTION
Adapt spec of item geometry to be one of point, lineString, polygon, multiPoint, multiLineString or multiPolygon.
This change is only in spec of v1, although the implementation is actually available in both v1 and v0.9.