### PR TITLE
PB-511: Add request context to all logs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,7 +43,7 @@ py-multihash = "~=2.0.1"
 django-prometheus = "~=2.3.1"
 django-admin-autocomplete-filter = "~=0.7.1"
 django-pgtrigger = "~=4.11.1"
-logging-utilities = "~=4.4.1"
+logging-utilities = "~=4.5.0"
 django-environ = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32b93ecc78a501f105c65882083f8c63a374dc1d70c95ecc8ae4c501337d405d"
+            "sha256": "26f4b2b9d09c47972e02c969bd13d98ec09f34125905c9231d496e8143b9495a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -369,12 +369,12 @@
         },
         "logging-utilities": {
             "hashes": [
-                "sha256:0e144647749fdb153a43cdede0b077b9bcfd50fc6a068e07716b1a002173e8ef",
-                "sha256:ed3bb7aa657315b08415a92499f5ce38c024cc1aa18b682f1fd55c72b54491b9"
+                "sha256:0f88c3ddf33a7e81da20839667a9bedadfe22de6f9087c801aa1f582b89b4c93",
+                "sha256:d96b6910d0a1c26216bca893c11d66c0a8a61113af44cd908b2e4f4ae569e067"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.0'",
-            "version": "==4.4.1"
+            "version": "==4.5.0"
         },
         "morphys": {
             "hashes": [

--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -38,6 +38,11 @@ filters:
     (): logging_utilities.filters.TimeAttribute
     isotime: False
     utc_isotime: True
+  add_request:
+    (): logging_utilities.filters.add_thread_context_filter.AddThreadContextFilter
+    contexts:
+    - logger_key: request
+      context_key: request
   django:
     (): logging_utilities.filters.django_request.JsonDjangoRequest
     attr_name: request
@@ -133,6 +138,7 @@ handlers:
       # handler, they will affect every handler
       - type_filter
       - isotime
+      - add_request
       - django
       # This filter only applies to the current handler (It does not modify the record in-place, but
       # instead selects which logs to display)

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -81,6 +81,9 @@ INSTALLED_APPS = [
 # last, put everything else in between
 MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    # Middleware to add request to thread variables, this should be far up in the chain so request
+    # information can be added to as many logs as possible.
+    'logging_utilities.django_middlewares.add_request_context.AddToThreadContextMiddleware',
     'middleware.logging.RequestResponseLoggingMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'middleware.cors.CORSHeadersMiddleware',


### PR DESCRIPTION
Add middleware and logging filter to add the django request to all log records.
Also see: https://github.com/geoadmin/lib-py-logging-utilities/pull/62
