### PR TITLE
Test the CORS headers for the actual landing page.

### DIFF
--- a/app/tests/tests_09/test_landing_page.py
+++ b/app/tests/tests_09/test_landing_page.py
@@ -13,6 +13,7 @@ class IndexTestCase(StacBaseTestCase):
     def test_landing_page(self):
         response = self.client.get(f"/{STAC_BASE_V}/")
         self.assertEqual(response.status_code, 200)
+        self.assertCors(response)
         self.assertEqual(response['Content-Type'], 'application/json')
         required_keys = ['description', 'id', 'stac_version', 'links']
         self.assertEqual(

--- a/app/tests/tests_10/test_landing_page.py
+++ b/app/tests/tests_10/test_landing_page.py
@@ -13,6 +13,7 @@ class IndexTestCase(StacBaseTestCase):
     def test_landing_page(self):
         response = self.client.get(f"/{STAC_BASE_V}/")
         self.assertEqual(response.status_code, 200)
+        self.assertCors(response)
         self.assertEqual(response['Content-Type'], 'application/json')
         required_keys = ['description', 'id', 'stac_version', 'links', 'type']
         self.assertEqual(


### PR DESCRIPTION
This test function assertion was added in https://github.com/geoadmin/service-stac/commit/54dca401bfcac33baf9cbf9fd8319bca253d6124 It only tests the redirection to the landing page but not the actual landing page.

This change ensures the landing page is also covered by this test.

It may make sense to test all the pages, which could be done in a separate change.