### PR TITLE
PB-754: Endpoint to immediately calculate extent

### DIFF
--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -18,6 +18,7 @@ from stac_api.views import ItemDetail
 from stac_api.views import ItemsList
 from stac_api.views import LandingPageDetail
 from stac_api.views import SearchList
+from stac_api.views import recalculate_extent
 
 # HEALTHCHECK_ENDPOINT = settings.HEALTHCHECK_ENDPOINT
 
@@ -57,7 +58,8 @@ urlpatterns = [
             path("conformance", ConformancePageDetail.as_view(), name='conformance'),
             path("search", SearchList.as_view(), name='search-list'),
             path("collections", CollectionList.as_view(), name='collections-list'),
-            path("collections/", include(collection_urls))
+            path("collections/", include(collection_urls)),
+            path("update-extent", recalculate_extent)
         ],
                  "v0.9"),
                 namespace='v0.9')
@@ -69,7 +71,8 @@ urlpatterns = [
             path("conformance", ConformancePageDetail.as_view(), name='conformance'),
             path("search", SearchList.as_view(), name='search-list'),
             path("collections", CollectionList.as_view(), name='collections-list'),
-            path("collections/", include(collection_urls))
+            path("collections/", include(collection_urls)),
+            path("update-extent", recalculate_extent)
         ],
                  "v1"),
                 namespace='v1')

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -11,6 +11,7 @@ from datetime import timezone
 from decimal import Decimal
 from decimal import InvalidOperation
 from enum import Enum
+from io import StringIO
 from urllib import parse
 
 import boto3
@@ -20,6 +21,7 @@ from botocore.client import Config
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.contrib.gis.geos import Polygon
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.urls import reverse
 
@@ -27,6 +29,18 @@ logger = logging.getLogger(__name__)
 
 AVAILABLE_S3_BUCKETS = Enum('AVAILABLE_S3_BUCKETS', list(settings.AWS_SETTINGS.keys()))
 API_VERSION = Enum('API_VERSION', ['v09', 'v1'])
+
+
+def call_calculate_extent(*args, **kwargs):
+    out = StringIO()
+    call_command(
+        "calculate_extent",
+        *args,
+        stdout=out,
+        stderr=StringIO(),
+        **kwargs,
+    )
+    return out.getvalue()
 
 
 def isoformat(date_time):

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -12,7 +12,10 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import generics
 from rest_framework import mixins
+from rest_framework import permissions
 from rest_framework import serializers
+from rest_framework.decorators import api_view
+from rest_framework.decorators import permission_classes
 from rest_framework.exceptions import APIException
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
@@ -38,6 +41,7 @@ from stac_api.serializers import ConformancePageSerializer
 from stac_api.serializers import ItemSerializer
 from stac_api.serializers import LandingPageSerializer
 from stac_api.serializers_utils import get_relation_links
+from stac_api.utils import call_calculate_extent
 from stac_api.utils import get_asset_path
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import is_api_version_1
@@ -286,6 +290,13 @@ class CollectionList(generics.GenericAPIView):
         if page is not None:
             return self.get_paginated_response(data)
         return Response(data)
+
+
+@api_view(['POST'])
+@permission_classes((permissions.AllowAny,))
+def recalculate_extent(request):
+    call_calculate_extent()
+    return Response()
 
 
 class CollectionDetail(


### PR DESCRIPTION
Add POST endpoint to run the management command to calculate the collection extents.
This is especially useful for e2e testing.

Should this be added to the spec and "officially" available?