### PR TITLE
Make pylint overgeneral-exceptions check actually work.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -526,6 +526,6 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception,
-                       StandardError
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception,
+                       builtins.StandardError

--- a/app/stac_api/management/commands/dummy_data.py
+++ b/app/stac_api/management/commands/dummy_data.py
@@ -149,7 +149,7 @@ class DummyDataHandler(CommandHandler):
                         errors += 1
 
             if errors:
-                raise Exception(
+                raise Exception(  # pylint: disable=broad-exception-raised
                     f'Failed to delete collection\'s {collection_name} items: {errors} errors'
                 )
         else:
@@ -192,7 +192,7 @@ class DummyDataHandler(CommandHandler):
                         errors += 1
 
             if errors:
-                raise Exception(f'Failed to create collection\'s items: {errors} errors')
+                raise Exception(f'Failed to create collection\'s items: {errors} errors')  # pylint: disable=broad-exception-raised
         else:
             for item_id in items:
                 self.create_item(collection, item_id, assets)

--- a/app/stac_api/serializers.py
+++ b/app/stac_api/serializers.py
@@ -411,7 +411,7 @@ class AssetSerializer(AssetBaseSerializer):
             if self.collection:
                 collection = self.collection
             else:
-                raise Exception("Implementation error")
+                raise LookupError("No collection defined.")
 
             if not collection.allow_external_assets:
                 logger.info(

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -171,7 +171,7 @@ def _get_boto_access_kwargs(s3_bucket: AVAILABLE_S3_BUCKETS = AVAILABLE_S3_BUCKE
         needed_env_vars = ['AWS_ROLE_ARN', 'AWS_WEB_IDENTITY_TOKEN_FILE']
         for env_var in needed_env_vars:
             if env_var not in os.environ:
-                raise Exception(
+                raise EnvironmentError(
                     f"For the {s3_bucket} bucket the environment variable "
                     "{env_var} must be configured"
                 )

--- a/app/tests/utils.py
+++ b/app/tests/utils.py
@@ -131,7 +131,7 @@ def mock_s3_bucket(s3_bucket: AVAILABLE_S3_BUCKETS = AVAILABLE_S3_BUCKETS.legacy
             )
             logger.debug('Mock S3 bucket created in %fs', time.time() - start)
         else:
-            raise Exception(
+            raise Exception(  # pylint: disable=broad-exception-raised
                 f"Unable to mock the s3 bucket: {error.response['Error']['Message']}"
             ) from error
     logger.debug('Mock S3 bucket in %fs', time.time() - start)


### PR DESCRIPTION
This fixes a bug in the pylintrc configuration. This also "fix" some broad exceptions either by using more specific ones or by disabling the check when I couldn't quickly find a more appropriate exception.