### PR TITLE
PB-676: remove duplicate YAML key from spec.

### DIFF
--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -1431,8 +1431,6 @@ components:
       description: Define which properties to query and the operations to apply
       example:
         title:
-          eq: "Swissregio"
-        title:
           contains: "Swiss"
         created:
           lte: "2021-01-01T00:00:00.000Z"

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -1977,7 +1977,6 @@ components:
       description: Define which properties to query and the operations to apply
       example:
         title:
-          eq: "Swissregio"
           contains: "Swiss"
         created:
           lte: "2021-01-01T00:00:00.000Z"

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -3098,7 +3098,6 @@ components:
       description: Define which properties to query and the operations to apply
       example:
         title:
-          eq: "Swissregio"
           contains: "Swiss"
         created:
           lte: "2021-01-01T00:00:00.000Z"


### PR DESCRIPTION
As far as YAML is concerned, each key in a Map must be unique. The "example" Map has two keys named "title". This change removes one of the two duplicate keys.

An alternative fix would involve turning this into a list of examples. However the OpenAPI validator we use does not seem to support it at this time.