### PR TITLE
PB-569: Remove obsolete "version" from docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   db:
     image: kartoza/postgis:12.0


### PR DESCRIPTION
This removes the following warning when running `make setup`:

    WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion