### PR TITLE
PB-796: handle paths without trailing slash without redirection.

### DIFF
--- a/app/config/admin.py
+++ b/app/config/admin.py
@@ -5,3 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class StacAdminSite(admin.AdminSite):
     site_header = _('STAC API admin')
     site_title = _('geoadmin STAC API')
+    # This is normally used to redirect URLs that are missing a trailing slash.
+    # We have our own special redirection code in middleware.internal_redirect
+    # for this and it doesn't play well with this feature. So we disable it.
+    final_catch_all_view = False

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -86,7 +86,7 @@ MIDDLEWARE = [
     'middleware.cors.CORSHeadersMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
+    'middleware.internal_redirect.CommonMiddlewareWithInternalRedirect',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/app/middleware/internal_redirect.py
+++ b/app/middleware/internal_redirect.py
@@ -12,9 +12,9 @@ class InternalRedirect(HttpResponseRedirect):
 
 class CommonMiddlewareWithInternalRedirect(CommonMiddleware):
     """
-  Same as CommonMiddleware except that when an HTTP redirection should be
-  issued, it follows the redirection itself.
-  """
+    Same as CommonMiddleware except that when an HTTP redirection should be
+    issued, it follows the redirection itself.
+    """
     response_redirect_class = InternalRedirect
     logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class CommonMiddlewareWithInternalRedirect(CommonMiddleware):
 
         # We don't use get_full_path_with_slash here as we only care about the path
         # without the query parametres.
-        new_path = '%s/' % request.path_info
+        new_path = '{request.path_info}/'
         self.logger.info('Internal redirect %s -> %s', request.path_info, new_path)
         request.path_info = new_path
         return get_wsgi_application().get_response(request)

--- a/app/middleware/internal_redirect.py
+++ b/app/middleware/internal_redirect.py
@@ -45,7 +45,7 @@ class CommonMiddlewareWithInternalRedirect(CommonMiddleware):
 
         # We don't use get_full_path_with_slash here as we only care about the path
         # without the query parametres.
-        new_path = '{request.path_info}/'
+        new_path = f'{request.path_info}/'
         self.logger.info('Internal redirect %s -> %s', request.path_info, new_path)
         request.path_info = new_path
         return get_wsgi_application().get_response(request)

--- a/app/middleware/internal_redirect.py
+++ b/app/middleware/internal_redirect.py
@@ -1,0 +1,51 @@
+import logging
+
+from django.conf import settings
+from django.core.wsgi import get_wsgi_application
+from django.http import HttpResponseRedirect
+from django.middleware.common import CommonMiddleware
+
+
+class InternalRedirect(HttpResponseRedirect):
+    pass
+
+
+class CommonMiddlewareWithInternalRedirect(CommonMiddleware):
+    """
+  Same as CommonMiddleware except that when an HTTP redirection should be
+  issued, it follows the redirection itself.
+  """
+    response_redirect_class = InternalRedirect
+    logger = logging.getLogger(__name__)
+
+    def get_full_path_with_slash(self, request):
+        # CommonMiddleware.get_full_path_with_slash refuses to process methods that
+        # may have data associated to them (i.e. DELETE, POST, PUT, PATCH) when
+        # DEBUG is True. Instead of reimplementing the method, we temporarily
+        # disable DEBUG.
+        debug_old_value = settings.DEBUG
+        try:
+            settings.DEBUG = False
+            return super().get_full_path_with_slash(request)
+        finally:
+            settings.DEBUG = debug_old_value
+
+    def process_response(self, request, response):
+        new_response = super().process_response(request, response)
+        if not isinstance(new_response, InternalRedirect):
+            return new_response
+
+        if request.path_info.endswith('/'):
+            self.logger.error(
+                'Not redirecting path that already ends with a slash: %s: %s',
+                request.path_info,
+                request
+            )
+            return new_response
+
+        # We don't use get_full_path_with_slash here as we only care about the path
+        # without the query parametres.
+        new_path = '%s/' % request.path_info
+        self.logger.info('Internal redirect %s -> %s', request.path_info, new_path)
+        request.path_info = new_path
+        return get_wsgi_application().get_response(request)

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -2,6 +2,8 @@ import logging
 import time
 from io import BytesIO
 
+from parameterized import parameterized
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client
@@ -47,12 +49,14 @@ class AdminBaseTestCase(TestCase):
         if create_item:
             self.item = self._create_item(self.collection)[0]
 
-    def _create_collection(self, with_link=False, with_provider=False, extra=None):
+    def _create_collection(
+        self, name="test_collection", with_link=False, with_provider=False, extra=None
+    ):
         # Post data to create a new collection
         # Note: the *-*_FORMS fields are necessary management form fields
         # originating from the AdminInline and must be present
         data = {
-            "name": "test_collection",
+            "name": name,
             "license": "free",
             "description": "some very important collection",
             "published": "on",
@@ -314,18 +318,26 @@ class AdminTestCase(AdminBaseTestCase):
         response = self.client.get("/api/stac/admin/login/?next=/api/stac/admin")
         self.assertEqual(response.status_code, 200, "Admin page login not up.")
 
-    def test_login(self):
+    @parameterized.expand([
+        ("/api/stac/admin/",),
+        ("/api/stac/admin",),
+    ])
+    def test_login(self, login_path):
         # Make sure login of the test user works
         self.client.login(username=self.username, password=self.password)
-        response = self.client.get("/api/stac/admin/")
+        response = self.client.get(login_path)
         self.assertEqual(response.status_code, 200, msg="Admin page login failed")
 
-    def test_login_failure(self):
+    @parameterized.expand([
+        ("/api/stac/admin/",),
+        ("/api/stac/admin",),
+    ])
+    def test_login_failure(self, login_path):
         # Make sure login with wrong password fails
         self.client.login(username=self.username, password="wrongpassword")
-        response = self.client.get("/api/stac/admin/")
+        response = self.client.get(login_path)
         self.assertEqual(response.status_code, 302)
-        self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
+        self.assertEqual(f"/api/stac/admin/login/?next={login_path}", response.url)
 
 
 #--------------------------------------------------------------------------------------------------
@@ -409,12 +421,16 @@ class AdminCollectionTestCase(AdminBaseTestCase):
             msg="Admin page wrong provider.roles after update"
         )
 
-    def test_add_collection_with_provider_empty_description(self):
+    @parameterized.expand([
+        ("/api/stac/admin/stac_api/collection/add", "test_collection_noslash"),
+        ("/api/stac/admin/stac_api/collection/add/", "test_collection_slash"),
+    ])
+    def test_add_collection_with_provider_empty_description(self, post_path, collection_name):
         # Login the user first
         self.client.login(username=self.username, password=self.password)
 
         data = {
-            "name": "test_collection",
+            "name": collection_name,
             "license": "free",
             "description": "some very important collection",
             "links-TOTAL_FORMS": "0",
@@ -428,7 +444,7 @@ class AdminCollectionTestCase(AdminBaseTestCase):
             "assets-TOTAL_FORMS": "0",
             "assets-INITIAL_FORMS": "0"
         }
-        response = self.client.post("/api/stac/admin/stac_api/collection/add/", data)
+        response = self.client.post(post_path, data)
 
         # Status code for successful creation is 302, since in the admin UI
         # you're redirected to the list view after successful creation
@@ -449,11 +465,16 @@ class AdminCollectionTestCase(AdminBaseTestCase):
             provider.description, None, msg="Admin page wrong provider.description on creation"
         )
 
-    def test_add_update_collection_empty_provider_description(self):
+    @parameterized.expand([
+        ("/api/stac/admin/stac_api/collection/{id}/change", "test_collection_noslash"),
+        ("/api/stac/admin/stac_api/collection/{id}/change/", "test_collection_slash"),
+    ])
+    def test_add_update_collection_empty_provider_description(self, post_path, collection_name):
         # Login the user first
         self.client.login(username=self.username, password=self.password)
 
-        collection, data, link, provider = self._create_collection(with_provider=True)
+        collection, data, link, provider = self._create_collection(name=collection_name,
+                                                                   with_provider=True)
 
         self.assertEqual(
             provider.description,
@@ -466,9 +487,7 @@ class AdminCollectionTestCase(AdminBaseTestCase):
         data["providers-0-id"] = provider.id
         data["providers-0-collection"] = collection.id
         data["providers-0-description"] = ""
-        response = self.client.post(
-            f"/api/stac/admin/stac_api/collection/{collection.id}/change/", data
-        )
+        response = self.client.post(post_path.format(id=collection.id), data)
 
         # Status code for successful creation is 302, since in the admin UI
         # you're redirected to the list view after successful creation

--- a/app/tests/tests_09/test_landing_page.py
+++ b/app/tests/tests_09/test_landing_page.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from django.test import Client
 
 from tests.tests_09.base_test import STAC_BASE_V
@@ -10,8 +12,12 @@ class IndexTestCase(StacBaseTestCase):
     def setUp(self):
         self.client = Client()
 
-    def test_landing_page(self):
-        response = self.client.get(f"/{STAC_BASE_V}/")
+    @parameterized.expand([
+        (f"/{STAC_BASE_V}/",),
+        (f"/{STAC_BASE_V}",),
+    ])
+    def test_landing_page(self, path):
+        response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertCors(response)
         self.assertEqual(response['Content-Type'], 'application/json')
@@ -30,9 +36,3 @@ class IndexTestCase(StacBaseTestCase):
                 set(),
                 msg="missing required attribute in the answer['links'] array"
             )
-
-    def test_landing_page_redirect(self):
-        response = self.client.get(f"/{STAC_BASE_V}")
-        self.assertEqual(response.status_code, 301)
-        self.assertLocationHeader(f"/{STAC_BASE_V}/", response)
-        self.assertCors(response)

--- a/app/tests/tests_10/test_landing_page.py
+++ b/app/tests/tests_10/test_landing_page.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from django.test import Client
 
 from tests.tests_10.base_test import STAC_BASE_V
@@ -10,8 +12,12 @@ class IndexTestCase(StacBaseTestCase):
     def setUp(self):
         self.client = Client()
 
-    def test_landing_page(self):
-        response = self.client.get(f"/{STAC_BASE_V}/")
+    @parameterized.expand([
+        (f"/{STAC_BASE_V}/",),
+        (f"/{STAC_BASE_V}",),
+    ])
+    def test_landing_page(self, path):
+        response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertCors(response)
         self.assertEqual(response['Content-Type'], 'application/json')
@@ -30,9 +36,3 @@ class IndexTestCase(StacBaseTestCase):
                 set(),
                 msg="missing required attribute in the answer['links'] array"
             )
-
-    def test_landing_page_redirect(self):
-        response = self.client.get(f"/{STAC_BASE_V}")
-        self.assertEqual(response.status_code, 301)
-        self.assertLocationHeader(f"/{STAC_BASE_V}/", response)
-        self.assertCors(response)


### PR DESCRIPTION
API Gateway v1 strips trailing slashes from the request paths. We have a few endpoints that use trailing slashes. Specifically:
	/api/stac/v1/
	/api/stac/v0.9/
	/api/stac/admin/*

Django's CommonMiddleware already has a feature to redirect URLs without trailing slash to their "slashed" equivalent when they exist. When combined with API Gateway v1 this causes a redirection loop.

This change introduces CommonMiddlewareWithInternalRedirect which handles the redirection internally to serve the query like if it had hit the "slashed" page directly.

It also updates the test to verify both endpoints work correctly.

Based on discussion in https://ltwiki.adr.admin.ch:8443/display/~adrien.kunysz@swisstopo.ch/STAC+API+trailing+slash+inconsistency