### PR TITLE
PB-851 Inline the collection assets to collection in admin

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -70,6 +70,11 @@ class CollectionLinkInline(admin.TabularInline):
     extra = 0
 
 
+class CollectionAssetInline(admin.StackedInline):
+    model = CollectionAsset
+    extra = 0
+
+
 @admin.register(Collection)
 class CollectionAdmin(admin.ModelAdmin):
 
@@ -110,7 +115,7 @@ class CollectionAdmin(admin.ModelAdmin):
         'etag',
         'update_interval'
     ]
-    inlines = [ProviderInline, CollectionLinkInline]
+    inlines = [ProviderInline, CollectionLinkInline, CollectionAssetInline]
     search_fields = ['name']
     list_display = ['name', 'published']
     list_filter = ['published']

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -59,7 +59,9 @@ class AdminBaseTestCase(TestCase):
             "providers-TOTAL_FORMS": "0",
             "providers-INITIAL_FORMS": "0",
             "links-TOTAL_FORMS": "0",
-            "links-INITIAL_FORMS": "0"
+            "links-INITIAL_FORMS": "0",
+            "assets-TOTAL_FORMS": "0",
+            "assets-INITIAL_FORMS": "0"
         }
         if with_link:
             data.update({
@@ -416,6 +418,8 @@ class AdminCollectionTestCase(AdminBaseTestCase):
             "providers-0-description": "",
             "providers-0-roles": "licensor",
             "providers-0-url": "http://www.example.com",
+            "assets-TOTAL_FORMS": "0",
+            "assets-INITIAL_FORMS": "0"
         }
         response = self.client.post("/api/stac/admin/stac_api/collection/add/", data)
 


### PR DESCRIPTION
Inline the collection assets to the collection's admin page.

The simplest, most straight forward implementation. Don't know whether the use case demands a better way. How many collection assets are usually in a collection?
I guess I could easily spend more time on this and create a custom template for this model, but on the other hand this will make it less dynamic in case of future changes.. 