### PR TITLE
Deflake serializer tests.

### DIFF
--- a/app/tests/tests_09/base_test.py
+++ b/app/tests/tests_09/base_test.py
@@ -2,7 +2,7 @@ import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
-from datetime import timedelta
+from datetime import datetime
 from pprint import pformat
 from urllib.parse import urlparse
 
@@ -14,6 +14,8 @@ from django.test import TransactionTestCase
 from stac_api.utils import fromisoformat
 from stac_api.utils import get_link
 from stac_api.utils import get_provider
+from stac_api.utils import isoformat
+from stac_api.utils import utc_aware
 
 from tests.utils import get_http_error_description
 
@@ -437,14 +439,14 @@ class StacTestMixin:
             else:
                 self._check_stac_list(path, sorted(value), sorted(current[key]))
         elif key in ['created', 'updated']:
-            # created and updated time are automatically set therefore don't do an exact
-            # test as we can't guess the exact time.
-            self.assertAlmostEqual(
-                fromisoformat(value),
-                fromisoformat(current[key]),
-                delta=timedelta(seconds=3),
-                msg=f'{path}: current datetime value is not equal to the expected'
-            )
+            # Created and updated time are automatically set therefore don't do an exact
+            # test as we can't guess the exact time. So we just check these timestamps
+            # are from after the start of the test and before "now".
+            self.assertLessEqual(value, current[key],
+                msg=f'{path}: current datetime value is before test start time')
+            now = isoformat(utc_aware(datetime.now()))
+            self.assertGreaterEqual(now, current[key],
+                msg=f'{path}: current datetime value is after test end time')
         elif key == 'href':
             self.assertEqual(
                 urlparse(value).path,

--- a/app/tests/tests_09/base_test.py
+++ b/app/tests/tests_09/base_test.py
@@ -442,11 +442,15 @@ class StacTestMixin:
             # Created and updated time are automatically set therefore don't do an exact
             # test as we can't guess the exact time. So we just check these timestamps
             # are from after the start of the test and before "now".
-            self.assertLessEqual(value, current[key],
-                msg=f'{path}: current datetime value is before test start time')
+            self.assertLessEqual(
+                value,
+                current[key],
+                msg=f'{path}: current datetime value is before test start time'
+            )
             now = isoformat(utc_aware(datetime.now()))
-            self.assertGreaterEqual(now, current[key],
-                msg=f'{path}: current datetime value is after test end time')
+            self.assertGreaterEqual(
+                now, current[key], msg=f'{path}: current datetime value is after test end time'
+            )
         elif key == 'href':
             self.assertEqual(
                 urlparse(value).path,

--- a/app/tests/tests_09/test_serializer.py
+++ b/app/tests/tests_09/test_serializer.py
@@ -1,5 +1,4 @@
 # pylint: disable=too-many-lines
-import time
 
 import logging
 from collections import OrderedDict
@@ -48,7 +47,6 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
     def setUp(self):
         self.data_factory = Factory()
         self.collection_created_after = utc_aware(datetime.now())
-        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.item = self.data_factory.create_item_sample(
             collection=self.collection.model, db_create=True
@@ -147,7 +145,6 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
     def setUp(self):
         self.data_factory = Factory()
         self.collection_created_after = utc_aware(datetime.now())
-        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.maxDiff = None  # pylint: disable=invalid-name
 

--- a/app/tests/tests_09/test_serializer.py
+++ b/app/tests/tests_09/test_serializer.py
@@ -1,4 +1,5 @@
 # pylint: disable=too-many-lines
+import time
 
 import logging
 from collections import OrderedDict
@@ -46,7 +47,8 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
     @mock_s3_asset_file
     def setUp(self):
         self.data_factory = Factory()
-        self.collection_created = utc_aware(datetime.now())
+        self.collection_created_after = utc_aware(datetime.now())
+        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.item = self.data_factory.create_item_sample(
             collection=self.collection.model, db_create=True
@@ -74,7 +76,7 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
 
         expected = self.collection.get_json('serialize')
         expected.update({
-            'created': isoformat(self.collection_created),
+            'created': isoformat(self.collection_created_after),
             'crs': ['http://www.opengis.net/def/crs/OGC/1.3/CRS84'],
             'extent': {
                 'spatial': {
@@ -135,7 +137,7 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
                 'geoadmin:variant': ['kgrs'],
                 'proj:epsg': [2056],
             },
-            'updated': isoformat(self.collection_created)
+            'updated': isoformat(self.collection_created_after)
         })
         self.check_stac_collection(expected, python_native)
 
@@ -144,7 +146,8 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
 
     def setUp(self):
         self.data_factory = Factory()
-        self.collection_created = utc_aware(datetime.now())
+        self.collection_created_after = utc_aware(datetime.now())
+        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.maxDiff = None  # pylint: disable=invalid-name
 
@@ -166,7 +169,7 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
 
         expected = self.collection.get_json('serialize')
         expected.update({
-            'created': isoformat(self.collection_created),
+            'created': isoformat(self.collection_created_after),
             'crs': ['http://www.opengis.net/def/crs/OGC/1.3/CRS84'],
             'extent': {
                 'spatial': {
@@ -222,7 +225,7 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
             ],
             'stac_version': STAC_VERSION,
             'summaries': {},
-            'updated': isoformat(self.collection_created)
+            'updated': isoformat(self.collection_created_after)
         })
         self.check_stac_collection(expected, python_native)
 

--- a/app/tests/tests_10/base_test.py
+++ b/app/tests/tests_10/base_test.py
@@ -443,11 +443,15 @@ class StacTestMixin:
             # Created and updated time are automatically set therefore don't do an exact
             # test as we can't guess the exact time. So we just check these timestamps
             # are from after the start of the test and before "now".
-            self.assertLessEqual(value, current[key],
-                msg=f'{path}: current datetime value is before test start time')
+            self.assertLessEqual(
+                value,
+                current[key],
+                msg=f'{path}: current datetime value is before test start time'
+            )
             now = isoformat(utc_aware(datetime.now()))
-            self.assertGreaterEqual(now, current[key],
-                msg=f'{path}: current datetime value is after test end time')
+            self.assertGreaterEqual(
+                now, current[key], msg=f'{path}: current datetime value is after test end time'
+            )
         elif key == 'href':
             self.assertEqual(
                 urlparse(value).path,

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 
+import time
 import logging
 from collections import OrderedDict
 from datetime import datetime
@@ -46,7 +47,8 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
     @mock_s3_asset_file
     def setUp(self):
         self.data_factory = Factory()
-        self.collection_created = utc_aware(datetime.now())
+        self.collection_created_after = utc_aware(datetime.now())
+        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.item = self.data_factory.create_item_sample(
             collection=self.collection.model, db_create=True
@@ -74,7 +76,7 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
 
         expected = self.collection.get_json('serialize')
         expected.update({
-            'created': isoformat(self.collection_created),
+            'created': isoformat(self.collection_created_after),
             'crs': ['http://www.opengis.net/def/crs/OGC/1.3/CRS84'],
             'extent': {
                 'spatial': {
@@ -132,7 +134,7 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
                 'geoadmin:variant': ['kgrs'],
                 'proj:epsg': [2056],
             },
-            'updated': isoformat(self.collection_created)
+            'updated': isoformat(self.collection_created_after)
         })
         self.check_stac_collection(expected, python_native)
 
@@ -141,7 +143,8 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
 
     def setUp(self):
         self.data_factory = Factory()
-        self.collection_created = utc_aware(datetime.now())
+        self.collection_created_after = utc_aware(datetime.now())
+        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.maxDiff = None  # pylint: disable=invalid-name
 
@@ -163,7 +166,7 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
 
         expected = self.collection.get_json('serialize')
         expected.update({
-            'created': isoformat(self.collection_created),
+            'created': isoformat(self.collection_created_after),
             'crs': ['http://www.opengis.net/def/crs/OGC/1.3/CRS84'],
             'extent': {
                 'spatial': {
@@ -216,7 +219,7 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
             ],
             'stac_version': STAC_VERSION,
             'summaries': {},
-            'updated': isoformat(self.collection_created)
+            'updated': isoformat(self.collection_created_after)
         })
         self.check_stac_collection(expected, python_native)
 

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-many-lines
 
-import time
 import logging
 from collections import OrderedDict
 from datetime import datetime
@@ -48,7 +47,6 @@ class CollectionSerializationTestCase(StacBaseTransactionTestCase):
     def setUp(self):
         self.data_factory = Factory()
         self.collection_created_after = utc_aware(datetime.now())
-        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.item = self.data_factory.create_item_sample(
             collection=self.collection.model, db_create=True
@@ -144,7 +142,6 @@ class EmptyCollectionSerializationTestCase(StacBaseTransactionTestCase):
     def setUp(self):
         self.data_factory = Factory()
         self.collection_created_after = utc_aware(datetime.now())
-        time.sleep(5)
         self.collection = self.data_factory.create_collection_sample(db_create=True)
         self.maxDiff = None  # pylint: disable=invalid-name
 


### PR DESCRIPTION
The serializer test involve comparing the "created" and "updated" fields of collections. These fields are populated with whatever Django thinks is the current time. Until this PR, the tests assumed that comparing to "test start time" +/- 2 seconds was good enough. As per PB-694 this has proved wrong several times.

This change updates the tests such that we only verify the field values are between the start time and end time of each test. As long as time goes forward this should be fine. In any case, it should already make the test much more reliable.

We verified this works by adding a 5 seconds delay after the start of the test (which was removed in the second to last change in this PR).