### PR TITLE
Clean up how we build the OpenAPI spec.

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -28,7 +28,6 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo -e " \033[1mLOCAL DOCKER TARGETS\033[0m "
-	@echo "- dockerlogin              Login to the AWS ECR registery for pulling/pushing docker images"
 	@echo -e " \033[1mTREAT THE SPECS TARGETS\033[0m "
 	@echo "- build-specs              Build the specs"
 	@echo "- lint-specs               lint the specs"

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/bash
+SHELL = /bin/bash -o pipefail
 .DEFAULT_GOAL := help
 
 # List of files that should be merged.

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -19,6 +19,9 @@ STATIC_BASE_DIR = static/spec/v1
 OPENAPI = $(STATIC_BASE_DIR)/openapi.yaml
 OPENAPI_TRANSACTIONAL = $(STATIC_BASE_DIR)/openapitransactional.yaml
 
+YQ ?= docker run --rm -v ${PWD}:/workdir 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:3.3.0 yq
+OPENAPI_VALIDATOR ?= docker run --volume "$(PWD)":/data 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/openapi-validator:0.54.0
+
 all: help
 
 
@@ -36,12 +39,12 @@ help:
 
 .PHONY: build-spec-openapi
 build-spec-openapi: $(PARTS)
-	docker run --rm -v ${PWD}:/workdir 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:3.3.0 yq merge -x $(PARTS) | \
+	$(YQ) merge -x $(PARTS) | \
 	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(OPENAPI)
 
 .PHONY: build-spec-transactional
 build-spec-transactional: build-spec-openapi $(OPENAPI) $(PARTS_TRANSACTIONAL)
-	docker run --rm -v ${PWD}:/workdir 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:3.3.0 yq merge -x $(OPENAPI) $(PARTS_TRANSACTIONAL) | \
+	$(YQ) merge -x $(OPENAPI) $(PARTS_TRANSACTIONAL) | \
 	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(OPENAPI_TRANSACTIONAL)
 
 
@@ -51,8 +54,8 @@ build-specs: build-spec-openapi build-spec-transactional
 
 .PHONY: lint-specs
 lint-specs: build-specs
-	docker run --volume "$(PWD)":/data 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/openapi-validator:0.54.0 -e $(OPENAPI)
-	docker run --volume "$(PWD)":/data 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/openapi-validator:0.54.0 -e $(OPENAPI_TRANSACTIONAL)
+	$(OPENAPI_VALIDATOR) -e $(OPENAPI)
+	$(OPENAPI_VALIDATOR) -e $(OPENAPI_TRANSACTIONAL)
 
 
 # Start a little server that serves api.html and openapi.yaml

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -19,7 +19,7 @@ STATIC_BASE_DIR = static/spec/v1
 OPENAPI = $(STATIC_BASE_DIR)/openapi.yaml
 OPENAPI_TRANSACTIONAL = $(STATIC_BASE_DIR)/openapitransactional.yaml
 
-YQ ?= docker run --rm -v ${PWD}:/workdir 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:3.3.0 yq
+YQ ?= docker run --rm -v ${PWD}:/workdir 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:4.44.1
 OPENAPI_VALIDATOR ?= docker run --volume "$(PWD)":/data 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/openapi-validator:0.54.0
 
 all: help
@@ -38,11 +38,11 @@ help:
 
 
 $(OPENAPI): $(PARTS)
-	$(YQ) merge -x $(^) | \
+	$(YQ) eval-all '. as $$item ireduce ({}; . *nd $$item )' $(^) | \
 	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(@)
 
 $(OPENAPI_TRANSACTIONAL): $(OPENAPI) $(PARTS_TRANSACTIONAL)
-	$(YQ) merge -x $(^) | \
+	$(YQ) eval-all '. as $$item ireduce ({}; . *nd $$item )' $(^) | \
 	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(@)
 
 .PHONY: build-specs

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -37,26 +37,32 @@ help:
 	@echo "- serve-specs              serve the specs locally on port $(SPEC_HTTP_PORT)"
 
 
-.PHONY: build-spec-openapi
-build-spec-openapi: $(PARTS)
-	$(YQ) merge -x $(PARTS) | \
-	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(OPENAPI)
+$(OPENAPI): $(PARTS)
+	$(YQ) merge -x $(^) | \
+	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(@)
 
-.PHONY: build-spec-transactional
-build-spec-transactional: build-spec-openapi $(OPENAPI) $(PARTS_TRANSACTIONAL)
-	$(YQ) merge -x $(OPENAPI) $(PARTS_TRANSACTIONAL) | \
-	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(OPENAPI_TRANSACTIONAL)
-
+$(OPENAPI_TRANSACTIONAL): $(OPENAPI) $(PARTS_TRANSACTIONAL)
+	$(YQ) merge -x $(^) | \
+	sed -E '/\$ref:/s/"\..*?(#.*?)"/"\1"/' > $(@)
 
 .PHONY: build-specs
-build-specs: build-spec-openapi build-spec-transactional
+build-specs: clean $(OPENAPI) $(OPENAPI_TRANSACTIONAL)
 
+.PHONY: clean
+clean:
+	$(RM) $(OPENAPI) $(OPENAPI_TRANSACTIONAL)
 
 .PHONY: lint-specs
 lint-specs: build-specs
 	$(OPENAPI_VALIDATOR) -e $(OPENAPI)
 	$(OPENAPI_VALIDATOR) -e $(OPENAPI_TRANSACTIONAL)
 
+# This can be useful to distinguish style and semantic differences when we
+# update the tools. For example if you update yq and see lot of whitespace
+# changes, you can "make static/spec/v1/openapi.props" and diff that to check
+# for change in the properties themselves.
+%.props: %.yaml
+	$(YQ) -P 'sort_keys(..)' -o=props $(^) > $(@)
 
 # Start a little server that serves api.html and openapi.yaml
 # since ReDoc (the js library used in api.html) cannot load spec

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -4,29 +4,24 @@ info:
     name: API Specification (based on STAC)
     url: http://data.geo.admin.ch/api/stac/v1/
   description: >-
-    This is an OpenAPI definition of the API to query and access federal geodata on
-    data.geo.admin.ch. The API is based on the core SpatioTemporal Asset Catalog API
-    specification [STAC](http://stacspec.org) and adds two extensions for extended
-    searching possibilities.
+    This is an OpenAPI definition of the API to query and access federal geodata on data.geo.admin.ch. The API is based on the core SpatioTemporal Asset Catalog API specification [STAC](http://stacspec.org) and adds two extensions for extended searching possibilities.
   title: The SpatioTemporal Asset Catalog API for data.geo.admin.ch
   version: 1.0.0
 servers:
-- description: Data.geo.admin.ch
-  url: http://data.geo.admin.ch/api/stac/v1
+  - description: Data.geo.admin.ch
+    url: http://data.geo.admin.ch/api/stac/v1
 tags:
-- description: Essential characteristics of this API
-  name: Capabilities
-- description: Access to data (features)
-  name: Data
-- description: Extension to OGC API - Features to support STAC metadata model and
-    search API
-  name: STAC
+  - description: Essential characteristics of this API
+    name: Capabilities
+  - description: Access to data (features)
+    name: Data
+  - description: Extension to OGC API - Features to support STAC metadata model and search API
+    name: STAC
 paths:
   /:
     get:
       description: >-
-        The landing page provides links to the API definition, the conformance statements
-        and to the feature collections in this dataset.
+        The landing page provides links to the API definition, the conformance statements and to the feature collections in this dataset.
       operationId: getLandingPage
       responses:
         "200":
@@ -35,12 +30,12 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Landing page
       tags:
-      - Capabilities
+        - Capabilities
   /collections:
     get:
       operationId: getCollections
       parameters:
-      - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           $ref: "#/components/responses/Collections"
@@ -49,14 +44,14 @@ paths:
       summary: Fetch collections
       description: The feature collections in the dataset
       tags:
-      - Data
+        - Data
   /collections/{collectionId}:
     get:
       operationId: describeCollection
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           $ref: "#/components/responses/Collection"
@@ -71,25 +66,23 @@ paths:
       summary: Fetch a single collection
       description: Describe the feature collection with id `collectionId`
       tags:
-      - Data
+        - Data
   /collections/{collectionId}/items:
     get:
       description: >-
         Fetch features of the feature collection with id `collectionId`.
 
 
-        Every feature in a dataset belongs to a collection. A dataset may consist
-        of multiple feature collections. A feature collection is often a collection
-        of features of a similar type, based on a common schema.
+        Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema.
 
 
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeatures
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/limit"
-      - $ref: "#/components/parameters/bbox"
-      - $ref: "#/components/parameters/datetime"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/datetime"
       responses:
         "200":
           $ref: "#/components/responses/Features"
@@ -101,7 +94,7 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch features
       tags:
-      - Data
+        - Data
   /collections/{collectionId}/items/{featureId}:
     get:
       description: >-
@@ -111,10 +104,10 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeature
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           $ref: "#/components/responses/Feature"
@@ -128,18 +121,18 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch a single feature
       tags:
-      - Data
+        - Data
   /{assetObjectHref}:
     servers:
-    - url: http://data.geo.admin.ch/
+      - url: http://data.geo.admin.ch/
     parameters:
-    - $ref: "#/components/parameters/assetObjectHref"
+      - $ref: "#/components/parameters/assetObjectHref"
     get:
       tags:
-      - Data
+        - Data
       summary: Fetch an asset object
       parameters:
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       operationId: getAssetObject
       description: |
         Return an asset object
@@ -255,8 +248,7 @@ paths:
   /conformance:
     get:
       description: >-
-        A list of all conformance classes specified in a standard that the server
-        conforms to.
+        A list of all conformance classes specified in a standard that the server conforms to.
       operationId: getConformanceDeclaration
       responses:
         "200":
@@ -265,18 +257,18 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Information about specifications that this API conforms to
       tags:
-      - Capabilities
+        - Capabilities
   /search:
     get:
       description: >-
         Retrieve Items matching filters. Intended as a shorthand API for simple queries.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/bbox"
-      - $ref: "#/components/parameters/datetime"
-      - $ref: "#/components/parameters/limit"
-      - $ref: "#/components/parameters/ids"
-      - $ref: "#/components/parameters/collectionsArray"
+        - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/datetime"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/ids"
+        - $ref: "#/components/parameters/collectionsArray"
       responses:
         "200":
           content:
@@ -288,11 +280,10 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Search STAC items with simple filtering.
       tags:
-      - STAC
+        - STAC
     post:
       description: >-
-        Retrieve items matching filters. Intended as the standard, full-featured query
-        API.
+        Retrieve items matching filters. Intended as the standard, full-featured query API.
       operationId: postSearchSTAC
       requestBody:
         content:
@@ -310,7 +301,7 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Search STAC items with full-featured filtering.
       tags:
-      - STAC
+        - STAC
 components:
   responses:
     Collection:
@@ -325,24 +316,18 @@ components:
         Information about the feature collection with id `collectionId`.
 
 
-        The response contains a link to the items in the collection (path `/collections/{collectionId}/items`,
-        link relation `items`) as well as key information about the collection. This
-        information includes:
+        The response contains a link to the items in the collection (path `/collections/{collectionId}/items`, link relation `items`) as well as key information about the collection. This information includes:
 
 
         * A local identifier for the collection that is unique for the dataset
 
-        * A list of coordinate reference systems (CRS) in which geometries may be
-        returned by the server. The first CRS is the default coordinate reference
-        system (the default is always WGS 84 with axis order longitude/latitude)
+        * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude)
 
         * An optional title and description for the collection
 
-        * An optional extent that can be used to provide an indication of the spatial
-        and temporal extent of the collection - typically derived from the data
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data
 
-        * An optional indicator about the type of the items in the collection (the
-        default value, if the indicator is not provided, is 'feature')
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature')
     Collections:
       content:
         application/json:
@@ -352,50 +337,38 @@ components:
         The feature collections shared by this API.
 
 
-        The dataset is organized as one or more feature collections. This resource
-        provides information about and access to the collections.
+        The dataset is organized as one or more feature collections. This resource provides information about and access to the collections.
 
 
-        The response contains the list of collections. For each collection, a link
-        to the items in the collection (path `/collections/{collectionId}/items`,
-        link relation `items`) as well as key information about the collection. This
-        information includes:
+        The response contains the list of collections. For each collection, a link to the items in the collection (path `/collections/{collectionId}/items`, link relation `items`) as well as key information about the collection. This information includes:
 
 
         * A local identifier for the collection that is unique for the dataset
 
-        * A list of coordinate reference systems (CRS) in which geometries may be
-        returned by the server. The first CRS is the default coordinate reference
-        system (the default is always WGS 84 with axis order longitude/latitude)
+        * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude)
 
         * An optional title and description for the collection
 
-        * An optional extent that can be used to provide an indication of the spatial
-        and temporal extent of the collection - typically derived from the data
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data
 
-        * An optional indicator about the type of the items in the collection (the
-        default value, if the indicator is not provided, is 'feature').
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
 
-        The `limit` parameter may be used to control the subset of the selected collections
-        that should be returned in the response, the page size. Each page include
-        links to support paging (link relation `next` and/or `previous`).
+        The `limit` parameter may be used to control the subset of the selected collections that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
     ConformanceDeclaration:
       content:
         application/json:
           example:
             conformsTo:
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
           schema:
             $ref: "#/components/schemas/confClasses"
       description: >-
         The URIs of all conformance classes supported by the server.
 
 
-        To support "generic" clients that want to access multiple OGC API Features
-        implementations - and not "just" a specific API / server, the server declares
-        the conformance classes it implements and conforms to.
+        To support "generic" clients that want to access multiple OGC API Features implementations - and not "just" a specific API / server, the server declares the conformance classes it implements and conforms to.
     Feature:
       headers:
         ETag:
@@ -412,24 +385,13 @@ components:
           schema:
             $ref: "#/components/schemas/items"
       description: >-
-        The response is a document consisting of features in the collection. The features
-        included in the response are determined by the server based on the query parameters
-        of the request. To support access to larger collections without overloading
-        the client, the API supports paged access with links to the next page, if
-        more features are selected that the page size.
+        The response is a document consisting of features in the collection. The features included in the response are determined by the server based on the query parameters of the request. To support access to larger collections without overloading the client, the API supports paged access with links to the next page, if more features are selected that the page size.
 
 
-        The `bbox` and `datetime` parameter can be used to select only a subset of
-        the features in the collection (the features that are in the bounding box
-        or time interval). The `bbox` parameter matches all features in the collection
-        that are not associated with a location, too. The `datetime` parameter matches
-        all features in the collection that are not associated with a time stamp or
-        interval, too.
+        The `bbox` and `datetime` parameter can be used to select only a subset of the features in the collection (the features that are in the bounding box or time interval). The `bbox` parameter matches all features in the collection that are not associated with a location, too. The `datetime` parameter matches all features in the collection that are not associated with a time stamp or interval, too.
 
 
-        The `limit` parameter may be used to control the subset of the selected features
-        that should be returned in the response, the page size. Each page include
-        links to support paging (link relation `next` and/or `previous`).
+        The `limit` parameter may be used to control the subset of the selected features that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
     NotModified:
       description: The cached resource was not modified since last request.
     InvalidParameter:
@@ -448,35 +410,32 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-            - href: http://data.geo.admin.ch/api/stac/v0.9/
-              rel: self
-              type: application/json
-              title: this document
-            - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
-              rel: service-doc
-              type: text/html
-              title: the API documentation
-            - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
-              rel: conformance
-              type: application/json
-              title: OGC API conformance classes implemented by this server
-            - href: http://data.geo.admin.ch/api/stac/v0.9/collections
-              rel: data
-              type: application/json
-              title: Information about the feature collections
-            - href: http://data.geo.admin.ch/api/stac/v0.9/search
-              rel: search
-              type: application/json
-              title: Search across feature collections
+              - href: http://data.geo.admin.ch/api/stac/v0.9/
+                rel: self
+                type: application/json
+                title: this document
+              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+                rel: service-doc
+                type: text/html
+                title: the API documentation
+              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+                rel: conformance
+                type: application/json
+                title: OGC API conformance classes implemented by this server
+              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+                rel: data
+                type: application/json
+                title: Information about the feature collections
+              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+                rel: search
+                type: application/json
+                title: Search across feature collections
             stac_version: 0.9.0
             title: data.geo.admin.ch
           schema:
             $ref: "#/components/schemas/landingPage"
       description: >-
-        The landing page provides links to the API definition (link relations `service-desc`
-        and `service-doc`), the Conformance declaration (path `/conformance`, link
-        relation `conformance`), and the Feature Collections (path `/collections`,
-        link relation `data`).
+        The landing page provides links to the API definition (link relations `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`, link relation `conformance`), and the Feature Collections (path `/collections`, link relation `data`).
     NotFound:
       description: The specified resource/URI was not found
       content:
@@ -518,11 +477,9 @@ components:
             code: 403
             description: "Permission denied"
     PreconditionFailed:
-      description: Some condition specified by the request could not be met in the
-        server
+      description: Some condition specified by the request could not be met in the server
     PreconditionFailedS3:
-      description: Some condition specified by the request could not be met in the
-        server
+      description: Some condition specified by the request could not be met in the server
       content:
         application/xml:
           schema:
@@ -537,8 +494,7 @@ components:
             </Error>
     ServerError:
       description: >-
-        The request was syntactically and semantically valid, but an error occurred
-        while trying to act upon it
+        The request was syntactically and semantically valid, but an error occurred while trying to act upon it
       content:
         application/json:
           schema:
@@ -575,54 +531,47 @@ components:
       type: object
     assetQueryProp:
       anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
+        - description: >-
+            If the object doesn't contain any of the operators, it is equivalent to using the equals operator
+        - description: Match using an operator
+          properties:
+            contains:
+              description: >-
+                Find items with a property that contains the specified literal string, e.g., matches ".*<STRING>.*". A case-insensitive comparison must be performed.
+              type: string
+            endsWith:
+              description: >-
+                Find items with a property that ends with the specified string. A case-insensitive comparison must be performed.
+              type: string
+            eq:
+              description: >-
+                Find items with a property that is equal to the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
               oneOf:
-              - type: string
-              - type: number
-            type: array
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
+                - type: string
+                - type: number
+                - type: boolean
+            in:
+              description: >-
+                Find items with a property that equals at least one entry in the specified array. A case-insensitive comparison must be performed.
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+              type: array
+            startsWith:
+              description: >-
+                Find items with a property that begins with the specified string. A case-insensitive comparison must be performed.
+              type: string
+          type: object
       description: Apply query operations to a specific property
     assetBase:
       title: Asset
       description: The `property name` defines the ID of the Asset.
       type: object
       required:
-      - created
-      - updated
+        - created
+        - updated
       properties:
         title:
           $ref: "#/components/schemas/title"
@@ -667,10 +616,10 @@ components:
         represented in JSON as `[5.96, 45.82, 10.49, 47.81]` and in a query as
         `bbox=5.96,45.82,10.49,47.81`."
       example:
-      - 7.0906249
-      - 45.9160584
-      - 7.1035698
-      - 45.925093
+        - 7.0906249
+        - 45.9160584
+        - 7.1035698
+        - 45.925093
       items:
         type: number
       maxItems: 4
@@ -679,8 +628,7 @@ components:
       readOnly: true
     bboxfilter:
       description: >-
-        Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four numbers:
+        Only features that have a geometry that intersects the bounding box are selected. The bounding box is provided as four numbers:
 
 
         * Lower left corner, coordinate axis 1
@@ -692,24 +640,18 @@ components:
         * Upper right corner, coordinate axis 2
 
 
-        The coordinate reference system of the values is WGS84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+        The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
-        For WGS84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value (west-most
-        box edge) is larger than the third value (east-most box edge).
+        For WGS84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude, maximum longitude and maximum latitude. However, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third value (east-most box edge).
 
 
-        Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E
-        and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82,
-        10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
+        Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82, 10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
       example:
-      - 7.0906249
-      - 45.9160584
-      - 7.1035698
-      - 45.925093
+        - 7.0906249
+        - 45.9160584
+        - 7.1035698
+        - 45.925093
       items:
         type: number
       maxItems: 4
@@ -729,8 +671,7 @@ components:
       type: string
     checksumMultihash:
       description: >-
-        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
-        format.
+        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/) format.
       example: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
       pattern: ^[a-f0-9]+$
       title: Multihash
@@ -753,10 +694,10 @@ components:
       properties:
         crs:
           default:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           description: The list of coordinate reference systems supported by the service
           example:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           items:
             type: string
           type: array
@@ -764,16 +705,10 @@ components:
         description:
           description: A description of the features in the collection
           example: >-
-            Swiss Map Raster are a conversion of the map image into a digital form
-            with no direct bearing on the individual map elements.
+            Swiss Map Raster are a conversion of the map image into a digital form with no direct bearing on the individual map elements.
 
 
-            The information is structured only in colour layers. Swiss Map Raster
-            pixel maps are ideal for finding background information for a broad variety
-            of screen applications, web and mobile applications and services, as well
-            as for geographic information systems. They can also be used as basic
-            maps for a variety of purposes (digital printing, plots, offset printing,
-            etc.).
+            The information is structured only in colour layers. Swiss Map Raster pixel maps are ideal for finding background information for a broad variety of screen applications, web and mobile applications and services, as well as for geographic information systems. They can also be used as basic maps for a variety of purposes (digital printing, plots, offset printing, etc.).
           type: string
         extent:
           $ref: "#/components/schemas/extent"
@@ -784,8 +719,7 @@ components:
         itemType:
           default: Feature
           description: >-
-            Indicator about the type of the items in the collection (the default value
-            is 'Feature').
+            Indicator about the type of the items in the collection (the default value is 'Feature').
           type: string
           readOnly: true
         license:
@@ -797,57 +731,43 @@ components:
         summaries:
           additionalProperties:
             oneOf:
-            - items:
-                description: A value of any type.
-              title: Set of values
-              type: array
-            - description: >-
-                By default, only ranges with a minimum and a maximum value can be
-                specified. Ranges can be specified for ordinal values only, which
-                means they need to have a rank order. Therefore, ranges can only be
-                specified for numbers and some special types of strings. Examples:
-                grades (A to F), dates or times. Implementors are free to add other
-                derived statistical values to the object, for example `mean` or `stddev`.
-              properties:
-                max:
-                  anyOf:
-                  - type: string
-                  - type: number
-                min:
-                  anyOf:
-                  - type: string
-                  - type: number
-              required:
-              - min
-              - max
-              title: Statistics
-              type: object
+              - items:
+                  description: A value of any type.
+                title: Set of values
+                type: array
+              - description: >-
+                  By default, only ranges with a minimum and a maximum value can be specified. Ranges can be specified for ordinal values only, which means they need to have a rank order. Therefore, ranges can only be specified for numbers and some special types of strings. Examples: grades (A to F), dates or times. Implementors are free to add other derived statistical values to the object, for example `mean` or `stddev`.
+                properties:
+                  max:
+                    anyOf:
+                      - type: string
+                      - type: number
+                  min:
+                    anyOf:
+                      - type: string
+                      - type: number
+                required:
+                  - min
+                  - max
+                title: Statistics
+                type: object
           description: >-
-            Summaries are either a unique set of all available values *or* statistics.
-            Statistics by default only specify the range (minimum and maximum values),
-            but can optionally be accompanied by additional statistical values. The
-            range can specify the potential range of values, but it is recommended
-            to be as precise as possible. The set of values must contain at least
-            one element and it is strongly recommended to list all values. It is recommended
-            to list as many properties as reasonable so that consumers get a full
-            overview of the Collection. Properties that are covered by the Collection
-            specification (e.g. `providers` and `license`) may not be repeated in
-            the summaries.
+            Summaries are either a unique set of all available values *or* statistics. Statistics by default only specify the range (minimum and maximum values), but can optionally be accompanied by additional statistical values. The range can specify the potential range of values, but it is recommended to be as precise as possible. The set of values must contain at least one element and it is strongly recommended to list all values. It is recommended to list as many properties as reasonable so that consumers get a full overview of the Collection. Properties that are covered by the Collection specification (e.g. `providers` and `license`) may not be repeated in the summaries.
           type: object
           readOnly: true
           example:
             eo:gsd:
-            - 10
-            - 20
+              - 10
+              - 20
             geoadmin:variant:
-            - kgrel
-            - komb
-            - krel
+              - kgrel
+              - komb
+              - krel
             geoadmin:lang:
-            - de
-            - fr
+              - de
+              - fr
             proj:epsg:
-            - 2056
+              - 2056
         title:
           description: Human readable title of the collection
           example: National Map 1:200'000
@@ -857,40 +777,39 @@ components:
         updated:
           $ref: "#/components/schemas/updated"
       required:
-      - id
-      - stac_version
-      - description
-      - license
-      - extent
-      - created
-      - updated
+        - id
+        - stac_version
+        - description
+        - license
+        - extent
+        - created
+        - updated
       type: object
     collection:
       allOf:
-      - $ref: "#/components/schemas/collectionBase"
-      - type: object
-        required:
-        - links
-        properties:
-          links:
-            type: array
-            items:
-              $ref: "#/components/schemas/link"
-            example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
-              rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9
-              rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-              rel: items
-            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-              rel: license
-              title: Licence for the free geodata of the Federal Office of Topography
-                swisstopo
-            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-              rel: describedby
+        - $ref: "#/components/schemas/collectionBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              type: array
+              items:
+                $ref: "#/components/schemas/link"
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                  rel: items
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
     collections:
       properties:
         collections:
@@ -901,22 +820,21 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
-            rel: next
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
-            rel: previous
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+              rel: next
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+              rel: previous
       required:
-      - links
-      - collections
+        - links
+        - collections
       type: object
     collectionsArray:
       description: >-
-        Array of Collection IDs to include in the search for items. Only Items in
-        one of the provided Collections will be searched.
+        Array of Collection IDs to include in the search for items. Only Items in one of the provided Collections will be searched.
       items:
         type: string
       type: array
@@ -928,8 +846,8 @@ components:
       type: object
       example:
         collections:
-        - ch.swisstopo.swisstlmregio
-        - ch.bfe.energieschweiz
+          - ch.swisstopo.swisstlmregio
+          - ch.bfe.energieschweiz
     confClasses:
       properties:
         conformsTo:
@@ -937,7 +855,7 @@ components:
             type: string
           type: array
       required:
-      - conformsTo
+        - conformsTo
       type: object
     datetime:
       description: RFC 3339 compliant datetime string
@@ -946,8 +864,7 @@ components:
       format: date-time
     datetimeQuery:
       description: >-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.
 
         Examples:
 
@@ -959,8 +876,7 @@ components:
         * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
 
-        Only features that have a temporal property that intersects the value of `datetime`
-        are selected.
+        Only features that have a temporal property that intersects the value of `datetime` are selected.
 
 
         When used as URL query argument, the value must be correctly url-encoded.
@@ -975,27 +891,14 @@ components:
         Detailed multi-line description to fully explain the catalog or collection.
 
 
-        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text
-        representation.
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.
       type: string
     eoGsd:
       description: >-
-        GSD is the nominal Ground Sample Distance for the data, as measured in meters
-        on the ground.
+        GSD is the nominal Ground Sample Distance for the data, as measured in meters on the ground.
 
 
-        There are many definitions of GSD. The value of this attribute should be related
-        to the spatial resolution at the sensor, rather than the pixel size of images
-        after ortho-rectification, pansharpening, or scaling. The GSD of a sensor
-        can vary depending on off-nadir and wavelength, so it is at the discretion
-        of the implementer to decide which value most accurately represents the GSD.
-        For example, Landsat8 optical and short-wave IR bands are all 30 meters, but
-        the panchromatic band is 15 meters. The eo:gsd should be 30 meters in this
-        case because that is nominal spatial resolution at the sensor. The Planet
-        PlanetScope Ortho Tile Product has an eo:gsd of 3.7 (or 4 if rounding), even
-        though the pixel size of the images is 3.125. For example, one might choose
-        for WorldView-2 the Multispectral 20° off-nadir value of 2.07 and for WorldView-3
-        the Multispectral 20° off-nadir value of 1.38.
+        There are many definitions of GSD. The value of this attribute should be related to the spatial resolution at the sensor, rather than the pixel size of images after ortho-rectification, pansharpening, or scaling. The GSD of a sensor can vary depending on off-nadir and wavelength, so it is at the discretion of the implementer to decide which value most accurately represents the GSD. For example, Landsat8 optical and short-wave IR bands are all 30 meters, but the panchromatic band is 15 meters. The eo:gsd should be 30 meters in this case because that is nominal spatial resolution at the sensor. The Planet PlanetScope Ortho Tile Product has an eo:gsd of 3.7 (or 4 if rounding), even though the pixel size of the images is 3.125. For example, one might choose for WorldView-2 the Multispectral 20° off-nadir value of 2.07 and for WorldView-3 the Multispectral 20° off-nadir value of 1.38.
       example: 2.5
       title: Ground Sample Distance
       type: number
@@ -1008,15 +911,15 @@ components:
           example: 500
         description:
           anyOf:
-          - type: string
-          - type: array
-            items:
-              anyOf:
-              - type: string
-              - type: object
-          - type: object
+            - type: string
+            - type: array
+              items:
+                anyOf:
+                  - type: string
+                  - type: object
+            - type: object
       required:
-      - code
+        - code
       type: object
     exceptionS3:
       description: >-
@@ -1037,31 +940,24 @@ components:
       xml:
         name: 'Error'
       required:
-      - Code
-      - Message
-      - RequestId
-      - HostId
+        - Code
+        - Message
+        - RequestId
+        - HostId
       type: object
     extent:
       description: >-
-        The extent of the features in the collection. In the Core only spatial and
-        temporal extents are specified. Extensions may add additional members to represent
-        other extents, for example, thermal or pressure ranges.
+        The extent of the features in the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional members to represent other extents, for example, thermal or pressure ranges.
       properties:
         spatial:
           description: The spatial extent of the features in the collection.
           properties:
             bbox:
               description: >-
-                One or more bounding boxes that describe the spatial extent of the
-                dataset. In the Core only a single bounding box is supported. Extensions
-                may support additional areas. If multiple areas are provided, the
-                union of the bounding boxes describes the spatial extent.
+                One or more bounding boxes that describe the spatial extent of the dataset. In the Core only a single bounding box is supported. Extensions may support additional areas. If multiple areas are provided, the union of the bounding boxes describes the spatial extent.
               items:
                 description: >-
-                  Each bounding box is provided as four or six numbers, depending
-                  on whether the coordinate reference system includes a vertical axis
-                  (height or depth):
+                  Each bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis (height or depth):
 
 
                   * Lower left corner, coordinate axis 1
@@ -1073,29 +969,21 @@ components:
                   * Upper right corner, coordinate axis 2
 
 
-                  The coordinate reference system of the values is WGS 84 longitude/latitude
-                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+                  The coordinate reference system of the values is WGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
-                  For WGS 84 longitude/latitude the values are in most cases the sequence
-                  of minimum longitude, minimum latitude, maximum longitude and maximum
-                  latitude. However, in cases where the box spans the antimeridian
-                  the first value (west-most box edge) is larger than the third value
-                  (east-most box edge).
+                  For WGS 84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude, maximum longitude and maximum latitude. However, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third value (east-most box edge).
 
 
-                  If the vertical axis is included, the third and the sixth number
-                  are the bottom and the top of the 3-dimensional bounding box.
+                  If the vertical axis is included, the third and the sixth number are the bottom and the top of the 3-dimensional bounding box.
 
 
-                  If a feature has multiple spatial geometry properties, it is the
-                  decision of the server whether only a single spatial geometry property
-                  is used to determine the extent or all relevant geometries.
+                  If a feature has multiple spatial geometry properties, it is the decision of the server whether only a single spatial geometry property is used to determine the extent or all relevant geometries.
                 example:
-                - 5.685114
-                - 45.534903
-                - 10.747775
-                - 47.982586
+                  - 5.685114
+                  - 45.534903
+                  - 10.747775
+                  - 47.982586
                 items:
                   type: number
                 maxItems: 6
@@ -1104,7 +992,7 @@ components:
               minItems: 1
               type: array
           required:
-          - bbox
+            - bbox
           type: object
         temporal:
           description: The temporal extent of the features in the collection.
@@ -1116,8 +1004,8 @@ components:
                 description: >-
                   Begin and end times of the time interval.
                 example:
-                - "2019-01-01T00:00:00Z"
-                - "2019-01-02T00:00:00Z"
+                  - "2019-01-01T00:00:00Z"
+                  - "2019-01-02T00:00:00Z"
                 items:
                   format: date-time
                   nullable: false
@@ -1129,20 +1017,20 @@ components:
               maxItems: 1
               type: array
           required:
-          - interval
+            - interval
           type: object
       required:
-      - spatial
-      - temporal
+        - spatial
+        - temporal
       type: object
       readOnly: true
     geoadminLang:
       enum:
-      - de
-      - it
-      - fr
-      - rm
-      - en
+        - de
+        - it
+        - fr
+        - rm
+        - en
       title: Product language
       type: string
     geoadminVariant:
@@ -1162,8 +1050,7 @@ components:
         http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     ids:
       description: >-
-        Array of Item ids to return. All other filter parameters that further restrict
-        the number of search results are ignored
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
       items:
         type: string
       type: array
@@ -1175,30 +1062,29 @@ components:
       type: object
       example:
         ids:
-        - swisstlmregio-2019
-        - swisstlmregio-2020
+          - swisstlmregio-2019
+          - swisstlmregio-2020
     intersectsFilter:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
           oneOf:
-          - $ref: "#/components/schemas/geoJsonPoint"
-          - $ref: "#/components/schemas/geoJsonLineString"
-          - $ref: "#/components/schemas/geoJsonPolygon"
-          - $ref: "#/components/schemas/geoJsonMultiPoint"
-          - $ref: "#/components/schemas/geoJsonMultiLineString"
-          - $ref: "#/components/schemas/geoJsonMultiPolygon"
+            - $ref: "#/components/schemas/geoJsonPoint"
+            - $ref: "#/components/schemas/geoJsonLineString"
+            - $ref: "#/components/schemas/geoJsonPolygon"
+            - $ref: "#/components/schemas/geoJsonMultiPoint"
+            - $ref: "#/components/schemas/geoJsonMultiLineString"
+            - $ref: "#/components/schemas/geoJsonMultiPolygon"
       type: object
       example:
         intersects:
           type: "Point"
           coordinates:
-          - 7
-          - 46
+            - 7
+            - 46
     itemBase:
       description: >-
-        A GeoJSON Feature augmented with foreign members that contain values relevant
-        to a STAC entity
+        A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
       properties:
         assets:
           $ref: "#/components/schemas/itemAssets"
@@ -1215,40 +1101,39 @@ components:
         type:
           $ref: "#/components/schemas/itemType"
       required:
-      - stac_version
-      - type
-      - geometry
-      - bbox
-      - properties
-      - assets
+        - stac_version
+        - type
+        - geometry
+        - bbox
+        - properties
+        - assets
       type: object
     item:
       allOf:
-      - type: object
-        required:
-        - id
-        - links
-        properties:
-          id:
-            $ref: "#/components/schemas/itemId"
-          links:
-            items:
-              $ref: "#/components/schemas/link"
-            type: array
-            example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
-              rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
-              rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: collection
-      - $ref: "#/components/schemas/itemBase"
+        - type: object
+          required:
+            - id
+            - links
+          properties:
+            id:
+              $ref: "#/components/schemas/itemId"
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
+        - $ref: "#/components/schemas/itemBase"
     items:
       description: >-
-        A FeatureCollection augmented with foreign members that contain values relevant
-        to a STAC entity
+        A FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       properties:
         features:
           items:
@@ -1259,36 +1144,36 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
-            rel: next
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
-            rel: previous
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+              rel: next
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+              rel: previous
         type:
           enum:
-          - FeatureCollection
+            - FeatureCollection
           type: string
       required:
-      - features
-      - type
+        - features
+        - type
       type: object
     itemAssets:
       title: Assets
       description: List of Assets attached to this feature.
       additionalProperties:
         allOf:
-        - type: object
-          required:
-          - type
-          properties:
-            type:
-              $ref: "#/components/schemas/assetType"
-        - $ref: "#/components/schemas/assetBase"
+          - type: object
+            required:
+              - type
+            properties:
+              type:
+                $ref: "#/components/schemas/assetType"
+          - $ref: "#/components/schemas/assetBase"
       type: object
       readOnly: true
       example:
@@ -1321,8 +1206,7 @@ components:
           updated: "2020-07-14T12:30:00Z"
     itemsSearch:
       description: >-
-        A GeoJSON FeatureCollection augmented with foreign members that contain values
-        relevant to a STAC entity
+        A GeoJSON FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       properties:
         features:
           items:
@@ -1330,50 +1214,48 @@ components:
           type: array
         type:
           enum:
-          - FeatureCollection
+            - FeatureCollection
           type: string
       required:
-      - features
-      - type
+        - features
+        - type
       type: object
     itemsSearchGet:
       allOf:
-      - $ref: "#/components/schemas/itemsSearch"
-      - type: object
-        properties:
-          links:
-            $ref: "#/components/schemas/itemsSearchLinks"
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchLinks"
     itemsSearchPost:
       allOf:
-      - $ref: "#/components/schemas/itemsSearch"
-      - type: object
-        properties:
-          links:
-            $ref: "#/components/schemas/itemsSearchPostLinks"
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchPostLinks"
     itemsSearchLinks:
       description: >-
-        An array of links. Can be used for pagination, e.g. by providing a link with
-        the `next` relation type.
+        An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search
-        rel: self
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
-        rel: next
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+          rel: self
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+          rel: next
       items:
         $ref: "#/components/schemas/link"
       type: array
     itemsSearchPostLinks:
       description: >-
-        An array of links. Can be used for pagination, e.g. by providing a link with
-        the `next` relation type.
+        An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search
-        rel: self
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
-        rel: next
-        method: POST
-        body: {}
-        merge: true
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+          rel: self
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+          rel: next
+          method: POST
+          body: {}
+          merge: true
       items:
         $ref: "#/components/schemas/linkPostSearch"
       type: array
@@ -1384,30 +1266,29 @@ components:
       type: string
     itemGeometry:
       oneOf:
-      - $ref: "#/components/schemas/geoJsonPoint"
-      - $ref: "#/components/schemas/geoJsonLineString"
-      - $ref: "#/components/schemas/geoJsonPolygon"
-      - $ref: "#/components/schemas/geoJsonMultiPoint"
-      - $ref: "#/components/schemas/geoJsonMultiLineString"
-      - $ref: "#/components/schemas/geoJsonMultiPolygon"
+        - $ref: "#/components/schemas/geoJsonPoint"
+        - $ref: "#/components/schemas/geoJsonLineString"
+        - $ref: "#/components/schemas/geoJsonPolygon"
+        - $ref: "#/components/schemas/geoJsonMultiPoint"
+        - $ref: "#/components/schemas/geoJsonMultiLineString"
+        - $ref: "#/components/schemas/geoJsonMultiPolygon"
     geoJsonPoint:
       title: GeoJSON Point
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - Point
+            - Point
         coordinates:
           description: >-
-            For type "Point", the "coordinates" member is a single position. The coordinate
-            reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "Point", the "coordinates" member is a single position. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - 7.0906823
-          - 45.9160584
+            - 7.0906823
+            - 45.9160584
           type: array
           minItems: 2
           items:
@@ -1416,23 +1297,21 @@ components:
       title: GeoJSON LineString
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - LineString
+            - LineString
         coordinates:
           description: >-
-            For type "LineString", the "coordinates" member is an array of two or
-            more positions. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "LineString", the "coordinates" member is an array of two or more positions. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
           type: array
           minItems: 2
           items:
@@ -1444,29 +1323,27 @@ components:
       title: GeoJSON Polygon
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - Polygon
+            - Polygon
         coordinates:
           description: >-
-            For type "Polygon", the "coordinates" member MUST be an array of linear
-            ring coordinate arrays. The coordinate reference system of the values
-            is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "Polygon", the "coordinates" member MUST be an array of linear ring coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
-            - - 7.1035146
-              - 45.925093
-            - - 7.0906249
-              - 45.9250537
-            - - 7.0906823
-              - 45.9160584
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
+              - - 7.1035146
+                - 45.925093
+              - - 7.0906249
+                - 45.9250537
+              - - 7.0906823
+                - 45.9160584
           type: array
           items:
             type: array
@@ -1480,25 +1357,23 @@ components:
       title: GeoJSON MultiPoint
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiPoint
+            - MultiPoint
         coordinates:
           description: >-
-            For type "MultiPoint", the "coordinates" member is an array of positions.
-            The coordinate reference system of the values is WGS84 longitude/latitude
-            (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiPoint", the "coordinates" member is an array of positions. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - 7.0906823
-            - 45.9160584
-          - - 7.1035698
-            - 45.9160977
-          - - 7.1035146
-            - 45.925093
+            - - 7.0906823
+              - 45.9160584
+            - - 7.1035698
+              - 45.9160977
+            - - 7.1035146
+              - 45.925093
           type: array
           items:
             type: array
@@ -1509,27 +1384,25 @@ components:
       title: GeoJSON MultiLineString
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiLineString
+            - MultiLineString
         coordinates:
           description: >-
-            For type "MultiLineString", the "coordinates" member is an array of LineString
-            coordinate arrays. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiLineString", the "coordinates" member is an array of LineString coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
-          - - - 7.1035146
-              - 45.925093
-            - - 7.0906249
-              - 45.9250537
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
+            - - - 7.1035146
+                - 45.925093
+              - - 7.0906249
+                - 45.9250537
           type: array
           items:
             type: array
@@ -1543,39 +1416,37 @@ components:
       title: GeoJSON MultiPolygon
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiPolygon
+            - MultiPolygon
         coordinates:
           description: >-
-            For type "MultiPolygon", the "coordinates" member is an array of Polygon
-            coordinate arrays. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiPolygon", the "coordinates" member is an array of Polygon coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - - 7.0906823
-                - 45.9160584
-              - - 7.1035698
-                - 45.9160977
-              - - 7.1035146
-                - 45.925093
-              - - 7.0906249
-                - 45.9250537
-              - - 7.0906823
-                - 45.9160584
-          - - - - 8.5816399
-                - 45.7218735
-              - - 8.5944806
-                - 45.7217417
-              - - 8.5946699
-                - 45.7307358
-              - - 8.581827
-                - 45.7308676
-              - - 8.5816399
-                - 45.7218735
+            - - - - 7.0906823
+                  - 45.9160584
+                - - 7.1035698
+                  - 45.9160977
+                - - 7.1035146
+                  - 45.925093
+                - - 7.0906249
+                  - 45.9250537
+                - - 7.0906823
+                  - 45.9160584
+            - - - - 8.5816399
+                  - 45.7218735
+                - - 8.5944806
+                  - 45.7217417
+                - - 8.5946699
+                  - 45.7307358
+                - - 8.581827
+                  - 45.7308676
+                - - 8.5816399
+                  - 45.7218735
           type: array
           items:
             type: array
@@ -1620,22 +1491,21 @@ components:
           maxLength: 255
           nullable: true
       required:
-      - created
-      - updated
+        - created
+        - updated
       type: object
     itemType:
       title: type
       description: The GeoJSON type
       enum:
-      - Feature
+        - Feature
       type: string
       readOnly: true
     landingPage:
       properties:
         description:
           example: >-
-            Access to data about buildings in the city of Bonn via a Web API that
-            conforms to the OGC API Features specification.
+            Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
           type: string
         id:
           type: string
@@ -1649,34 +1519,26 @@ components:
           example: Buildings in Bonn
           type: string
       required:
-      - links
-      - stac_version
-      - id
-      - description
+        - links
+        - stac_version
+        - id
+        - description
       type: object
     license:
       description: >-
-        License(s) of the data as a SPDX [License identifier](https://spdx.org/licenses/).
-        Alternatively, use `proprietary` if the license is not on the SPDX license
-        list or `various` if multiple licenses apply. In these two cases links to
-        the license texts SHOULD be added, see the `license` link relation type.
+        License(s) of the data as a SPDX [License identifier](https://spdx.org/licenses/). Alternatively, use `proprietary` if the license is not on the SPDX license list or `various` if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the `license` link relation type.
 
 
-        Non-SPDX licenses SHOULD add a link to the license text with the `license`
-        relation in the links section. The license text MUST NOT be provided as a
-        value of this field. If there is no public license URL available, it is RECOMMENDED
-        to host the license text and link to it.
+        Non-SPDX licenses SHOULD add a link to the license text with the `license` relation in the links section. The license text MUST NOT be provided as a value of this field. If there is no public license URL available, it is RECOMMENDED to host the license text and link to it.
       example: proprietary
       type: string
     limit:
       default: 100
       description: >-
-        The `limit` parameter limits the number of results that are included in the
-        response.
+        The `limit` parameter limits the number of results that are included in the response.
 
 
-        To retrieve the next bunch of result, use the `next` link in the `links` section
-        of the response.
+        To retrieve the next bunch of result, use the `next` link in the `links` section of the response.
 
 
         Minimum = 1. Maximum = 100. Default = 100.
@@ -1702,11 +1564,11 @@ components:
           type: array
         type:
           enum:
-          - LineString
+            - LineString
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     link:
       properties:
@@ -1719,8 +1581,7 @@ components:
             Relationship between the current document and the linked document.
 
 
-            NOTE: the following relations are reserved and automatically generated:
-            `self`, `root`, `parent`, `items`, `collection`, `next`, `previous`
+            NOTE: the following relations are reserved and automatically generated: `self`, `root`, `parent`, `items`, `collection`, `next`, `previous`
           example: describedby
           type: string
         title:
@@ -1734,35 +1595,31 @@ components:
           default: GET
           description: Specifies the HTTP method that the link expects
           enum:
-          - GET
-          - POST
+            - GET
+            - POST
           type: string
       required:
-      - href
-      - rel
+        - href
+        - rel
       title: Link
       type: object
     linkPostSearch:
       allOf:
-      - $ref: "#/components/schemas/link"
-      - type: object
-        properties:
-          body:
-            default: {}
-            description: For `POST /search` requests, the link can specify the HTTP
-              body as a JSON object.
-            type: object
-          merge:
-            default: false
-            description: >-
-              This is only valid when the server is responding to `POST /search `request.
+        - $ref: "#/components/schemas/link"
+        - type: object
+          properties:
+            body:
+              default: {}
+              description: For `POST /search` requests, the link can specify the HTTP body as a JSON object.
+              type: object
+            merge:
+              default: false
+              description: >-
+                This is only valid when the server is responding to `POST /search `request.
 
 
-              If merge is true, the client is expected to merge the body value into
-              the current request body before following the link. This avoids passing
-              large post bodies back and forth when following links, particularly
-              for navigating pages through the `POST /search` endpoint.
-            type: boolean
+                If merge is true, the client is expected to merge the body value into the current request body before following the link. This avoids passing large post bodies back and forth when following links, particularly for navigating pages through the `POST /search` endpoint.
+              type: boolean
     multilinestringGeoJSON:
       properties:
         coordinates:
@@ -1777,11 +1634,11 @@ components:
           type: array
         type:
           enum:
-          - MultiLineString
+            - MultiLineString
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     multipointGeoJSON:
       properties:
@@ -1794,11 +1651,11 @@ components:
           type: array
         type:
           enum:
-          - MultiPoint
+            - MultiPoint
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     multipolygonGeoJSON:
       properties:
@@ -1816,16 +1673,15 @@ components:
           type: array
         type:
           enum:
-          - MultiPolygon
+            - MultiPolygon
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     numberMatched:
       description: >-
-        The number of features of the feature type that match the selection parameters
-        like `bbox`.
+        The number of features of the feature type that match the selection parameters like `bbox`.
       example: 127
       minimum: 0
       type: integer
@@ -1834,12 +1690,10 @@ components:
         The number of features in the feature collection.
 
 
-        A server may omit this information in a response, if the information about
-        the number of features is not known or difficult to compute.
+        A server may omit this information in a response, if the information about the number of features is not known or difficult to compute.
 
 
-        If the value is provided, the value shall be identical to the number of items
-        in the "features" array.
+        If the value is provided, the value shall be identical to the number of items in the "features" array.
       example: 10
       minimum: 0
       type: integer
@@ -1852,11 +1706,11 @@ components:
           type: array
         type:
           enum:
-          - Point
+            - Point
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     polygonGeoJSON:
       properties:
@@ -1872,48 +1726,39 @@ components:
           type: array
         type:
           enum:
-          - Polygon
+            - Polygon
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
       example:
         coordinates:
-        - - - 7.242974548172171
-            - 46.57310580640624
-          - - 7.243756483316452
-            - 46.35721185723752
-          - - 7.698490766144817
-            - 46.357085154660915
-          - - 7.699524647567326
-            - 46.57297861624267
-          - - 7.242974548172171
-            - 46.57310580640624
+          - - - 7.242974548172171
+              - 46.57310580640624
+            - - 7.243756483316452
+              - 46.35721185723752
+            - - 7.698490766144817
+              - 46.357085154660915
+            - - 7.699524647567326
+              - 46.57297861624267
+            - - 7.242974548172171
+              - 46.57310580640624
         type: Polygon
     projEpsg:
       description: >-
-        A Coordinate Reference System (CRS) is the data reference system (sometimes
-        called a 'projection') used by the asset data, and can usually be referenced
-        using an EPSG code. If the asset data does not have a CRS, such as in the
-        case of non-rectified imagery with Ground Control Points, proj:epsg should
-        be set to null. It should also be set to null if a CRS exists, but for which
-        there is no valid EPSG code.
+        A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection') used by the asset data, and can usually be referenced using an EPSG code. If the asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points, proj:epsg should be set to null. It should also be set to null if a CRS exists, but for which there is no valid EPSG code.
       example: 2056
       title: EPSG code.
       type: integer
     providers:
       description: >-
-        A list of providers, which may include all organizations capturing or processing
-        the data or the hosting provider. Providers should be listed in chronological
-        order with the most recent provider being the last element of the list.
+        A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list.
       items:
         properties:
           description:
             description: >-
-              Multi-line description to add further provider information such as processing
-              details for processors and producers, hosting details for hosts or basic
-              contact information.
+              Multi-line description to add further provider information such as processing details for processors and producers, hosting details for hosts or basic contact information.
 
 
               CommonMark 0.29 syntax MAY be used for rich text representation.
@@ -1948,29 +1793,28 @@ components:
                 element of the list.
             items:
               enum:
-              - producer
-              - licensor
-              - processor
-              - host
+                - producer
+                - licensor
+                - processor
+                - host
               type: string
             type: array
           url:
             description: >-
-              Homepage on which the provider describes the dataset and publishes contact
-              information.
+              Homepage on which the provider describes the dataset and publishes contact information.
             format: url
             type: string
         required:
-        - name
+          - name
         title: Provider
         type: object
       type: array
       example:
-      - name: Federal Office of Topography - swisstopo
-        roles:
-        - producer
-        - licensor
-        url: https://www.swisstopo.admin.ch
+        - name: Federal Office of Topography - swisstopo
+          roles:
+            - producer
+            - licensor
+          url: https://www.swisstopo.admin.ch
     query:
       additionalProperties:
         $ref: "#/components/schemas/queryProp"
@@ -1991,102 +1835,90 @@ components:
       type: object
     queryProp:
       anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          gt:
-            description: Find items with a property value greater than the specified
-              value.
-            oneOf:
-            - format: date-time
+        - description: >-
+            If the object doesn't contain any of the operators, it is equivalent to using the equals operator
+        - description: Match using an operator
+          properties:
+            contains:
+              description: >-
+                Find items with a property that contains the specified literal string, e.g., matches ".*<STRING>.*". A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          gte:
-            description: Find items with a property value greater than or equal the
-              specified value.
-            oneOf:
-            - format: date-time
+            endsWith:
+              description: >-
+                Find items with a property that ends with the specified string. A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
+            eq:
+              description: >-
+                Find items with a property that is equal to the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
               oneOf:
-              - type: string
-              - type: number
-            type: array
-          lt:
-            description: Find items with a property value less than the specified
-              value.
-            oneOf:
-            - format: date-time
+                - type: string
+                - type: number
+                - type: boolean
+            gt:
+              description: Find items with a property value greater than the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            gte:
+              description: Find items with a property value greater than or equal the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            in:
+              description: >-
+                Find items with a property that equals at least one entry in the specified array. A case-insensitive comparison must be performed.
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+              type: array
+            lt:
+              description: Find items with a property value less than the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            lte:
+              description: Find items with a property value less than or equal the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            neq:
+              description: >-
+                Find items that *don't* contain the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
+              oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+            startsWith:
+              description: >-
+                Find items with a property that begins with the specified string. A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          lte:
-            description: Find items with a property value less than or equal the specified
-              value.
-            oneOf:
-            - format: date-time
-              type: string
-            - type: number
-          neq:
-            description: >-
-              Find items that *don't* contain the specified value. For strings, a
-              case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
+          type: object
       description: >-
-        Apply query operations to a specific property. The following properties are
-        currently supported: `created`, `updated`, `title`.
+        Apply query operations to a specific property. The following properties are currently supported: `created`, `updated`, `title`.
     roles:
       type: array
       items:
         type: string
       description: Purposes of the asset
       example:
-      - thumbnail
+        - thumbnail
     searchBody:
       allOf:
-      - $ref: "#/components/schemas/queryFilter"
-      - $ref: "#/components/schemas/bboxFilter"
-      - $ref: "#/components/schemas/datetimeFilter"
-      - $ref: "#/components/schemas/intersectsFilter"
-      - $ref: "#/components/schemas/collectionsFilter"
-      - $ref: "#/components/schemas/idsFilter"
-      - $ref: "#/components/schemas/limitFilter"
+        #        - $ref: "#/components/schemas/assetQueryFilter"
+        - $ref: "#/components/schemas/queryFilter"
+        - $ref: "#/components/schemas/bboxFilter"
+        - $ref: "#/components/schemas/datetimeFilter"
+        - $ref: "#/components/schemas/intersectsFilter"
+        - $ref: "#/components/schemas/collectionsFilter"
+        - $ref: "#/components/schemas/idsFilter"
+        - $ref: "#/components/schemas/limitFilter"
       description: The search criteria
       type: object
     stac_version:
@@ -2095,8 +1927,7 @@ components:
       type: string
       readOnly: true
     timeStamp:
-      description: This property indicates the time and date when the response was
-        generated.
+      description: This property indicates the time and date when the response was generated.
       example: "2017-08-17T08:05:32Z"
       format: date-time
       type: string
@@ -2121,8 +1952,7 @@ components:
   parameters:
     assetQuery:
       description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the
-        assetQueryFilter used in POST.
+        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
       in: query
       name: assetQuery
       required: false
@@ -2175,8 +2005,7 @@ components:
         type: string
     ids:
       description: >-
-        Array of Item ids to return. All other filter parameters that further restrict
-        the number of search results are ignored
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
       explode: false
       in: query
       name: ids
@@ -2192,8 +2021,7 @@ components:
         $ref: "#/components/schemas/limit"
       style: form
     query:
-      description: Query for properties in items. Use the JSON form of the queryFilter
-        used in POST.
+      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
       in: query
       name: query
       required: false
@@ -2205,15 +2033,10 @@ components:
       schema:
         type: string
       description: >-
-        The RFC7232 `If-None-Match` header field makes the GET request method conditional.
-        It is composed of a comma separated list of ETags or value "*".
+        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
 
 
-        The server compares the client's ETags (sent with `If-None-Match`) with the
-        ETag for its current version of the resource, and if both values match (that
-        is, the resource has not changed), the server sends back a `304 Not Modified`
-        status, without a body, which tells the client that the cached version of
-        the response is still good to use (fresh).
+        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
     IfMatch:
       name: If-Match
@@ -2221,25 +2044,16 @@ components:
       schema:
         type: string
       description: >-
-        The RFC7232 `If-Match` header field makes the GET request method conditional.
-        It is composed of a comma separated list of ETags or value "*".
+        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
 
 
-        The server compares the client's ETags (sent with `If-Match`) with the ETag
-        for its current version of the resource, and if both values don't match (that
-        is, the resource has changed), the server sends back a `412 Precondition Failed`
-        status, without a body, which tells the client that the cached version of
-        the response is not good to use anymore.
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
   headers:
     ETag:
       schema:
         type: string
       description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag
-        for the selected resource. An entity-tag is an opaque identifier for different
-        versions of a resource over time, regardless whether multiple versions are
-        valid at the same time. An entity-tag consists of an opaque quoted string,
-        possibly prefixed by a weakness indicator.
+        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
       required: true

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -4,254 +4,249 @@ info:
     name: API Specification (based on STAC)
     url: http://data.geo.admin.ch/api/stac/v1/
   description: >-
-    This is an OpenAPI definition of the API to query and access federal geodata on
-    data.geo.admin.ch. The API is based on the core SpatioTemporal Asset Catalog API
-    specification [STAC](http://stacspec.org) and adds two extensions for extended
-    searching possibilities.
+    This is an OpenAPI definition of the API to query and access federal geodata on data.geo.admin.ch. The API is based on the core SpatioTemporal Asset Catalog API specification [STAC](http://stacspec.org) and adds two extensions for extended searching possibilities.
   title: The SpatioTemporal Asset Catalog API for data.geo.admin.ch
   version: 1.0.0
 servers:
-- description: Data.geo.admin.ch
-  url: http://data.geo.admin.ch/api/stac/v1
+  - description: Data.geo.admin.ch
+    url: http://data.geo.admin.ch/api/stac/v1
 tags:
-- description: Essential characteristics of this API
-  name: Capabilities
-- description: Access to data (features)
-  name: Data
-- description: Extension to OGC API - Features to support STAC metadata model and
-    search API
-  name: STAC
-- name: Data Management
-  description: |
-    Metadata management requests. Theses requests are used to create, update or delete the STAC
-    metadata.
+  - description: Essential characteristics of this API
+    name: Capabilities
+  - description: Access to data (features)
+    name: Data
+  - description: Extension to OGC API - Features to support STAC metadata model and search API
+    name: STAC
+  - name: Data Management
+    description: |
+      Metadata management requests. Theses requests are used to create, update or delete the STAC
+      metadata.
 
-    *NOTE: these requests require authentication as described in [here](#tag/Authentication).*
+      *NOTE: these requests require authentication as described in [here](#tag/Authentication).*
 
-    ## Supported Media Type
+      ## Supported Media Type
 
-    List of the current supported media types:
+      List of the current supported media types:
 
-    | Media Type | Description | File Extension(s) |
-    | ---------- | ----------- | ----------------- |
-    | application/x.ascii-grid+zip | Zipped ESRI ASCII raster format (.asc) | .zip |
-    | application/x.ascii-xyz+zip | Zipped XYZ (.xyz) | .zip |
-    | application/x.e00+zip | Zipped e00 | .zip |
-    | application/x.geotiff+zip | Zipped GeoTIFF | .zip |
-    | image/tiff; application=geotiff | GeoTIFF | .tiff, .tif |
-    | application/x.tiff+zip | Zipped TIFF | .zip |
-    | application/x.png+zip | Zipped PNG | .zip |
-    | application/x.jpeg+zip | Zipped JPEG | .zip |
-    | application/vnd.google-earth.kml+xml | KML | .kml |
-    | application/vnd.google-earth.kmz | Zipped KML | .kmz |
-    | application/x.dxf+zip | Zipped DXF | .zip |
-    | application/gml+xml | GML | .gml, .xml |
-    | application/x.gml+zip | Zipped GML | .zip |
-    | application/vnd.las | LIDAR | .las |
-    | application/vnd.laszip | Zipped LIDAR | .laz, .zip |
-    | application/x.shapefile+zip | Zipped Shapefile | .zip |
-    | application/x.filegdb+zip | Zipped File Geodatabase | .zip |
-    | application/x.filegdbp+zip | Zipped File Geodatabase (ArcGIS Pro) | .zip |
-    | application/x.ms-access+zip | Zipped Personal Geodatabase | .zip |
-    | application/x.ms-excel+zip | Zipped Excel | .zip |
-    | application/x.tab+zip | Zipped Mapinfo-TAB | .zip |
-    | application/x.tab-raster+zip | Zipped Mapinfo-Raster-TAB | .zip |
-    | application/x.csv+zip | Zipped CSV | .zip |
-    | text/csv | CSV | .csv |
-    | application/geopackage+sqlite3 | Geopackage | .gpkg |
-    | application/x.geopackage+zip | Zipped Geopackage | .zip |
-    | application/geo+json | GeoJSON (<span style="color: red">does not support auto HTTP compression !</span>) | .json, .geojson |
-    | application/x.geojson+zip | Zipped GeoJSON | .zip |
-    | application/x.interlis; version=2.3 | Interlis 2 | .xtf, .xml |
-    | application/x.interlis+zip; version=2.3 | Zipped XTF (2.3) | .zip |
-    | application/x.interlis; version=1 | Interlis 1 | .itf |
-    | application/x.interlis+zip; version=1 | Zipped ITF | .zip |
-    | image/tiff; application=geotiff; profile=cloud-optimized | Cloud Optimized GeoTIFF (COG) | .tiff, .tif |`
-    | application/pdf | PDF | .pdf |
-    | application/x.pdf+zip | Zipped PDF | .zip |
-    | application/json | JSON | .json |
-    | application/x.json+zip | Zipped JSON | .zip |
-    | application/x-netcdf | NetCDF | .nc |
-    | application/x.netcdf+zip | Zipped NetCDF | .zip |
-    | application/xml | XML | .xml |
-    | application/x.xml+zip | Zipped XML | .zip |
-    | application/vnd.mapbox-vector-tile | mbtiles | .mbtiles |
-    | text/plain | Text | .txt |
-    | text/x.plain+zip | Zipped text | .zip |
-    | application/x.dwg+zip | Zipped DWG | .zip |
-    | application/zip | Generic Zip File | .zip |
-    | image/tiff | TIFF | .tiff, .tif |
-    | image/jpeg | JPEG | .jpeg, .jpg |
-    | image/png | PNG | .png |
-    | application/vnd.sqlite3 | sqlite | .sqlite |
-- name: Asset Upload Management
-  description: |
-    Asset files are uploaded via the STAC API using the API requests described in this chapter.
+      | Media Type | Description | File Extension(s) |
+      | ---------- | ----------- | ----------------- |
+      | application/x.ascii-grid+zip | Zipped ESRI ASCII raster format (.asc) | .zip |
+      | application/x.ascii-xyz+zip | Zipped XYZ (.xyz) | .zip |
+      | application/x.e00+zip | Zipped e00 | .zip |
+      | application/x.geotiff+zip | Zipped GeoTIFF | .zip |
+      | image/tiff; application=geotiff | GeoTIFF | .tiff, .tif |
+      | application/x.tiff+zip | Zipped TIFF | .zip |
+      | application/x.png+zip | Zipped PNG | .zip |
+      | application/x.jpeg+zip | Zipped JPEG | .zip |
+      | application/vnd.google-earth.kml+xml | KML | .kml |
+      | application/vnd.google-earth.kmz | Zipped KML | .kmz |
+      | application/x.dxf+zip | Zipped DXF | .zip |
+      | application/gml+xml | GML | .gml, .xml |
+      | application/x.gml+zip | Zipped GML | .zip |
+      | application/vnd.las | LIDAR | .las |
+      | application/vnd.laszip | Zipped LIDAR | .laz, .zip |
+      | application/x.shapefile+zip | Zipped Shapefile | .zip |
+      | application/x.filegdb+zip | Zipped File Geodatabase | .zip |
+      | application/x.filegdbp+zip | Zipped File Geodatabase (ArcGIS Pro) | .zip |
+      | application/x.ms-access+zip | Zipped Personal Geodatabase | .zip |
+      | application/x.ms-excel+zip | Zipped Excel | .zip |
+      | application/x.tab+zip | Zipped Mapinfo-TAB | .zip |
+      | application/x.tab-raster+zip | Zipped Mapinfo-Raster-TAB | .zip |
+      | application/x.csv+zip | Zipped CSV | .zip |
+      | text/csv | CSV | .csv |
+      | application/geopackage+sqlite3 | Geopackage | .gpkg |
+      | application/x.geopackage+zip | Zipped Geopackage | .zip |
+      | application/geo+json | GeoJSON (<span style="color: red">does not support auto HTTP compression !</span>) | .json, .geojson |
+      | application/x.geojson+zip | Zipped GeoJSON | .zip |
+      | application/x.interlis; version=2.3 | Interlis 2 | .xtf, .xml |
+      | application/x.interlis+zip; version=2.3 | Zipped XTF (2.3) | .zip |
+      | application/x.interlis; version=1 | Interlis 1 | .itf |
+      | application/x.interlis+zip; version=1 | Zipped ITF | .zip |
+      | image/tiff; application=geotiff; profile=cloud-optimized | Cloud Optimized GeoTIFF (COG) | .tiff, .tif |`
+      | application/pdf | PDF | .pdf |
+      | application/x.pdf+zip | Zipped PDF | .zip |
+      | application/json | JSON | .json |
+      | application/x.json+zip | Zipped JSON | .zip |
+      | application/x-netcdf | NetCDF | .nc |
+      | application/x.netcdf+zip | Zipped NetCDF | .zip |
+      | application/xml | XML | .xml |
+      | application/x.xml+zip | Zipped XML | .zip |
+      | application/vnd.mapbox-vector-tile | mbtiles | .mbtiles |
+      | text/plain | Text | .txt |
+      | text/x.plain+zip | Zipped text | .zip |
+      | application/x.dwg+zip | Zipped DWG | .zip |
+      | application/zip | Generic Zip File | .zip |
+      | image/tiff | TIFF | .tiff, .tif |
+      | image/jpeg | JPEG | .jpeg, .jpg |
+      | image/png | PNG | .png |
+      | application/vnd.sqlite3 | sqlite | .sqlite |
+  - name: Asset Upload Management
+    description: |
+      Asset files are uploaded via the STAC API using the API requests described in this chapter.
 
-    - [Authentication](#section/Authentication)
-    - [Compression](#section/Compression)
-    - [Example](#section/Example)
+      - [Authentication](#section/Authentication)
+      - [Compression](#section/Compression)
+      - [Example](#section/Example)
 
-    <span style="color:red">***IMPORTANT NOTES:***</span>
-      - <span style="color:red">*Files bigger than 10 MB should use compression,
-        see [Compression](#section/Compression)*</span>
-
-
-    ## Authentication
-
-    POST/PUT requests require authentication as described in [here](#tag/Authentication).
-
-    ## Compression
-
-    Files between *1 MB* and *10 MB* are automatically compressed during download using *gzip* or
-    *br* based on the `Accept-Encoding` header of the request. But note that this compression is
-    only done for standard Media Type (see [File types that CloudFront compresses](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-cloudfront-file-types)).
-
-    <span style="color: red">It is highly recommended to upload files bigger than *10 MB* using
-    a compressed media type (see [Supported Media Type](#section/Supported-Media-Type)) !
-    If this not possible (as e.g. for json directly usd in a browser application), the file should
-    be either compressed upfront (see below) or split in smaller files.</span>
-
-    ### Upfront Compression using `content_encoding`
-
-    In the case where you have a file bigger than 10 MB that you can't split into multiple files
-    or pack into a compressed media type, then you can use the upfront compression method together
-    with the `content_encoding` parameter.
-
-    For this you need to first compress the file using gzip or br compression algorithm and then
-    use the `content_encoding` parameter in the [Create Asset's multipart upload](#tag/Asset-Upload-Management/operation/createAssetUpload)
-
-    ***NOTES:***
-     - In this case the file will be always delivered compressed, which means that the client that
-     download the file needs to be compatible with the HTTP Compression algorithm defined in
-     `Content-Encoding` header.
+      <span style="color:red">***IMPORTANT NOTES:***</span>
+        - <span style="color:red">*Files bigger than 10 MB should use compression,
+          see [Compression](#section/Compression)*</span>
 
 
-    ## Example
+      ## Authentication
 
-    ```python
-    import os
-    import hashlib
-    from base64 import b64encode
+      POST/PUT requests require authentication as described in [here](#tag/Authentication).
 
-    import requests
-    import multihash
+      ## Compression
 
-    # variables
-    scheme = 'https'
-    hostname = 'data.geo.admin.ch'
-    collection = 'ch.swisstopo.pixelkarte-farbe-pk200.noscale'
-    item = 'smr200-200-4-2016'
-    asset = 'smr200-200-4-2016-2056-kgrs-10.tiff'
-    asset_path = f'collections/{collection}/items/{item}/assets/{asset}'
-    user = os.environ.get('STAC_USER', 'unknown-user')
-    password = os.environ.get('STAC_PASSWORD', 'unknown-password')
+      Files between *1 MB* and *10 MB* are automatically compressed during download using *gzip* or
+      *br* based on the `Accept-Encoding` header of the request. But note that this compression is
+      only done for standard Media Type (see [File types that CloudFront compresses](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-cloudfront-file-types)).
 
-    with open('smr200-200-4-2016-2056-kgrs-10.tiff', 'rb') as fd:
-      data = fd.read()
+      <span style="color: red">It is highly recommended to upload files bigger than *10 MB* using
+      a compressed media type (see [Supported Media Type](#section/Supported-Media-Type)) !
+      If this not possible (as e.g. for json directly usd in a browser application), the file should
+      be either compressed upfront (see below) or split in smaller files.</span>
 
-    checksum_multihash = multihash.to_hex_string(multihash.encode(hashlib.sha256(data).digest(), 'sha2-256'))
-    md5 = b64encode(hashlib.md5(data).digest()).decode('utf-8')
+      ### Upfront Compression using `content_encoding`
 
-    # 1. Create a multipart upload
-    response = requests.post(
-      f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads",
-      auth=(user, password),
-      json={
-        "number_parts": 1,
-        "md5_parts": [{
-          "part_number": 1,
-          "md5": md5
-        }],
-        "checksum:multihash": checksum_multihash
-      }
-    )
-    upload_id = response.json()['upload_id']
+      In the case where you have a file bigger than 10 MB that you can't split into multiple files
+      or pack into a compressed media type, then you can use the upfront compression method together
+      with the `content_encoding` parameter.
 
-    # 2. Upload the part using the presigned url
-    response = requests.put(response.json()['urls'][0]['url'], data=data, headers={'Content-MD5': md5})
-    etag = response.headers['ETag']
+      For this you need to first compress the file using gzip or br compression algorithm and then
+      use the `content_encoding` parameter in the [Create Asset's multipart upload](#tag/Asset-Upload-Management/operation/createAssetUpload)
 
-    # 3. Complete the upload
-    response = requests.post(
-      f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads/{upload_id}/complete",
-      auth=(user, password),
-      json={'parts': [{'etag': etag, 'part_number': 1}]}
-    )
-    ```
+      ***NOTES:***
+       - In this case the file will be always delivered compressed, which means that the client that
+       download the file needs to be compatible with the HTTP Compression algorithm defined in
+       `Content-Encoding` header.
 
-    See https://aws.amazon.com/premiumsupport/knowledge-center/data-integrity-s3/ for other examples on how to compute the base64 MD5 of a part.
-- name: Authentication
-  description: |
-    All write requests require authentication. There is currently three type of supported authentications:
 
-    * [Session authentication](#section/Session-authentication)
-    * [Basic authentication](#section/Basic-authentication)
-    * [Token authentication](#section/Token-authentication)
+      ## Example
 
-    ## Session authentication
+      ```python
+      import os
+      import hashlib
+      from base64 import b64encode
 
-    When using the browsable API the user can simply use the admin interface for logging in.
-    Once logged in, the browsable API can be used to perform write requests.
+      import requests
+      import multihash
 
-    ## Basic authentication
+      # variables
+      scheme = 'https'
+      hostname = 'data.geo.admin.ch'
+      collection = 'ch.swisstopo.pixelkarte-farbe-pk200.noscale'
+      item = 'smr200-200-4-2016'
+      asset = 'smr200-200-4-2016-2056-kgrs-10.tiff'
+      asset_path = f'collections/{collection}/items/{item}/assets/{asset}'
+      user = os.environ.get('STAC_USER', 'unknown-user')
+      password = os.environ.get('STAC_PASSWORD', 'unknown-password')
 
-    The username and password for authentication can be added to every write request the user wants to perform.
-    Here is an example of posting an asset using curl (_username_="MickeyMouse", _password_="I_love_Minnie_Mouse"):
+      with open('smr200-200-4-2016-2056-kgrs-10.tiff', 'rb') as fd:
+        data = fd.read()
 
-    ```
-    curl --request POST \
-      --user MickeyMouse:I_love_Minnie_Mouse \
-      --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
-      --header 'Content-Type: application/json' \
-      --data '{
-        "id": "fancy_unique_id",
-        "item": "swisstlmregio-2020",
-        "title": "My title",
-        "type": "application/x.filegdb+zip",
-        "description": "My description",
-        "proj:epsg": 2056,
-        "checksum:multihash": "12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC"
-    }'
-    ```
+      checksum_multihash = multihash.to_hex_string(multihash.encode(hashlib.sha256(data).digest(), 'sha2-256'))
+      md5 = b64encode(hashlib.md5(data).digest()).decode('utf-8')
 
-    ## Token authentication
+      # 1. Create a multipart upload
+      response = requests.post(
+        f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads",
+        auth=(user, password),
+        json={
+          "number_parts": 1,
+          "md5_parts": [{
+            "part_number": 1,
+            "md5": md5
+          }],
+          "checksum:multihash": checksum_multihash
+        }
+      )
+      upload_id = response.json()['upload_id']
 
-    A user specific token for authentication can be added to every write request the user wants to perform.
-    Here is an example of posting an asset using curl:
+      # 2. Upload the part using the presigned url
+      response = requests.put(response.json()['urls'][0]['url'], data=data, headers={'Content-MD5': md5})
+      etag = response.headers['ETag']
 
-    ```
-    curl --request POST \
-      --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
-      --header 'Authorization: Token ccecf40693bfc52ba090cd46eb7f19e723fe831f' \
-      --header 'Content-Type: application/json' \
-      --data '{
-        "id": "fancy_unique_id",
-        "item": "swisstlmregio-2020",
-        "title": "My title",
-        "type": "application/x.filegdb+zip",
-        "description": "My description",
-        "proj:epsg": 2056,
-        "checksum:multihash": "12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC"
-    }'
-    ```
+      # 3. Complete the upload
+      response = requests.post(
+        f"{scheme}://{hostname}/api/stac/v0.9/{asset_path}/uploads/{upload_id}/complete",
+        auth=(user, password),
+        json={'parts': [{'etag': etag, 'part_number': 1}]}
+      )
+      ```
 
-    Tokens can either be generated in the admin interface or existing users can perform a POST request
-    on the get-token endpoint to request a token (also see [Request token for token authentication](#operation/getToken)).
-    Here is an example using curl:
+      See https://aws.amazon.com/premiumsupport/knowledge-center/data-integrity-s3/ for other examples on how to compute the base64 MD5 of a part.
+  - name: Authentication
+    description: |
+      All write requests require authentication. There is currently three type of supported authentications:
 
-    ```
-    curl --request POST \
-      --url https://data.geoadmin.ch/api/stac/get-token \
-      --header 'Content-Type: application/json' \
-      --data '{"username": "MickeyMouse", "password": "I_love_Minnie_Mouse"}'
-    ```
+      * [Session authentication](#section/Session-authentication)
+      * [Basic authentication](#section/Basic-authentication)
+      * [Token authentication](#section/Token-authentication)
+
+      ## Session authentication
+
+      When using the browsable API the user can simply use the admin interface for logging in.
+      Once logged in, the browsable API can be used to perform write requests.
+
+      ## Basic authentication
+
+      The username and password for authentication can be added to every write request the user wants to perform.
+      Here is an example of posting an asset using curl (_username_="MickeyMouse", _password_="I_love_Minnie_Mouse"):
+
+      ```
+      curl --request POST \
+        --user MickeyMouse:I_love_Minnie_Mouse \
+        --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+        --header 'Content-Type: application/json' \
+        --data '{
+          "id": "fancy_unique_id",
+          "item": "swisstlmregio-2020",
+          "title": "My title",
+          "type": "application/x.filegdb+zip",
+          "description": "My description",
+          "proj:epsg": 2056,
+          "checksum:multihash": "12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC"
+      }'
+      ```
+
+      ## Token authentication
+
+      A user specific token for authentication can be added to every write request the user wants to perform.
+      Here is an example of posting an asset using curl:
+
+      ```
+      curl --request POST \
+        --url https://data.geoadmin.ch/api/stac/v0.9/collections/ch.swisstopo.swisstlmregio/items/swisstlmregio-2020/assets \
+        --header 'Authorization: Token ccecf40693bfc52ba090cd46eb7f19e723fe831f' \
+        --header 'Content-Type: application/json' \
+        --data '{
+          "id": "fancy_unique_id",
+          "item": "swisstlmregio-2020",
+          "title": "My title",
+          "type": "application/x.filegdb+zip",
+          "description": "My description",
+          "proj:epsg": 2056,
+          "checksum:multihash": "12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC"
+      }'
+      ```
+
+      Tokens can either be generated in the admin interface or existing users can perform a POST request
+      on the get-token endpoint to request a token (also see [Request token for token authentication](#operation/getToken)).
+      Here is an example using curl:
+
+      ```
+      curl --request POST \
+        --url https://data.geoadmin.ch/api/stac/get-token \
+        --header 'Content-Type: application/json' \
+        --data '{"username": "MickeyMouse", "password": "I_love_Minnie_Mouse"}'
+      ```
 paths:
   /:
     get:
       description: >-
-        The landing page provides links to the API definition, the conformance statements
-        and to the feature collections in this dataset.
+        The landing page provides links to the API definition, the conformance statements and to the feature collections in this dataset.
       operationId: getLandingPage
       responses:
         "200":
@@ -260,12 +255,12 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Landing page
       tags:
-      - Capabilities
+        - Capabilities
   /collections:
     get:
       operationId: getCollections
       parameters:
-      - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           $ref: "#/components/responses/Collections"
@@ -274,14 +269,14 @@ paths:
       summary: Fetch collections
       description: The feature collections in the dataset
       tags:
-      - Data
+        - Data
   /collections/{collectionId}:
     get:
       operationId: describeCollection
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           $ref: "#/components/responses/Collection"
@@ -296,41 +291,38 @@ paths:
       summary: Fetch a single collection
       description: Describe the feature collection with id `collectionId`
       tags:
-      - Data
+        - Data
     put:
       tags:
-      - Data Management
+        - Data Management
       summary: Update or create a collection
       description: >-
-        Update or create a collection with Id `collectionId` with a complete collection
-        definition. If the collection doesn't exists it is then created.
+        Update or create a collection with Id `collectionId` with a complete collection definition. If the collection doesn't exists it is then created.
       operationId: updateCollection
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/collectionWrite"
             example:
-              description: The National Map 1:200,000 is a topographic map giving
-                an overview of Switzerland.
+              description: The National Map 1:200,000 is a topographic map giving an overview of Switzerland.
               id: ch.swisstopo.pixelkarte-farbe-pk200.noscale
               license: proprietary
               links:
-              - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-                rel: license
-                title: Licence for the free geodata of the Federal Office of Topography
-                  swisstopo
-              - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-                rel: describedby
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
               providers:
-              - name: Federal Office of Topography - swisstopo
-                roles:
-                - producer
-                - licensor
-                url: https://www.swisstopo.admin.ch
+                - name: Federal Office of Topography - swisstopo
+                  roles:
+                    - producer
+                    - licensor
+                  url: https://www.swisstopo.admin.ch
               title: National Map 1:200'000
       responses:
         "200":
@@ -361,15 +353,14 @@ paths:
           $ref: "#/components/responses/ServerError"
     patch:
       tags:
-      - Data Management
+        - Data Management
       summary: Partial update of a collection
       description: >-
-        Update an existing collection with Id `collectionId` with a partial collection
-        definition
+        Update an existing collection with Id `collectionId` with a partial collection definition
       operationId: partialUpdateCollection
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IfMatch"
       requestBody:
         content:
           application/json:
@@ -379,18 +370,17 @@ paths:
               id: ch.swisstopo.pixelkarte-farbe-pk200.noscale
               license: proprietary
               links:
-              - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-                rel: license
-                title: Licence for the free geodata of the Federal Office of Topography
-                  swisstopo
-              - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-                rel: describedby
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
               providers:
-              - name: Federal Office of Topography - swisstopo
-                roles:
-                - producer
-                - licensor
-                url: https://www.swisstopo.admin.ch
+                - name: Federal Office of Topography - swisstopo
+                  roles:
+                    - producer
+                    - licensor
+                  url: https://www.swisstopo.admin.ch
               title: National Map 1:200'000
       responses:
         "200":
@@ -413,18 +403,16 @@ paths:
         Fetch features of the feature collection with id `collectionId`.
 
 
-        Every feature in a dataset belongs to a collection. A dataset may consist
-        of multiple feature collections. A feature collection is often a collection
-        of features of a similar type, based on a common schema.
+        Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema.
 
 
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeatures
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/limit"
-      - $ref: "#/components/parameters/bbox"
-      - $ref: "#/components/parameters/datetime"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/datetime"
       responses:
         "200":
           $ref: "#/components/responses/Features"
@@ -436,7 +424,7 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch features
       tags:
-      - Data
+        - Data
   /collections/{collectionId}/items/{featureId}:
     get:
       description: >-
@@ -446,10 +434,10 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getFeature
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           $ref: "#/components/responses/Feature"
@@ -463,24 +451,21 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch a single feature
       tags:
-      - Data
+        - Data
     put:
       summary: Update or create a feature
       description: >-
-        Update or create a feature with Id `featureId` with a complete feature definition.
-        If the feature doesn't exists it is then created.
+        Update or create a feature with Id `featureId` with a complete feature definition. If the feature doesn't exists it is then created.
 
 
-        *NOTE: Optional fields that are not part of the PUT payload, will be erased
-        in the resource. For example if the resource has a properties.title and the
-        PUT payload doesn't, then the resource's properties.title will be removed.*
+        *NOTE: Optional fields that are not part of the PUT payload, will be erased in the resource. For example if the resource has a properties.title and the PUT payload doesn't, then the resource's properties.title will be removed.*
       operationId: putFeature
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       requestBody:
         content:
           application/json:
@@ -491,26 +476,25 @@ paths:
               geometry:
                 type: Polygon
                 coordinates:
-                - - - 7.0906823
-                    - 45.9160584
-                  - - 7.1035698
-                    - 45.9160977
-                  - - 7.1035146
-                    - 45.925093
-                  - - 7.0906249
-                    - 45.9250537
-                  - - 7.0906823
-                    - 45.9160584
+                  - - - 7.0906823
+                      - 45.9160584
+                    - - 7.1035698
+                      - 45.9160977
+                    - - 7.1035146
+                      - 45.925093
+                    - - 7.0906249
+                      - 45.9250537
+                    - - 7.0906823
+                      - 45.9160584
               properties:
                 datetime: "2016-05-03T13:22:30.040Z"
                 title: A CS3 item
               links:
-              - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-                rel: license
-                title: Licence for the free geodata of the Federal Office of Topography
-                  swisstopo
-              - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-                rel: describedby
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
       responses:
         "200":
           description: Returns the updated Item
@@ -543,15 +527,14 @@ paths:
     patch:
       summary: Update an existing feature by Id with a partial item definition
       description: >-
-        Use this method to update an existing feature. Requires a JSON fragment (containing
-        the fields to be updated) be submitted.
+        Use this method to update an existing feature. Requires a JSON fragment (containing the fields to be updated) be submitted.
       operationId: patchFeature
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       requestBody:
         content:
           application/json:
@@ -591,11 +574,11 @@ paths:
       description: Use this method to delete an existing feature/item.
       operationId: deleteFeature
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       responses:
         "200":
           $ref: "#/components/responses/DeletedResource"
@@ -609,15 +592,15 @@ paths:
           $ref: "#/components/responses/ServerError"
   /{assetObjectHref}:
     servers:
-    - url: http://data.geo.admin.ch/
+      - url: http://data.geo.admin.ch/
     parameters:
-    - $ref: "#/components/parameters/assetObjectHref"
+      - $ref: "#/components/parameters/assetObjectHref"
     get:
       tags:
-      - Data
+        - Data
       summary: Fetch an asset object
       parameters:
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       operationId: getAssetObject
       description: |
         Return an asset object
@@ -733,8 +716,7 @@ paths:
   /conformance:
     get:
       description: >-
-        A list of all conformance classes specified in a standard that the server
-        conforms to.
+        A list of all conformance classes specified in a standard that the server conforms to.
       operationId: getConformanceDeclaration
       responses:
         "200":
@@ -743,18 +725,18 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Information about specifications that this API conforms to
       tags:
-      - Capabilities
+        - Capabilities
   /search:
     get:
       description: >-
         Retrieve Items matching filters. Intended as a shorthand API for simple queries.
       operationId: getSearchSTAC
       parameters:
-      - $ref: "#/components/parameters/bbox"
-      - $ref: "#/components/parameters/datetime"
-      - $ref: "#/components/parameters/limit"
-      - $ref: "#/components/parameters/ids"
-      - $ref: "#/components/parameters/collectionsArray"
+        - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/datetime"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/ids"
+        - $ref: "#/components/parameters/collectionsArray"
       responses:
         "200":
           content:
@@ -766,11 +748,10 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Search STAC items with simple filtering.
       tags:
-      - STAC
+        - STAC
     post:
       description: >-
-        Retrieve items matching filters. Intended as the standard, full-featured query
-        API.
+        Retrieve items matching filters. Intended as the standard, full-featured query API.
       operationId: postSearchSTAC
       requestBody:
         content:
@@ -788,7 +769,7 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Search STAC items with full-featured filtering.
       tags:
-      - STAC
+        - STAC
   /collections/{collectionId}/items/{featureId}/assets:
     get:
       description: >-
@@ -797,8 +778,8 @@ paths:
         Every asset belongs to an item.
       operationId: getAssets
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
       responses:
         "200":
           $ref: "#/components/responses/Assets"
@@ -810,19 +791,18 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch all assets for a feature
       tags:
-      - Data
+        - Data
   /collections/{collectionId}/items/{featureId}/assets/{assetId}:
     get:
       description: >-
-        Fetch the asset with id `assetId` of the feature with id `featureId` in the
-        feature collection with id `collectionId`.
+        Fetch the asset with id `assetId` of the feature with id `featureId` in the feature collection with id `collectionId`.
       operationId: getAsset
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/assetId"
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           $ref: "#/components/responses/Asset"
@@ -836,23 +816,22 @@ paths:
           $ref: "#/components/responses/ServerError"
       summary: Fetch a single asset
       tags:
-      - Data
+        - Data
     put:
       summary: Update or create an asset
       description: >-
-        Update or create an asset with Id `assetId` with a complete asset definition.
-        If the asset doesn't exists it is then created.
+        Update or create an asset with Id `assetId` with a complete asset definition. If the asset doesn't exists it is then created.
 
 
         *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: putAsset
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/assetId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       requestBody:
         content:
           application/json:
@@ -888,19 +867,18 @@ paths:
     patch:
       summary: Update an existing asset by Id with a partial asset definition
       description: >-
-        Use this method to update an existing asset. Requires a JSON fragment (containing
-        the fields to be updated) be submitted.
+        Use this method to update an existing asset. Requires a JSON fragment (containing the fields to be updated) be submitted.
 
 
         *Note: to upload an asset file see [Asset Upload Management](#tag/Asset-Upload-Management)*
       operationId: patchAsset
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/assetId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       requestBody:
         content:
           application/json:
@@ -930,12 +908,12 @@ paths:
         **NOTE: Asset file on S3 will be also removed !**
       operationId: deleteAsset
       tags:
-      - Data Management
+        - Data Management
       parameters:
-      - $ref: "#/components/parameters/collectionId"
-      - $ref: "#/components/parameters/featureId"
-      - $ref: "#/components/parameters/assetId"
-      - $ref: "#/components/parameters/IfMatchWrite"
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/featureId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
       responses:
         "200":
           $ref: "#/components/responses/DeletedResource"
@@ -949,24 +927,23 @@ paths:
           $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads:
     parameters:
-    - $ref: "#/components/parameters/collectionId"
-    - $ref: "#/components/parameters/featureId"
-    - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
     get:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: List all Asset's multipart uploads
       description: >-
-        Return a list of all Asset's multipart uploads that are in progress and have
-        been completed or aborted.
+        Return a list of all Asset's multipart uploads that are in progress and have been completed or aborted.
       operationId: getAssetUploads
       parameters:
-      - name: status
-        in: query
-        description: Filter the list by status.
-        schema:
-          $ref: "#/components/schemas/status"
-      - $ref: "#/components/parameters/limit"
+        - name: status
+          in: query
+          description: Filter the list by status.
+          schema:
+            $ref: "#/components/schemas/status"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           description: List of Asset's uploads
@@ -976,30 +953,30 @@ paths:
                 $ref: "#/components/schemas/assetUploads"
               example:
                 uploads:
-                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnusebaJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
-                  status: in-progress
-                  number_parts: 1
-                  urls:
-                  - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff
-                    part: 1
-                    expires: "2019-08-24T14:15:22Z"
-                  created: "2019-08-24T14:15:22Z"
-                  checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
-                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YaaegJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
-                  status: completed
-                  number_parts: 1
-                  created: "2019-08-24T14:15:22Z"
-                  completed: "2019-08-24T14:15:22Z"
-                  checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
-                - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
-                  status: aborted
-                  number_parts: 1
-                  created: "2019-08-24T14:15:22Z"
-                  aborted: "2019-08-24T14:15:22Z"
-                  checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnusebaJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: in-progress
+                    number_parts: 1
+                    urls:
+                      - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff
+                        part: 1
+                        expires: "2019-08-24T14:15:22Z"
+                    created: "2019-08-24T14:15:22Z"
+                    checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YaaegJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: completed
+                    number_parts: 1
+                    created: "2019-08-24T14:15:22Z"
+                    completed: "2019-08-24T14:15:22Z"
+                    checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
+                  - upload_id: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
+                    status: aborted
+                    number_parts: 1
+                    created: "2019-08-24T14:15:22Z"
+                    aborted: "2019-08-24T14:15:22Z"
+                    checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
                 links:
-                - rel: next
-                  href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+                  - rel: next
+                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -1008,7 +985,7 @@ paths:
           $ref: "#/components/responses/ServerError"
     post:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Create a new Asset's multipart upload
       description: |
         Create Asset's multipart upload.
@@ -1041,8 +1018,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Another upload is already in progress, you need first to complete
-            or abort it before creating a new upload.
+          description: Another upload is already in progress, you need first to complete or abort it before creating a new upload.
           content:
             application/json:
               schema:
@@ -1051,20 +1027,20 @@ paths:
           $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}:
     parameters:
-    - $ref: "#/components/parameters/collectionId"
-    - $ref: "#/components/parameters/featureId"
-    - $ref: "#/components/parameters/assetId"
-    - $ref: "#/components/parameters/uploadId"
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
     get:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Get an Asset's multipart upload
       description: |
         Return an Asset's multipart upload.
       operationId: getAssetUpload
       parameters:
-      - $ref: "#/components/parameters/IfMatch"
-      - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           description: Asset's multipart upload description.
@@ -1092,52 +1068,44 @@ paths:
           $ref: "#/components/responses/ServerError"
   /storage-prefix/{presignedUrl}:
     servers:
-    - url: https://s3.aws-region.amazonaws.com/
+      - url: https://s3.aws-region.amazonaws.com/
     parameters:
-    - $ref: "#/components/parameters/presignedUrl"
+      - $ref: "#/components/parameters/presignedUrl"
     put:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Upload asset file part
       description: >-
-        Upload an Asset file part using the presigned url(s) returned by [Create a
-        new Asset's multipart upload](#operation/createAssetUpload).
+        Upload an Asset file part using the presigned url(s) returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
 
-        Parts that have been uploaded but not completed can be checked using [Get
-        an Asset's multipart upload](#operation/getAssetUpload)
+        Parts that have been uploaded but not completed can be checked using [Get an Asset's multipart upload](#operation/getAssetUpload)
 
-        A file part must be at least 5 MB except for the last one and at most 5 GB,
-        otherwise the complete operation will fail.
+        A file part must be at least 5 MB except for the last one and at most 5 GB, otherwise the complete operation will fail.
 
-        *Note: this endpoint doesn't require any authentication as it is already part
-        of the presigned url*
+        *Note: this endpoint doesn't require any authentication as it is already part of the presigned url*
       operationId: uploadAssetFilePart
       parameters:
-      - name: Content-MD5
-        in: header
-        description: The base64-encoded 128-bit MD5 digest of this part.
-        required: true
-        schema:
-          type: string
-          example: yLLiDqX2OL7mcIMTjob60A==
+        - name: Content-MD5
+          in: header
+          description: The base64-encoded 128-bit MD5 digest of this part.
+          required: true
+          schema:
+            type: string
+            example: yLLiDqX2OL7mcIMTjob60A==
       responses:
         "200":
-          description: Asset file part uploaded part successfully (Response has no
-            content).
+          description: Asset file part uploaded part successfully (Response has no content).
           content: {}
           headers:
             ETag:
               schema:
                 type: string
               description: >-
-                The RFC7232 ETag header field in a response provides the current entity-
-                tag for the selected resource.
+                The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource.
 
                 This ETag is required in the complete multipart upload payload.
 
-                An entity-tag is an opaque identifier for different versions of a
-                resource over time, regardless whether multiple versions are valid
-                at the same time. An entity-tag consists of an opaque quoted string.
+                An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string.
               example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
               required: true
         "400":
@@ -1147,18 +1115,18 @@ paths:
               schema:
                 type: object
                 required:
-                - Error
+                  - Error
                 properties:
                   Error:
                     type: object
                     required:
-                    - Code
-                    - Message
+                      - Code
+                      - Message
                     properties:
                       Code:
                         type: string
                         enum:
-                        - "BadDigest"
+                          - "BadDigest"
                       Message:
                         type: string
                     additionalProperties:
@@ -1174,25 +1142,24 @@ paths:
                   <HostId>kDMsU45sQ4oZjkTgba2SNBy/0RMshW2lEWmfKnaotvViav5Qlyz4aSQdmS9FRVKp1HgJUBj3h5w=</HostId>
                 </Error>
         "403":
-          description: Asset file part upload Bad Request, Signature does not match
-            (e.g. missing Content-MD5 header).
+          description: Asset file part upload Bad Request, Signature does not match (e.g. missing Content-MD5 header).
           content:
             application/xml:
               schema:
                 type: object
                 required:
-                - Error
+                  - Error
                 properties:
                   Error:
                     type: object
                     required:
-                    - Code
-                    - Message
+                      - Code
+                      - Message
                     properties:
                       Code:
                         type: string
                         enum:
-                        - "SignatureDoesNotMatch"
+                          - "SignatureDoesNotMatch"
                       Message:
                         type: string
                     additionalProperties:
@@ -1225,20 +1192,17 @@ paths:
                 </Error>
   /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/complete:
     parameters:
-    - $ref: "#/components/parameters/collectionId"
-    - $ref: "#/components/parameters/featureId"
-    - $ref: "#/components/parameters/assetId"
-    - $ref: "#/components/parameters/uploadId"
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
     post:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Complete multipart upload
       operationId: completeMultipartUpload
       description: >-
-        Complete the multipart upload process. After completion, the Asset metadata
-        are updated with the new `checksum:multihash` from the upload and the parts
-        are automatically deleted. The Asset `href` field is also set if it was the
-        first upload.
+        Complete the multipart upload process. After completion, the Asset metadata are updated with the new `checksum:multihash` from the upload and the parts are automatically deleted. The Asset `href` field is also set if it was the first upload.
       requestBody:
         content:
           application/json:
@@ -1268,18 +1232,17 @@ paths:
           $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/abort:
     parameters:
-    - $ref: "#/components/parameters/collectionId"
-    - $ref: "#/components/parameters/featureId"
-    - $ref: "#/components/parameters/assetId"
-    - $ref: "#/components/parameters/uploadId"
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
     post:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Abort multipart upload
       operationId: abortMultipartUpload
       description: >-
-        Abort the multipart upload process. All already uploaded parts are automatically
-        deleted.
+        Abort the multipart upload process. All already uploaded parts are automatically deleted.
       responses:
         "200":
           description: Asset multipart upload aborted successfully.
@@ -1295,13 +1258,13 @@ paths:
           $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}/parts:
     parameters:
-    - $ref: "#/components/parameters/collectionId"
-    - $ref: "#/components/parameters/featureId"
-    - $ref: "#/components/parameters/assetId"
-    - $ref: "#/components/parameters/uploadId"
+      - $ref: "#/components/parameters/collectionId"
+      - $ref: "#/components/parameters/featureId"
+      - $ref: "#/components/parameters/assetId"
+      - $ref: "#/components/parameters/uploadId"
     get:
       tags:
-      - Asset Upload Management
+        - Asset Upload Management
       summary: Get upload parts
       operationId: getUploadParts
       description: >-
@@ -1310,11 +1273,9 @@ paths:
 
         ### Pagination
 
-        By default all parts are returned (maximum number of parts being 100). The
-        user can use pagination to reduce the number of returned parts. Pagination
-        is done via the `limit` query parameter (see below).
+        By default all parts are returned (maximum number of parts being 100). The user can use pagination to reduce the number of returned parts. Pagination is done via the `limit` query parameter (see below).
       parameters:
-      - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           description: List of parts already uploaded.
@@ -1330,10 +1291,10 @@ paths:
           $ref: "#/components/responses/ServerError"
   /get-token:
     servers:
-    - url: http://data.geo.admin.ch/api/stac/
+      - url: http://data.geo.admin.ch/api/stac/
     post:
       tags:
-      - Authentication
+        - Authentication
       summary: >-
         Request token for token authentication.
       operationId: getToken
@@ -1351,8 +1312,8 @@ paths:
                   type: string
                   description: password of user for whom token is requested
               required:
-              - username
-              - password
+                - username
+                - password
             example:
               username: "Mickey Mouse"
               password: "I_love_Minnie_Mouse"
@@ -1397,24 +1358,18 @@ components:
         Information about the feature collection with id `collectionId`.
 
 
-        The response contains a link to the items in the collection (path `/collections/{collectionId}/items`,
-        link relation `items`) as well as key information about the collection. This
-        information includes:
+        The response contains a link to the items in the collection (path `/collections/{collectionId}/items`, link relation `items`) as well as key information about the collection. This information includes:
 
 
         * A local identifier for the collection that is unique for the dataset
 
-        * A list of coordinate reference systems (CRS) in which geometries may be
-        returned by the server. The first CRS is the default coordinate reference
-        system (the default is always WGS 84 with axis order longitude/latitude)
+        * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude)
 
         * An optional title and description for the collection
 
-        * An optional extent that can be used to provide an indication of the spatial
-        and temporal extent of the collection - typically derived from the data
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data
 
-        * An optional indicator about the type of the items in the collection (the
-        default value, if the indicator is not provided, is 'feature')
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature')
     Collections:
       content:
         application/json:
@@ -1424,50 +1379,38 @@ components:
         The feature collections shared by this API.
 
 
-        The dataset is organized as one or more feature collections. This resource
-        provides information about and access to the collections.
+        The dataset is organized as one or more feature collections. This resource provides information about and access to the collections.
 
 
-        The response contains the list of collections. For each collection, a link
-        to the items in the collection (path `/collections/{collectionId}/items`,
-        link relation `items`) as well as key information about the collection. This
-        information includes:
+        The response contains the list of collections. For each collection, a link to the items in the collection (path `/collections/{collectionId}/items`, link relation `items`) as well as key information about the collection. This information includes:
 
 
         * A local identifier for the collection that is unique for the dataset
 
-        * A list of coordinate reference systems (CRS) in which geometries may be
-        returned by the server. The first CRS is the default coordinate reference
-        system (the default is always WGS 84 with axis order longitude/latitude)
+        * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude)
 
         * An optional title and description for the collection
 
-        * An optional extent that can be used to provide an indication of the spatial
-        and temporal extent of the collection - typically derived from the data
+        * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data
 
-        * An optional indicator about the type of the items in the collection (the
-        default value, if the indicator is not provided, is 'feature').
+        * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
 
-        The `limit` parameter may be used to control the subset of the selected collections
-        that should be returned in the response, the page size. Each page include
-        links to support paging (link relation `next` and/or `previous`).
+        The `limit` parameter may be used to control the subset of the selected collections that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
     ConformanceDeclaration:
       content:
         application/json:
           example:
             conformsTo:
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
-            - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
+              - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
           schema:
             $ref: "#/components/schemas/confClasses"
       description: >-
         The URIs of all conformance classes supported by the server.
 
 
-        To support "generic" clients that want to access multiple OGC API Features
-        implementations - and not "just" a specific API / server, the server declares
-        the conformance classes it implements and conforms to.
+        To support "generic" clients that want to access multiple OGC API Features implementations - and not "just" a specific API / server, the server declares the conformance classes it implements and conforms to.
     Feature:
       headers:
         ETag:
@@ -1484,24 +1427,13 @@ components:
           schema:
             $ref: "#/components/schemas/items"
       description: >-
-        The response is a document consisting of features in the collection. The features
-        included in the response are determined by the server based on the query parameters
-        of the request. To support access to larger collections without overloading
-        the client, the API supports paged access with links to the next page, if
-        more features are selected that the page size.
+        The response is a document consisting of features in the collection. The features included in the response are determined by the server based on the query parameters of the request. To support access to larger collections without overloading the client, the API supports paged access with links to the next page, if more features are selected that the page size.
 
 
-        The `bbox` and `datetime` parameter can be used to select only a subset of
-        the features in the collection (the features that are in the bounding box
-        or time interval). The `bbox` parameter matches all features in the collection
-        that are not associated with a location, too. The `datetime` parameter matches
-        all features in the collection that are not associated with a time stamp or
-        interval, too.
+        The `bbox` and `datetime` parameter can be used to select only a subset of the features in the collection (the features that are in the bounding box or time interval). The `bbox` parameter matches all features in the collection that are not associated with a location, too. The `datetime` parameter matches all features in the collection that are not associated with a time stamp or interval, too.
 
 
-        The `limit` parameter may be used to control the subset of the selected features
-        that should be returned in the response, the page size. Each page include
-        links to support paging (link relation `next` and/or `previous`).
+        The `limit` parameter may be used to control the subset of the selected features that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
     NotModified:
       description: The cached resource was not modified since last request.
     InvalidParameter:
@@ -1520,35 +1452,32 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-            - href: http://data.geo.admin.ch/api/stac/v0.9/
-              rel: self
-              type: application/json
-              title: this document
-            - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
-              rel: service-doc
-              type: text/html
-              title: the API documentation
-            - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
-              rel: conformance
-              type: application/json
-              title: OGC API conformance classes implemented by this server
-            - href: http://data.geo.admin.ch/api/stac/v0.9/collections
-              rel: data
-              type: application/json
-              title: Information about the feature collections
-            - href: http://data.geo.admin.ch/api/stac/v0.9/search
-              rel: search
-              type: application/json
-              title: Search across feature collections
+              - href: http://data.geo.admin.ch/api/stac/v0.9/
+                rel: self
+                type: application/json
+                title: this document
+              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+                rel: service-doc
+                type: text/html
+                title: the API documentation
+              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+                rel: conformance
+                type: application/json
+                title: OGC API conformance classes implemented by this server
+              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+                rel: data
+                type: application/json
+                title: Information about the feature collections
+              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+                rel: search
+                type: application/json
+                title: Search across feature collections
             stac_version: 0.9.0
             title: data.geo.admin.ch
           schema:
             $ref: "#/components/schemas/landingPage"
       description: >-
-        The landing page provides links to the API definition (link relations `service-desc`
-        and `service-doc`), the Conformance declaration (path `/conformance`, link
-        relation `conformance`), and the Feature Collections (path `/collections`,
-        link relation `data`).
+        The landing page provides links to the API definition (link relations `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`, link relation `conformance`), and the Feature Collections (path `/collections`, link relation `data`).
     NotFound:
       description: The specified resource/URI was not found
       content:
@@ -1590,11 +1519,9 @@ components:
             code: 403
             description: "Permission denied"
     PreconditionFailed:
-      description: Some condition specified by the request could not be met in the
-        server
+      description: Some condition specified by the request could not be met in the server
     PreconditionFailedS3:
-      description: Some condition specified by the request could not be met in the
-        server
+      description: Some condition specified by the request could not be met in the server
       content:
         application/xml:
           schema:
@@ -1609,8 +1536,7 @@ components:
             </Error>
     ServerError:
       description: >-
-        The request was syntactically and semantically valid, but an error occurred
-        while trying to act upon it
+        The request was syntactically and semantically valid, but an error occurred while trying to act upon it
       content:
         application/json:
           schema:
@@ -1655,14 +1581,13 @@ components:
                 items:
                   $ref: "#/components/schemas/link"
                 description: >-
-                  The array contain at least a link to the parent resource (`rel:
-                  parent`).
+                  The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-                  rel: parent
+                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                    rel: parent
             required:
-            - code
-            - links
+              - code
+              - links
   schemas:
     assetQuery:
       additionalProperties:
@@ -1692,54 +1617,47 @@ components:
       type: object
     assetQueryProp:
       anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
+        - description: >-
+            If the object doesn't contain any of the operators, it is equivalent to using the equals operator
+        - description: Match using an operator
+          properties:
+            contains:
+              description: >-
+                Find items with a property that contains the specified literal string, e.g., matches ".*<STRING>.*". A case-insensitive comparison must be performed.
+              type: string
+            endsWith:
+              description: >-
+                Find items with a property that ends with the specified string. A case-insensitive comparison must be performed.
+              type: string
+            eq:
+              description: >-
+                Find items with a property that is equal to the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
               oneOf:
-              - type: string
-              - type: number
-            type: array
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
+                - type: string
+                - type: number
+                - type: boolean
+            in:
+              description: >-
+                Find items with a property that equals at least one entry in the specified array. A case-insensitive comparison must be performed.
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+              type: array
+            startsWith:
+              description: >-
+                Find items with a property that begins with the specified string. A case-insensitive comparison must be performed.
+              type: string
+          type: object
       description: Apply query operations to a specific property
     assetBase:
       title: Asset
       description: The `property name` defines the ID of the Asset.
       type: object
       required:
-      - created
-      - updated
+        - created
+        - updated
       properties:
         title:
           $ref: "#/components/schemas/title"
@@ -1784,10 +1702,10 @@ components:
         represented in JSON as `[5.96, 45.82, 10.49, 47.81]` and in a query as
         `bbox=5.96,45.82,10.49,47.81`."
       example:
-      - 7.0906249
-      - 45.9160584
-      - 7.1035698
-      - 45.925093
+        - 7.0906249
+        - 45.9160584
+        - 7.1035698
+        - 45.925093
       items:
         type: number
       maxItems: 4
@@ -1796,8 +1714,7 @@ components:
       readOnly: true
     bboxfilter:
       description: >-
-        Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four numbers:
+        Only features that have a geometry that intersects the bounding box are selected. The bounding box is provided as four numbers:
 
 
         * Lower left corner, coordinate axis 1
@@ -1809,24 +1726,18 @@ components:
         * Upper right corner, coordinate axis 2
 
 
-        The coordinate reference system of the values is WGS84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+        The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
-        For WGS84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value (west-most
-        box edge) is larger than the third value (east-most box edge).
+        For WGS84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude, maximum longitude and maximum latitude. However, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third value (east-most box edge).
 
 
-        Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E
-        and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82,
-        10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
+        Example: The bounding box of Switzerland in WGS 84 (from 5.96°E to 10.49°E and from 45.82°N to 47.81°N) would be represented in JSON as `[5.96, 45.82, 10.49, 47.81]` and in a query as `bbox=5.96,45.82,10.49,47.81`."
       example:
-      - 7.0906249
-      - 45.9160584
-      - 7.1035698
-      - 45.925093
+        - 7.0906249
+        - 45.9160584
+        - 7.1035698
+        - 45.925093
       items:
         type: number
       maxItems: 4
@@ -1846,8 +1757,7 @@ components:
       type: string
     checksumMultihash:
       description: >-
-        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/)
-        format.
+        `sha2-256` checksum of the asset in [multihash](https://multiformats.io/multihash/) format.
       example: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
       pattern: ^[a-f0-9]+$
       title: Multihash
@@ -1870,10 +1780,10 @@ components:
       properties:
         crs:
           default:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           description: The list of coordinate reference systems supported by the service
           example:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           items:
             type: string
           type: array
@@ -1881,16 +1791,10 @@ components:
         description:
           description: A description of the features in the collection
           example: >-
-            Swiss Map Raster are a conversion of the map image into a digital form
-            with no direct bearing on the individual map elements.
+            Swiss Map Raster are a conversion of the map image into a digital form with no direct bearing on the individual map elements.
 
 
-            The information is structured only in colour layers. Swiss Map Raster
-            pixel maps are ideal for finding background information for a broad variety
-            of screen applications, web and mobile applications and services, as well
-            as for geographic information systems. They can also be used as basic
-            maps for a variety of purposes (digital printing, plots, offset printing,
-            etc.).
+            The information is structured only in colour layers. Swiss Map Raster pixel maps are ideal for finding background information for a broad variety of screen applications, web and mobile applications and services, as well as for geographic information systems. They can also be used as basic maps for a variety of purposes (digital printing, plots, offset printing, etc.).
           type: string
         extent:
           $ref: "#/components/schemas/extent"
@@ -1901,8 +1805,7 @@ components:
         itemType:
           default: Feature
           description: >-
-            Indicator about the type of the items in the collection (the default value
-            is 'Feature').
+            Indicator about the type of the items in the collection (the default value is 'Feature').
           type: string
           readOnly: true
         license:
@@ -1914,57 +1817,43 @@ components:
         summaries:
           additionalProperties:
             oneOf:
-            - items:
-                description: A value of any type.
-              title: Set of values
-              type: array
-            - description: >-
-                By default, only ranges with a minimum and a maximum value can be
-                specified. Ranges can be specified for ordinal values only, which
-                means they need to have a rank order. Therefore, ranges can only be
-                specified for numbers and some special types of strings. Examples:
-                grades (A to F), dates or times. Implementors are free to add other
-                derived statistical values to the object, for example `mean` or `stddev`.
-              properties:
-                max:
-                  anyOf:
-                  - type: string
-                  - type: number
-                min:
-                  anyOf:
-                  - type: string
-                  - type: number
-              required:
-              - min
-              - max
-              title: Statistics
-              type: object
+              - items:
+                  description: A value of any type.
+                title: Set of values
+                type: array
+              - description: >-
+                  By default, only ranges with a minimum and a maximum value can be specified. Ranges can be specified for ordinal values only, which means they need to have a rank order. Therefore, ranges can only be specified for numbers and some special types of strings. Examples: grades (A to F), dates or times. Implementors are free to add other derived statistical values to the object, for example `mean` or `stddev`.
+                properties:
+                  max:
+                    anyOf:
+                      - type: string
+                      - type: number
+                  min:
+                    anyOf:
+                      - type: string
+                      - type: number
+                required:
+                  - min
+                  - max
+                title: Statistics
+                type: object
           description: >-
-            Summaries are either a unique set of all available values *or* statistics.
-            Statistics by default only specify the range (minimum and maximum values),
-            but can optionally be accompanied by additional statistical values. The
-            range can specify the potential range of values, but it is recommended
-            to be as precise as possible. The set of values must contain at least
-            one element and it is strongly recommended to list all values. It is recommended
-            to list as many properties as reasonable so that consumers get a full
-            overview of the Collection. Properties that are covered by the Collection
-            specification (e.g. `providers` and `license`) may not be repeated in
-            the summaries.
+            Summaries are either a unique set of all available values *or* statistics. Statistics by default only specify the range (minimum and maximum values), but can optionally be accompanied by additional statistical values. The range can specify the potential range of values, but it is recommended to be as precise as possible. The set of values must contain at least one element and it is strongly recommended to list all values. It is recommended to list as many properties as reasonable so that consumers get a full overview of the Collection. Properties that are covered by the Collection specification (e.g. `providers` and `license`) may not be repeated in the summaries.
           type: object
           readOnly: true
           example:
             eo:gsd:
-            - 10
-            - 20
+              - 10
+              - 20
             geoadmin:variant:
-            - kgrel
-            - komb
-            - krel
+              - kgrel
+              - komb
+              - krel
             geoadmin:lang:
-            - de
-            - fr
+              - de
+              - fr
             proj:epsg:
-            - 2056
+              - 2056
         title:
           description: Human readable title of the collection
           example: National Map 1:200'000
@@ -1974,40 +1863,39 @@ components:
         updated:
           $ref: "#/components/schemas/updated"
       required:
-      - id
-      - stac_version
-      - description
-      - license
-      - extent
-      - created
-      - updated
+        - id
+        - stac_version
+        - description
+        - license
+        - extent
+        - created
+        - updated
       type: object
     collection:
       allOf:
-      - $ref: "#/components/schemas/collectionBase"
-      - type: object
-        required:
-        - links
-        properties:
-          links:
-            type: array
-            items:
-              $ref: "#/components/schemas/link"
-            example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
-              rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9
-              rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-              rel: items
-            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-              rel: license
-              title: Licence for the free geodata of the Federal Office of Topography
-                swisstopo
-            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-              rel: describedby
+        - $ref: "#/components/schemas/collectionBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              type: array
+              items:
+                $ref: "#/components/schemas/link"
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                  rel: items
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
     collections:
       properties:
         collections:
@@ -2018,22 +1906,21 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
-            rel: next
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
-            rel: previous
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+              rel: next
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+              rel: previous
       required:
-      - links
-      - collections
+        - links
+        - collections
       type: object
     collectionsArray:
       description: >-
-        Array of Collection IDs to include in the search for items. Only Items in
-        one of the provided Collections will be searched.
+        Array of Collection IDs to include in the search for items. Only Items in one of the provided Collections will be searched.
       items:
         type: string
       type: array
@@ -2045,8 +1932,8 @@ components:
       type: object
       example:
         collections:
-        - ch.swisstopo.swisstlmregio
-        - ch.bfe.energieschweiz
+          - ch.swisstopo.swisstlmregio
+          - ch.bfe.energieschweiz
     confClasses:
       properties:
         conformsTo:
@@ -2054,7 +1941,7 @@ components:
             type: string
           type: array
       required:
-      - conformsTo
+        - conformsTo
       type: object
     datetime:
       description: RFC 3339 compliant datetime string
@@ -2063,8 +1950,7 @@ components:
       format: date-time
     datetimeQuery:
       description: >-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.
 
         Examples:
 
@@ -2076,8 +1962,7 @@ components:
         * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
 
-        Only features that have a temporal property that intersects the value of `datetime`
-        are selected.
+        Only features that have a temporal property that intersects the value of `datetime` are selected.
 
 
         When used as URL query argument, the value must be correctly url-encoded.
@@ -2092,27 +1977,14 @@ components:
         Detailed multi-line description to fully explain the catalog or collection.
 
 
-        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text
-        representation.
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.
       type: string
     eoGsd:
       description: >-
-        GSD is the nominal Ground Sample Distance for the data, as measured in meters
-        on the ground.
+        GSD is the nominal Ground Sample Distance for the data, as measured in meters on the ground.
 
 
-        There are many definitions of GSD. The value of this attribute should be related
-        to the spatial resolution at the sensor, rather than the pixel size of images
-        after ortho-rectification, pansharpening, or scaling. The GSD of a sensor
-        can vary depending on off-nadir and wavelength, so it is at the discretion
-        of the implementer to decide which value most accurately represents the GSD.
-        For example, Landsat8 optical and short-wave IR bands are all 30 meters, but
-        the panchromatic band is 15 meters. The eo:gsd should be 30 meters in this
-        case because that is nominal spatial resolution at the sensor. The Planet
-        PlanetScope Ortho Tile Product has an eo:gsd of 3.7 (or 4 if rounding), even
-        though the pixel size of the images is 3.125. For example, one might choose
-        for WorldView-2 the Multispectral 20° off-nadir value of 2.07 and for WorldView-3
-        the Multispectral 20° off-nadir value of 1.38.
+        There are many definitions of GSD. The value of this attribute should be related to the spatial resolution at the sensor, rather than the pixel size of images after ortho-rectification, pansharpening, or scaling. The GSD of a sensor can vary depending on off-nadir and wavelength, so it is at the discretion of the implementer to decide which value most accurately represents the GSD. For example, Landsat8 optical and short-wave IR bands are all 30 meters, but the panchromatic band is 15 meters. The eo:gsd should be 30 meters in this case because that is nominal spatial resolution at the sensor. The Planet PlanetScope Ortho Tile Product has an eo:gsd of 3.7 (or 4 if rounding), even though the pixel size of the images is 3.125. For example, one might choose for WorldView-2 the Multispectral 20° off-nadir value of 2.07 and for WorldView-3 the Multispectral 20° off-nadir value of 1.38.
       example: 2.5
       title: Ground Sample Distance
       type: number
@@ -2125,15 +1997,15 @@ components:
           example: 500
         description:
           anyOf:
-          - type: string
-          - type: array
-            items:
-              anyOf:
-              - type: string
-              - type: object
-          - type: object
+            - type: string
+            - type: array
+              items:
+                anyOf:
+                  - type: string
+                  - type: object
+            - type: object
       required:
-      - code
+        - code
       type: object
     exceptionS3:
       description: >-
@@ -2154,31 +2026,24 @@ components:
       xml:
         name: 'Error'
       required:
-      - Code
-      - Message
-      - RequestId
-      - HostId
+        - Code
+        - Message
+        - RequestId
+        - HostId
       type: object
     extent:
       description: >-
-        The extent of the features in the collection. In the Core only spatial and
-        temporal extents are specified. Extensions may add additional members to represent
-        other extents, for example, thermal or pressure ranges.
+        The extent of the features in the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional members to represent other extents, for example, thermal or pressure ranges.
       properties:
         spatial:
           description: The spatial extent of the features in the collection.
           properties:
             bbox:
               description: >-
-                One or more bounding boxes that describe the spatial extent of the
-                dataset. In the Core only a single bounding box is supported. Extensions
-                may support additional areas. If multiple areas are provided, the
-                union of the bounding boxes describes the spatial extent.
+                One or more bounding boxes that describe the spatial extent of the dataset. In the Core only a single bounding box is supported. Extensions may support additional areas. If multiple areas are provided, the union of the bounding boxes describes the spatial extent.
               items:
                 description: >-
-                  Each bounding box is provided as four or six numbers, depending
-                  on whether the coordinate reference system includes a vertical axis
-                  (height or depth):
+                  Each bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis (height or depth):
 
 
                   * Lower left corner, coordinate axis 1
@@ -2190,29 +2055,21 @@ components:
                   * Upper right corner, coordinate axis 2
 
 
-                  The coordinate reference system of the values is WGS 84 longitude/latitude
-                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+                  The coordinate reference system of the values is WGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
-                  For WGS 84 longitude/latitude the values are in most cases the sequence
-                  of minimum longitude, minimum latitude, maximum longitude and maximum
-                  latitude. However, in cases where the box spans the antimeridian
-                  the first value (west-most box edge) is larger than the third value
-                  (east-most box edge).
+                  For WGS 84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude, maximum longitude and maximum latitude. However, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third value (east-most box edge).
 
 
-                  If the vertical axis is included, the third and the sixth number
-                  are the bottom and the top of the 3-dimensional bounding box.
+                  If the vertical axis is included, the third and the sixth number are the bottom and the top of the 3-dimensional bounding box.
 
 
-                  If a feature has multiple spatial geometry properties, it is the
-                  decision of the server whether only a single spatial geometry property
-                  is used to determine the extent or all relevant geometries.
+                  If a feature has multiple spatial geometry properties, it is the decision of the server whether only a single spatial geometry property is used to determine the extent or all relevant geometries.
                 example:
-                - 5.685114
-                - 45.534903
-                - 10.747775
-                - 47.982586
+                  - 5.685114
+                  - 45.534903
+                  - 10.747775
+                  - 47.982586
                 items:
                   type: number
                 maxItems: 6
@@ -2221,7 +2078,7 @@ components:
               minItems: 1
               type: array
           required:
-          - bbox
+            - bbox
           type: object
         temporal:
           description: The temporal extent of the features in the collection.
@@ -2233,8 +2090,8 @@ components:
                 description: >-
                   Begin and end times of the time interval.
                 example:
-                - "2019-01-01T00:00:00Z"
-                - "2019-01-02T00:00:00Z"
+                  - "2019-01-01T00:00:00Z"
+                  - "2019-01-02T00:00:00Z"
                 items:
                   format: date-time
                   nullable: false
@@ -2246,20 +2103,20 @@ components:
               maxItems: 1
               type: array
           required:
-          - interval
+            - interval
           type: object
       required:
-      - spatial
-      - temporal
+        - spatial
+        - temporal
       type: object
       readOnly: true
     geoadminLang:
       enum:
-      - de
-      - it
-      - fr
-      - rm
-      - en
+        - de
+        - it
+        - fr
+        - rm
+        - en
       title: Product language
       type: string
     geoadminVariant:
@@ -2279,8 +2136,7 @@ components:
         http://data.geo.admin.ch/ch.swisstopo.swissimage/collections/cs/items/CS3-20160503_132130_04/thumb.png
     ids:
       description: >-
-        Array of Item ids to return. All other filter parameters that further restrict
-        the number of search results are ignored
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
       items:
         type: string
       type: array
@@ -2292,30 +2148,29 @@ components:
       type: object
       example:
         ids:
-        - swisstlmregio-2019
-        - swisstlmregio-2020
+          - swisstlmregio-2019
+          - swisstlmregio-2020
     intersectsFilter:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
           oneOf:
-          - $ref: "#/components/schemas/geoJsonPoint"
-          - $ref: "#/components/schemas/geoJsonLineString"
-          - $ref: "#/components/schemas/geoJsonPolygon"
-          - $ref: "#/components/schemas/geoJsonMultiPoint"
-          - $ref: "#/components/schemas/geoJsonMultiLineString"
-          - $ref: "#/components/schemas/geoJsonMultiPolygon"
+            - $ref: "#/components/schemas/geoJsonPoint"
+            - $ref: "#/components/schemas/geoJsonLineString"
+            - $ref: "#/components/schemas/geoJsonPolygon"
+            - $ref: "#/components/schemas/geoJsonMultiPoint"
+            - $ref: "#/components/schemas/geoJsonMultiLineString"
+            - $ref: "#/components/schemas/geoJsonMultiPolygon"
       type: object
       example:
         intersects:
           type: "Point"
           coordinates:
-          - 7
-          - 46
+            - 7
+            - 46
     itemBase:
       description: >-
-        A GeoJSON Feature augmented with foreign members that contain values relevant
-        to a STAC entity
+        A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
       properties:
         assets:
           $ref: "#/components/schemas/itemAssets"
@@ -2332,40 +2187,39 @@ components:
         type:
           $ref: "#/components/schemas/itemType"
       required:
-      - stac_version
-      - type
-      - geometry
-      - bbox
-      - properties
-      - assets
+        - stac_version
+        - type
+        - geometry
+        - bbox
+        - properties
+        - assets
       type: object
     item:
       allOf:
-      - type: object
-        required:
-        - id
-        - links
-        properties:
-          id:
-            $ref: "#/components/schemas/itemId"
-          links:
-            items:
-              $ref: "#/components/schemas/link"
-            type: array
-            example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
-              rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
-              rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-              rel: collection
-      - $ref: "#/components/schemas/itemBase"
+        - type: object
+          required:
+            - id
+            - links
+          properties:
+            id:
+              $ref: "#/components/schemas/itemId"
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
+        - $ref: "#/components/schemas/itemBase"
     items:
       description: >-
-        A FeatureCollection augmented with foreign members that contain values relevant
-        to a STAC entity
+        A FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       properties:
         features:
           items:
@@ -2376,36 +2230,36 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
-            rel: next
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
-            rel: previous
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+              rel: next
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+              rel: previous
         type:
           enum:
-          - FeatureCollection
+            - FeatureCollection
           type: string
       required:
-      - features
-      - type
+        - features
+        - type
       type: object
     itemAssets:
       title: Assets
       description: List of Assets attached to this feature.
       additionalProperties:
         allOf:
-        - type: object
-          required:
-          - type
-          properties:
-            type:
-              $ref: "#/components/schemas/assetType"
-        - $ref: "#/components/schemas/assetBase"
+          - type: object
+            required:
+              - type
+            properties:
+              type:
+                $ref: "#/components/schemas/assetType"
+          - $ref: "#/components/schemas/assetBase"
       type: object
       readOnly: true
       example:
@@ -2438,8 +2292,7 @@ components:
           updated: "2020-07-14T12:30:00Z"
     itemsSearch:
       description: >-
-        A GeoJSON FeatureCollection augmented with foreign members that contain values
-        relevant to a STAC entity
+        A GeoJSON FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       properties:
         features:
           items:
@@ -2447,50 +2300,48 @@ components:
           type: array
         type:
           enum:
-          - FeatureCollection
+            - FeatureCollection
           type: string
       required:
-      - features
-      - type
+        - features
+        - type
       type: object
     itemsSearchGet:
       allOf:
-      - $ref: "#/components/schemas/itemsSearch"
-      - type: object
-        properties:
-          links:
-            $ref: "#/components/schemas/itemsSearchLinks"
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchLinks"
     itemsSearchPost:
       allOf:
-      - $ref: "#/components/schemas/itemsSearch"
-      - type: object
-        properties:
-          links:
-            $ref: "#/components/schemas/itemsSearchPostLinks"
+        - $ref: "#/components/schemas/itemsSearch"
+        - type: object
+          properties:
+            links:
+              $ref: "#/components/schemas/itemsSearchPostLinks"
     itemsSearchLinks:
       description: >-
-        An array of links. Can be used for pagination, e.g. by providing a link with
-        the `next` relation type.
+        An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search
-        rel: self
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
-        rel: next
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+          rel: self
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+          rel: next
       items:
         $ref: "#/components/schemas/link"
       type: array
     itemsSearchPostLinks:
       description: >-
-        An array of links. Can be used for pagination, e.g. by providing a link with
-        the `next` relation type.
+        An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search
-        rel: self
-      - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
-        rel: next
-        method: POST
-        body: {}
-        merge: true
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+          rel: self
+        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+          rel: next
+          method: POST
+          body: {}
+          merge: true
       items:
         $ref: "#/components/schemas/linkPostSearch"
       type: array
@@ -2501,30 +2352,29 @@ components:
       type: string
     itemGeometry:
       oneOf:
-      - $ref: "#/components/schemas/geoJsonPoint"
-      - $ref: "#/components/schemas/geoJsonLineString"
-      - $ref: "#/components/schemas/geoJsonPolygon"
-      - $ref: "#/components/schemas/geoJsonMultiPoint"
-      - $ref: "#/components/schemas/geoJsonMultiLineString"
-      - $ref: "#/components/schemas/geoJsonMultiPolygon"
+        - $ref: "#/components/schemas/geoJsonPoint"
+        - $ref: "#/components/schemas/geoJsonLineString"
+        - $ref: "#/components/schemas/geoJsonPolygon"
+        - $ref: "#/components/schemas/geoJsonMultiPoint"
+        - $ref: "#/components/schemas/geoJsonMultiLineString"
+        - $ref: "#/components/schemas/geoJsonMultiPolygon"
     geoJsonPoint:
       title: GeoJSON Point
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - Point
+            - Point
         coordinates:
           description: >-
-            For type "Point", the "coordinates" member is a single position. The coordinate
-            reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "Point", the "coordinates" member is a single position. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - 7.0906823
-          - 45.9160584
+            - 7.0906823
+            - 45.9160584
           type: array
           minItems: 2
           items:
@@ -2533,23 +2383,21 @@ components:
       title: GeoJSON LineString
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - LineString
+            - LineString
         coordinates:
           description: >-
-            For type "LineString", the "coordinates" member is an array of two or
-            more positions. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "LineString", the "coordinates" member is an array of two or more positions. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
           type: array
           minItems: 2
           items:
@@ -2561,29 +2409,27 @@ components:
       title: GeoJSON Polygon
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - Polygon
+            - Polygon
         coordinates:
           description: >-
-            For type "Polygon", the "coordinates" member MUST be an array of linear
-            ring coordinate arrays. The coordinate reference system of the values
-            is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "Polygon", the "coordinates" member MUST be an array of linear ring coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
-            - - 7.1035146
-              - 45.925093
-            - - 7.0906249
-              - 45.9250537
-            - - 7.0906823
-              - 45.9160584
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
+              - - 7.1035146
+                - 45.925093
+              - - 7.0906249
+                - 45.9250537
+              - - 7.0906823
+                - 45.9160584
           type: array
           items:
             type: array
@@ -2597,25 +2443,23 @@ components:
       title: GeoJSON MultiPoint
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiPoint
+            - MultiPoint
         coordinates:
           description: >-
-            For type "MultiPoint", the "coordinates" member is an array of positions.
-            The coordinate reference system of the values is WGS84 longitude/latitude
-            (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiPoint", the "coordinates" member is an array of positions. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - 7.0906823
-            - 45.9160584
-          - - 7.1035698
-            - 45.9160977
-          - - 7.1035146
-            - 45.925093
+            - - 7.0906823
+              - 45.9160584
+            - - 7.1035698
+              - 45.9160977
+            - - 7.1035146
+              - 45.925093
           type: array
           items:
             type: array
@@ -2626,27 +2470,25 @@ components:
       title: GeoJSON MultiLineString
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiLineString
+            - MultiLineString
         coordinates:
           description: >-
-            For type "MultiLineString", the "coordinates" member is an array of LineString
-            coordinate arrays. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiLineString", the "coordinates" member is an array of LineString coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - 7.0906823
-              - 45.9160584
-            - - 7.1035698
-              - 45.9160977
-          - - - 7.1035146
-              - 45.925093
-            - - 7.0906249
-              - 45.9250537
+            - - - 7.0906823
+                - 45.9160584
+              - - 7.1035698
+                - 45.9160977
+            - - - 7.1035146
+                - 45.925093
+              - - 7.0906249
+                - 45.9250537
           type: array
           items:
             type: array
@@ -2660,39 +2502,37 @@ components:
       title: GeoJSON MultiPolygon
       type: object
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       properties:
         type:
           type: string
           enum:
-          - MultiPolygon
+            - MultiPolygon
         coordinates:
           description: >-
-            For type "MultiPolygon", the "coordinates" member is an array of Polygon
-            coordinate arrays. The coordinate reference system of the values is WGS84
-            longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+            For type "MultiPolygon", the "coordinates" member is an array of Polygon coordinate arrays. The coordinate reference system of the values is WGS84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
           example:
-          - - - - 7.0906823
-                - 45.9160584
-              - - 7.1035698
-                - 45.9160977
-              - - 7.1035146
-                - 45.925093
-              - - 7.0906249
-                - 45.9250537
-              - - 7.0906823
-                - 45.9160584
-          - - - - 8.5816399
-                - 45.7218735
-              - - 8.5944806
-                - 45.7217417
-              - - 8.5946699
-                - 45.7307358
-              - - 8.581827
-                - 45.7308676
-              - - 8.5816399
-                - 45.7218735
+            - - - - 7.0906823
+                  - 45.9160584
+                - - 7.1035698
+                  - 45.9160977
+                - - 7.1035146
+                  - 45.925093
+                - - 7.0906249
+                  - 45.9250537
+                - - 7.0906823
+                  - 45.9160584
+            - - - - 8.5816399
+                  - 45.7218735
+                - - 8.5944806
+                  - 45.7217417
+                - - 8.5946699
+                  - 45.7307358
+                - - 8.581827
+                  - 45.7308676
+                - - 8.5816399
+                  - 45.7218735
           type: array
           items:
             type: array
@@ -2737,22 +2577,21 @@ components:
           maxLength: 255
           nullable: true
       required:
-      - created
-      - updated
+        - created
+        - updated
       type: object
     itemType:
       title: type
       description: The GeoJSON type
       enum:
-      - Feature
+        - Feature
       type: string
       readOnly: true
     landingPage:
       properties:
         description:
           example: >-
-            Access to data about buildings in the city of Bonn via a Web API that
-            conforms to the OGC API Features specification.
+            Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.
           type: string
         id:
           type: string
@@ -2766,34 +2605,26 @@ components:
           example: Buildings in Bonn
           type: string
       required:
-      - links
-      - stac_version
-      - id
-      - description
+        - links
+        - stac_version
+        - id
+        - description
       type: object
     license:
       description: >-
-        License(s) of the data as a SPDX [License identifier](https://spdx.org/licenses/).
-        Alternatively, use `proprietary` if the license is not on the SPDX license
-        list or `various` if multiple licenses apply. In these two cases links to
-        the license texts SHOULD be added, see the `license` link relation type.
+        License(s) of the data as a SPDX [License identifier](https://spdx.org/licenses/). Alternatively, use `proprietary` if the license is not on the SPDX license list or `various` if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the `license` link relation type.
 
 
-        Non-SPDX licenses SHOULD add a link to the license text with the `license`
-        relation in the links section. The license text MUST NOT be provided as a
-        value of this field. If there is no public license URL available, it is RECOMMENDED
-        to host the license text and link to it.
+        Non-SPDX licenses SHOULD add a link to the license text with the `license` relation in the links section. The license text MUST NOT be provided as a value of this field. If there is no public license URL available, it is RECOMMENDED to host the license text and link to it.
       example: proprietary
       type: string
     limit:
       default: 100
       description: >-
-        The `limit` parameter limits the number of results that are included in the
-        response.
+        The `limit` parameter limits the number of results that are included in the response.
 
 
-        To retrieve the next bunch of result, use the `next` link in the `links` section
-        of the response.
+        To retrieve the next bunch of result, use the `next` link in the `links` section of the response.
 
 
         Minimum = 1. Maximum = 100. Default = 100.
@@ -2819,11 +2650,11 @@ components:
           type: array
         type:
           enum:
-          - LineString
+            - LineString
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     link:
       properties:
@@ -2836,8 +2667,7 @@ components:
             Relationship between the current document and the linked document.
 
 
-            NOTE: the following relations are reserved and automatically generated:
-            `self`, `root`, `parent`, `items`, `collection`, `next`, `previous`
+            NOTE: the following relations are reserved and automatically generated: `self`, `root`, `parent`, `items`, `collection`, `next`, `previous`
           example: describedby
           type: string
         title:
@@ -2851,35 +2681,31 @@ components:
           default: GET
           description: Specifies the HTTP method that the link expects
           enum:
-          - GET
-          - POST
+            - GET
+            - POST
           type: string
       required:
-      - href
-      - rel
+        - href
+        - rel
       title: Link
       type: object
     linkPostSearch:
       allOf:
-      - $ref: "#/components/schemas/link"
-      - type: object
-        properties:
-          body:
-            default: {}
-            description: For `POST /search` requests, the link can specify the HTTP
-              body as a JSON object.
-            type: object
-          merge:
-            default: false
-            description: >-
-              This is only valid when the server is responding to `POST /search `request.
+        - $ref: "#/components/schemas/link"
+        - type: object
+          properties:
+            body:
+              default: {}
+              description: For `POST /search` requests, the link can specify the HTTP body as a JSON object.
+              type: object
+            merge:
+              default: false
+              description: >-
+                This is only valid when the server is responding to `POST /search `request.
 
 
-              If merge is true, the client is expected to merge the body value into
-              the current request body before following the link. This avoids passing
-              large post bodies back and forth when following links, particularly
-              for navigating pages through the `POST /search` endpoint.
-            type: boolean
+                If merge is true, the client is expected to merge the body value into the current request body before following the link. This avoids passing large post bodies back and forth when following links, particularly for navigating pages through the `POST /search` endpoint.
+              type: boolean
     multilinestringGeoJSON:
       properties:
         coordinates:
@@ -2894,11 +2720,11 @@ components:
           type: array
         type:
           enum:
-          - MultiLineString
+            - MultiLineString
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     multipointGeoJSON:
       properties:
@@ -2911,11 +2737,11 @@ components:
           type: array
         type:
           enum:
-          - MultiPoint
+            - MultiPoint
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     multipolygonGeoJSON:
       properties:
@@ -2933,16 +2759,15 @@ components:
           type: array
         type:
           enum:
-          - MultiPolygon
+            - MultiPolygon
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     numberMatched:
       description: >-
-        The number of features of the feature type that match the selection parameters
-        like `bbox`.
+        The number of features of the feature type that match the selection parameters like `bbox`.
       example: 127
       minimum: 0
       type: integer
@@ -2951,12 +2776,10 @@ components:
         The number of features in the feature collection.
 
 
-        A server may omit this information in a response, if the information about
-        the number of features is not known or difficult to compute.
+        A server may omit this information in a response, if the information about the number of features is not known or difficult to compute.
 
 
-        If the value is provided, the value shall be identical to the number of items
-        in the "features" array.
+        If the value is provided, the value shall be identical to the number of items in the "features" array.
       example: 10
       minimum: 0
       type: integer
@@ -2969,11 +2792,11 @@ components:
           type: array
         type:
           enum:
-          - Point
+            - Point
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
     polygonGeoJSON:
       properties:
@@ -2989,48 +2812,39 @@ components:
           type: array
         type:
           enum:
-          - Polygon
+            - Polygon
           type: string
       required:
-      - type
-      - coordinates
+        - type
+        - coordinates
       type: object
       example:
         coordinates:
-        - - - 7.242974548172171
-            - 46.57310580640624
-          - - 7.243756483316452
-            - 46.35721185723752
-          - - 7.698490766144817
-            - 46.357085154660915
-          - - 7.699524647567326
-            - 46.57297861624267
-          - - 7.242974548172171
-            - 46.57310580640624
+          - - - 7.242974548172171
+              - 46.57310580640624
+            - - 7.243756483316452
+              - 46.35721185723752
+            - - 7.698490766144817
+              - 46.357085154660915
+            - - 7.699524647567326
+              - 46.57297861624267
+            - - 7.242974548172171
+              - 46.57310580640624
         type: Polygon
     projEpsg:
       description: >-
-        A Coordinate Reference System (CRS) is the data reference system (sometimes
-        called a 'projection') used by the asset data, and can usually be referenced
-        using an EPSG code. If the asset data does not have a CRS, such as in the
-        case of non-rectified imagery with Ground Control Points, proj:epsg should
-        be set to null. It should also be set to null if a CRS exists, but for which
-        there is no valid EPSG code.
+        A Coordinate Reference System (CRS) is the data reference system (sometimes called a 'projection') used by the asset data, and can usually be referenced using an EPSG code. If the asset data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points, proj:epsg should be set to null. It should also be set to null if a CRS exists, but for which there is no valid EPSG code.
       example: 2056
       title: EPSG code.
       type: integer
     providers:
       description: >-
-        A list of providers, which may include all organizations capturing or processing
-        the data or the hosting provider. Providers should be listed in chronological
-        order with the most recent provider being the last element of the list.
+        A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list.
       items:
         properties:
           description:
             description: >-
-              Multi-line description to add further provider information such as processing
-              details for processors and producers, hosting details for hosts or basic
-              contact information.
+              Multi-line description to add further provider information such as processing details for processors and producers, hosting details for hosts or basic contact information.
 
 
               CommonMark 0.29 syntax MAY be used for rich text representation.
@@ -3069,29 +2883,28 @@ components:
                 element of the list.
             items:
               enum:
-              - producer
-              - licensor
-              - processor
-              - host
+                - producer
+                - licensor
+                - processor
+                - host
               type: string
             type: array
           url:
             description: >-
-              Homepage on which the provider describes the dataset and publishes contact
-              information.
+              Homepage on which the provider describes the dataset and publishes contact information.
             format: url
             type: string
         required:
-        - name
+          - name
         title: Provider
         type: object
       type: array
       example:
-      - name: Federal Office of Topography - swisstopo
-        roles:
-        - producer
-        - licensor
-        url: https://www.swisstopo.admin.ch
+        - name: Federal Office of Topography - swisstopo
+          roles:
+            - producer
+            - licensor
+          url: https://www.swisstopo.admin.ch
     query:
       additionalProperties:
         $ref: "#/components/schemas/queryProp"
@@ -3112,102 +2925,90 @@ components:
       type: object
     queryProp:
       anyOf:
-      - description: >-
-          If the object doesn't contain any of the operators, it is equivalent to
-          using the equals operator
-      - description: Match using an operator
-        properties:
-          contains:
-            description: >-
-              Find items with a property that contains the specified literal string,
-              e.g., matches ".*<STRING>.*". A case-insensitive comparison must be
-              performed.
-            type: string
-          endsWith:
-            description: >-
-              Find items with a property that ends with the specified string. A case-insensitive
-              comparison must be performed.
-            type: string
-          eq:
-            description: >-
-              Find items with a property that is equal to the specified value. For
-              strings, a case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          gt:
-            description: Find items with a property value greater than the specified
-              value.
-            oneOf:
-            - format: date-time
+        - description: >-
+            If the object doesn't contain any of the operators, it is equivalent to using the equals operator
+        - description: Match using an operator
+          properties:
+            contains:
+              description: >-
+                Find items with a property that contains the specified literal string, e.g., matches ".*<STRING>.*". A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          gte:
-            description: Find items with a property value greater than or equal the
-              specified value.
-            oneOf:
-            - format: date-time
+            endsWith:
+              description: >-
+                Find items with a property that ends with the specified string. A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          in:
-            description: >-
-              Find items with a property that equals at least one entry in the specified
-              array. A case-insensitive comparison must be performed.
-            items:
+            eq:
+              description: >-
+                Find items with a property that is equal to the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
               oneOf:
-              - type: string
-              - type: number
-            type: array
-          lt:
-            description: Find items with a property value less than the specified
-              value.
-            oneOf:
-            - format: date-time
+                - type: string
+                - type: number
+                - type: boolean
+            gt:
+              description: Find items with a property value greater than the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            gte:
+              description: Find items with a property value greater than or equal the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            in:
+              description: >-
+                Find items with a property that equals at least one entry in the specified array. A case-insensitive comparison must be performed.
+              items:
+                oneOf:
+                  - type: string
+                  - type: number
+              type: array
+            lt:
+              description: Find items with a property value less than the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            lte:
+              description: Find items with a property value less than or equal the specified value.
+              oneOf:
+                - format: date-time
+                  type: string
+                - type: number
+            neq:
+              description: >-
+                Find items that *don't* contain the specified value. For strings, a case-insensitive comparison must be performed.
+              nullable: true
+              oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+            startsWith:
+              description: >-
+                Find items with a property that begins with the specified string. A case-insensitive comparison must be performed.
               type: string
-            - type: number
-          lte:
-            description: Find items with a property value less than or equal the specified
-              value.
-            oneOf:
-            - format: date-time
-              type: string
-            - type: number
-          neq:
-            description: >-
-              Find items that *don't* contain the specified value. For strings, a
-              case-insensitive comparison must be performed.
-            nullable: true
-            oneOf:
-            - type: string
-            - type: number
-            - type: boolean
-          startsWith:
-            description: >-
-              Find items with a property that begins with the specified string. A
-              case-insensitive comparison must be performed.
-            type: string
-        type: object
+          type: object
       description: >-
-        Apply query operations to a specific property. The following properties are
-        currently supported: `created`, `updated`, `title`.
+        Apply query operations to a specific property. The following properties are currently supported: `created`, `updated`, `title`.
     roles:
       type: array
       items:
         type: string
       description: Purposes of the asset
       example:
-      - thumbnail
+        - thumbnail
     searchBody:
       allOf:
-      - $ref: "#/components/schemas/queryFilter"
-      - $ref: "#/components/schemas/bboxFilter"
-      - $ref: "#/components/schemas/datetimeFilter"
-      - $ref: "#/components/schemas/intersectsFilter"
-      - $ref: "#/components/schemas/collectionsFilter"
-      - $ref: "#/components/schemas/idsFilter"
-      - $ref: "#/components/schemas/limitFilter"
+        #        - $ref: "#/components/schemas/assetQueryFilter"
+        - $ref: "#/components/schemas/queryFilter"
+        - $ref: "#/components/schemas/bboxFilter"
+        - $ref: "#/components/schemas/datetimeFilter"
+        - $ref: "#/components/schemas/intersectsFilter"
+        - $ref: "#/components/schemas/collectionsFilter"
+        - $ref: "#/components/schemas/idsFilter"
+        - $ref: "#/components/schemas/limitFilter"
       description: The search criteria
       type: object
     stac_version:
@@ -3216,8 +3017,7 @@ components:
       type: string
       readOnly: true
     timeStamp:
-      description: This property indicates the time and date when the response was
-        generated.
+      description: This property indicates the time and date when the response was generated.
       example: "2017-08-17T08:05:32Z"
       format: date-time
       type: string
@@ -3262,49 +3062,48 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
-            rel: item
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: collection
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: item
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     collectionWrite:
       title: collection
       allOf:
-      - $ref: "#/components/schemas/collectionBase"
-      - type: object
-        properties:
-          published:
-            type: boolean
-            default: True
-            description: |
-              Collection that are not published are not listed in the /collections endpoint. Same for collection's items,
-              they are then not listed in the /search endpoint when not published.
-          links:
-            type: array
-            items:
-              $ref: "#/components/schemas/link"
-            example:
-            - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
-              rel: license
-              title: Licence for the free geodata of the Federal Office of Topography
-                swisstopo
-            - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
-              rel: describedby
+        - $ref: "#/components/schemas/collectionBase"
+        - type: object
+          properties:
+            published:
+              type: boolean
+              default: True
+              description: |
+                Collection that are not published are not listed in the /collections endpoint. Same for collection's items,
+                they are then not listed in the /search endpoint when not published.
+            links:
+              type: array
+              items:
+                $ref: "#/components/schemas/link"
+              example:
+                - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
+                  rel: license
+                  title: Licence for the free geodata of the Federal Office of Topography swisstopo
+                - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
+                  rel: describedby
     assetWrite:
       title: Asset
       description: The `property name` defines the ID of the Asset.
       type: object
       required:
-      - id
-      - type
-      - created
-      - updated
-      - links
+        - id
+        - type
+        - created
+        - updated
+        - links
       properties:
         id:
           $ref: "#/components/schemas/assetId"
@@ -3336,16 +3135,16 @@ components:
           type: array
           readOnly: true
           example:
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
-            rel: self
-          - href: https://data.geo.admin.ch/api/stac/v0.9/
-            rel: root
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
-            rel: parent
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
-            rel: item
-          - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
-            rel: collection
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+              rel: item
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     mediaTypeWrite:
       type: string
       description: |
@@ -3358,34 +3157,33 @@ components:
       example: image/tiff; application=geotiff
     writeItem:
       allOf:
-      - $ref: "#/components/schemas/itemBase"
-      - type: object
-        properties:
-          links:
-            items:
-              $ref: "#/components/schemas/link"
-            type: array
-            description: >-
-              Add additional link to the generated ones (`self`, `root`, `parent`,
-              `items`, `collection`, `next`, `previous`)
+        - $ref: "#/components/schemas/itemBase"
+        - type: object
+          properties:
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              description: >-
+                Add additional link to the generated ones (`self`, `root`, `parent`, `items`, `collection`, `next`, `previous`)
     createItem:
       allOf:
-      - type: object
-        required:
-        - id
-        properties:
-          id:
-            $ref: "#/components/schemas/itemId"
-      - $ref: "#/components/schemas/writeItem"
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              $ref: "#/components/schemas/itemId"
+        - $ref: "#/components/schemas/writeItem"
     updateItem:
       allOf:
-      - type: object
-        required:
-        - id
-        properties:
-          id:
-            $ref: "#/components/schemas/itemIdUpdate"
-      - $ref: "#/components/schemas/writeItem"
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              $ref: "#/components/schemas/itemIdUpdate"
+        - $ref: "#/components/schemas/writeItem"
     partialItem:
       type: object
       properties:
@@ -3400,8 +3198,7 @@ components:
           items:
             $ref: "#/components/schemas/link"
           description: >-
-            Add/update additional link to the generated ones (`self`, `root`, `parent`,
-            `items`, `collection`, `next`, `previous`)
+            Add/update additional link to the generated ones (`self`, `root`, `parent`, `items`, `collection`, `next`, `previous`)
       example:
         properties:
           datetime: "2016-05-03T13:22:30.040Z"
@@ -3420,24 +3217,22 @@ components:
         description:
           description: A description of the features in the collection
           type: string
-          example: The National Map 1:200,000 is a topographic map giving an overview
-            of Switzerland.
+          example: The National Map 1:200,000 is a topographic map giving an overview of Switzerland.
         links:
           type: array
           items:
             $ref: "#/components/schemas/link"
           example:
-          - href: http://data.example.com/buildings
-            rel: item
-          - href: http://example.com/concepts/buildings.html
-            rel: describedBy
-            type: text/html
+            - href: http://data.example.com/buildings
+              rel: item
+            - href: http://example.com/concepts/buildings.html
+              rel: describedBy
+              type: text/html
         extent:
           $ref: "#/components/schemas/extent"
         itemType:
           description: >-
-            Indicator about the type of the items in the collection (the default value
-            is 'feature').
+            Indicator about the type of the items in the collection (the default value is 'feature').
           type: string
           default: feature
         crs:
@@ -3446,16 +3241,15 @@ components:
           items:
             type: string
           default:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           example:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
-          - http://www.opengis.net/def/crs/EPSG/0/4326
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/EPSG/0/4326
         example:
           title: The new title of the collection
     itemIdUpdate:
       description: >-
-        Item identifier (unique per collection. If it doesn't match the `featureId`
-        in path parameters, then the Item is renamed.
+        Item identifier (unique per collection. If it doesn't match the `featureId` in path parameters, then the Item is renamed.
       example: smr200-200-4-2019
       type: string
     uploadId:
@@ -3492,8 +3286,8 @@ components:
       title: AssetUploads
       type: object
       required:
-      - uploads
-      - links
+        - uploads
+        - links
       properties:
         uploads:
           description: List of uploads that are within the asset.
@@ -3506,17 +3300,17 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-          - rel: next
-            href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+            - rel: next
+              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
     assetUpload:
       title: AssetUpload
       type: object
       required:
-      - upload_id
-      - status
-      - created
-      - "checksum:multihash"
-      - number_parts
+        - upload_id
+        - status
+        - created
+        - "checksum:multihash"
+        - number_parts
       properties:
         upload_id:
           $ref: "#/components/schemas/uploadId"
@@ -3545,12 +3339,12 @@ components:
       title: AssetUpload
       type: object
       required:
-      - upload_id
-      - status
-      - created
-      - "checksum:multihash"
-      - number_parts
-      - md5_parts
+        - upload_id
+        - status
+        - created
+        - "checksum:multihash"
+        - number_parts
+        - md5_parts
       properties:
         upload_id:
           $ref: "#/components/schemas/uploadId"
@@ -3579,7 +3373,7 @@ components:
       title: CompleteUpload
       type: object
       required:
-      - parts
+        - parts
       properties:
         parts:
           type: array
@@ -3588,15 +3382,14 @@ components:
             title: File parts that have been uploaded
             type: object
             required:
-            - etag
-            - part_number
+              - etag
+              - part_number
             properties:
               etag:
                 title: ETag
                 type: string
                 description: >-
-                  ETag of the uploaded file part (returned in the header of the answer
-                  of [Upload asset file part](#operation/uploadAssetFilePart)).
+                  ETag of the uploaded file part (returned in the header of the answer of [Upload asset file part](#operation/uploadAssetFilePart)).
                 example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
               part_number:
                 $ref: "#/components/schemas/part_number"
@@ -3604,12 +3397,12 @@ components:
       title: UploadCompleted
       type: object
       required:
-      - upload_id
-      - status
-      - number_parts
-      - created
-      - completed
-      - "checksum:multihash"
+        - upload_id
+        - status
+        - number_parts
+        - created
+        - completed
+        - "checksum:multihash"
       properties:
         upload_id:
           $ref: "#/components/schemas/uploadId"
@@ -3618,7 +3411,7 @@ components:
           description: Status of the Asset's multipart upload.
           type: string
           enum:
-          - completed
+            - completed
           example: completed
         number_parts:
           $ref: "#/components/schemas/number_parts"
@@ -3632,12 +3425,12 @@ components:
       title: UploadCompleted
       type: object
       required:
-      - upload_id
-      - status
-      - number_parts
-      - created
-      - aborted
-      - "checksum:multihash"
+        - upload_id
+        - status
+        - number_parts
+        - created
+        - aborted
+        - "checksum:multihash"
       properties:
         upload_id:
           $ref: "#/components/schemas/uploadId"
@@ -3646,7 +3439,7 @@ components:
           description: Status of the Asset's multipart upload.
           type: string
           enum:
-          - aborted
+            - aborted
           example: aborted
         number_parts:
           $ref: "#/components/schemas/number_parts"
@@ -3660,17 +3453,17 @@ components:
       title: Parts
       type: object
       required:
-      - parts
-      - links
+        - parts
+        - links
       properties:
         parts:
           type: object
           description: List of uploaded parts
           required:
-          - etag
-          - part_number
-          - modified
-          - size
+            - etag
+            - part_number
+            - modified
+            - size
           properties:
             etag:
               $ref: "#/components/schemas/uploadEtag"
@@ -3691,16 +3484,16 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-          - rel: next
-            href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+            - rel: next
+              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
     status:
       title: Status
       description: Status of the Asset's multipart upload.
       type: string
       enum:
-      - in-progress
-      - aborted
-      - completed
+        - in-progress
+        - aborted
+        - completed
       readOnly: true
     number_parts:
       description: Number of parts for the Asset's multipart upload.
@@ -3715,14 +3508,13 @@ components:
       items:
         type: object
         required:
-        - part_number
-        - md5
+          - part_number
+          - md5
         properties:
           part_number:
             $ref: "#/components/schemas/part_number"
           md5:
-            description: The base64-encoded 128-bit MD5 digest of the associate part
-              data.
+            description: The base64-encoded 128-bit MD5 digest of the associate part data.
             type: string
             example: yLLiDqX2OL7mcIMTjob60A==
     update_interval:
@@ -3770,13 +3562,12 @@ components:
       description: Multipart upload url.
       type: object
       required:
-      - url
-      - part
-      - expires
+        - url
+        - part
+        - expires
       properties:
         url:
-          description: Presigned URL to use to upload the Asset File part using the
-            PUT method.
+          description: Presigned URL to use to upload the Asset File part using the PUT method.
           type: string
           format: url
           example: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff
@@ -3786,8 +3577,7 @@ components:
           minimum: 1
           maximum: 100
         expires:
-          description: Date time when this presigned URL expires and is not valid
-            anymore.
+          description: Date time when this presigned URL expires and is not valid anymore.
           type: string
           format: date-time
     uploadEtag:
@@ -3811,14 +3601,13 @@ components:
           description: Current Asset upload unique identifier
           example: KrFTuglD.N8ireqry_w3.oQqNwrYI7SfSXpVRiusKah0YigDnuM06hfJNIUZg4R_No0MMW9FLU2UG5anTW0boTUYVxKfBZWCFXqnQTpjnQEo1K7la39MYpjSTvIbZgnG
       required:
-      - code
-      - upload_id
+        - code
+        - upload_id
       type: object
   parameters:
     assetQuery:
       description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the
-        assetQueryFilter used in POST.
+        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
       in: query
       name: assetQuery
       required: false
@@ -3871,8 +3660,7 @@ components:
         type: string
     ids:
       description: >-
-        Array of Item ids to return. All other filter parameters that further restrict
-        the number of search results are ignored
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
       explode: false
       in: query
       name: ids
@@ -3888,8 +3676,7 @@ components:
         $ref: "#/components/schemas/limit"
       style: form
     query:
-      description: Query for properties in items. Use the JSON form of the queryFilter
-        used in POST.
+      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
       in: query
       name: query
       required: false
@@ -3901,15 +3688,10 @@ components:
       schema:
         type: string
       description: >-
-        The RFC7232 `If-None-Match` header field makes the GET request method conditional.
-        It is composed of a comma separated list of ETags or value "*".
+        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
 
 
-        The server compares the client's ETags (sent with `If-None-Match`) with the
-        ETag for its current version of the resource, and if both values match (that
-        is, the resource has not changed), the server sends back a `304 Not Modified`
-        status, without a body, which tells the client that the cached version of
-        the response is still good to use (fresh).
+        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
     IfMatch:
       name: If-Match
@@ -3917,15 +3699,10 @@ components:
       schema:
         type: string
       description: >-
-        The RFC7232 `If-Match` header field makes the GET request method conditional.
-        It is composed of a comma separated list of ETags or value "*".
+        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
 
 
-        The server compares the client's ETags (sent with `If-Match`) with the ETag
-        for its current version of the resource, and if both values don't match (that
-        is, the resource has changed), the server sends back a `412 Precondition Failed`
-        status, without a body, which tells the client that the cached version of
-        the response is not good to use anymore.
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
     assetId:
       name: assetId
@@ -3947,8 +3724,7 @@ components:
       description: >-
         Presigned url returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
 
-        Note: the url returned by the above endpoint is the full url including scheme,
-        host and path
+        Note: the url returned by the above endpoint is the full url including scheme, host and path
       required: true
       schema:
         type: string
@@ -3958,26 +3734,17 @@ components:
       schema:
         type: string
       description: >-
-        The RFC7232 `If-Match` header field makes the PUT/PATCH/DEL request method
-        conditional. It is composed of a comma separated list of ETags or value "*".
+        The RFC7232 `If-Match` header field makes the PUT/PATCH/DEL request method conditional. It is composed of a comma separated list of ETags or value "*".
 
 
-        The server compares the client's ETags (sent with `If-Match`) with the ETag
-        for its current version of the resource, and if both values don't match (that
-        is, the resource has changed), the server sends back a `412 Precondition Failed`
-        status, without a body, which tells the client that he would overwrite another
-        changes of the resource.
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that he would overwrite another changes of the resource.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
   headers:
     ETag:
       schema:
         type: string
       description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag
-        for the selected resource. An entity-tag is an opaque identifier for different
-        versions of a resource over time, regardless whether multiple versions are
-        valid at the same time. An entity-tag consists of an opaque quoted string,
-        possibly prefixed by a weakness indicator.
+        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
       required: true
   examples:
@@ -3988,9 +3755,9 @@ components:
         status: in-progress
         number_parts: 1
         urls:
-        - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff
-          part: 1
-          expires: '2019-08-24T14:15:22Z'
+          - url: https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk50.noscale/smr200-200-4-2019/smr50-263-2016-2056-kgrs-2.5.tiff
+            part: 1
+            expires: '2019-08-24T14:15:22Z'
         created: '2019-08-24T14:15:22Z'
         checksum:multihash: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
     completed:


### PR DESCRIPTION
This should make it easier to inject things we need to use AWS API Gateway. It should also be a bit more robust and easier to use for external developers.