### PR TITLE
Actually test that login works correctly.

### DIFF
--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -317,8 +317,15 @@ class AdminTestCase(AdminBaseTestCase):
     def test_login(self):
         # Make sure login of the test user works
         self.client.login(username=self.username, password=self.password)
-        response = self.client.get("/api/stac/admin")
-        self.assertEqual(response.status_code, 301, msg="Admin page login failed")
+        response = self.client.get("/api/stac/admin/")
+        self.assertEqual(response.status_code, 200, msg="Admin page login failed")
+
+    def test_login_failure(self):
+        # Make sure login with wrong password fails
+        self.client.login(username=self.username, password="wrongpassword")
+        response = self.client.get("/api/stac/admin/")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
/api/stac/admin always redirects so we don't actually know whether login succeeds when testing that endpoint. In this change we modify the test to point to /api/stac/admin/ which does return 200 when valid credentials are used and 302 when failing to log in. We also add a test to verify invalid credentials are correctly rejected/redirected.