### PR TITLE
PB-754: Fix extent calculation query

### DIFF
--- a/app/stac_api/management/commands/calculate_extent.py
+++ b/app/stac_api/management/commands/calculate_extent.py
@@ -57,6 +57,7 @@ class Handler(CommandHandler):
                     UNION
                         -- This covers the case that the last item of a collection is deleted.
                         SELECT %s AS collection_id, NULL, NULL, NULL
+                    ORDER BY extent_geometry, extent_start_datetime, extent_end_datetime
                     LIMIT 1
                     )
                     -- Update related collection extent


### PR DESCRIPTION
End-to-end test cases were flaky because the extent was sometimes not updated correctly.

The UNION operation does not guarantee order.
Add ORDER BY to make sure the NULL values are removed by LIMIT if there is another row.