### PR TITLE
PB-756: CRUD API for collection assets

### DIFF
--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -39,6 +39,7 @@ if settings.DEBUG:
     import debug_toolbar
 
     from stac_api.views_test import TestAssetUpsertHttp500
+    from stac_api.views_test import TestCollectionAssetUpsertHttp500
     from stac_api.views_test import TestCollectionUpsertHttp500
     from stac_api.views_test import TestHttp500
     from stac_api.views_test import TestItemUpsertHttp500
@@ -60,6 +61,11 @@ if settings.DEBUG:
             'tests/test_asset_upsert_http_500/<collection_name>/<item_name>/<asset_name>',
             TestAssetUpsertHttp500.as_view(),
             name='test-asset-detail-http-500'
+        ),
+        path(
+            'tests/test_collection_asset_upsert_http_500/<collection_name>/<asset_name>',
+            TestCollectionAssetUpsertHttp500.as_view(),
+            name='test-collection-asset-detail-http-500'
         ),
         # Add v0.9 namespace to test routes.
         path(

--- a/app/stac_api/serializers_utils.py
+++ b/app/stac_api/serializers_utils.py
@@ -72,6 +72,14 @@ view_relations = {
         'parent': 'landing-page',
         'browser': 'browser-collection',
     },
+    'collection-assets-list': {
+        'parent': 'collection-detail',
+        'browser': None,
+    },
+    'collection-asset-detail': {
+        'parent': 'collection-detail',
+        'browser': None,
+    },
     'items-list': {
         'parent': 'collection-detail',
         'browser': 'browser-collection',
@@ -107,6 +115,8 @@ def get_parent_link(request, view, view_args=()):
     '''
 
     def parent_args(view, args):
+        if view.startswith('collection-asset'):
+            return args[:1]
         if view.startswith('item'):
             return args[:1]
         if view.startswith('asset'):

--- a/app/stac_api/signals.py
+++ b/app/stac_api/signals.py
@@ -6,6 +6,7 @@ from django.dispatch import receiver
 
 from stac_api.models import Asset
 from stac_api.models import AssetUpload
+from stac_api.models import CollectionAsset
 
 logger = logging.getLogger(__name__)
 
@@ -35,4 +36,13 @@ def delete_s3_asset(sender, instance, **kwargs):
     # when the object holding its reference is deleted
     # hence it has to be done here.
     logger.info("The asset %s is deleted from s3", instance.file.name)
+    instance.file.delete(save=False)
+
+
+@receiver(pre_delete, sender=CollectionAsset)
+def delete_s3_collection_asset(sender, instance, **kwargs):
+    # The file is not automatically deleted by Django
+    # when the object holding its reference is deleted
+    # hence it has to be done here.
+    logger.info("The collection asset %s is deleted from s3", instance.file.name)
     instance.file.delete(save=False)

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -11,6 +11,8 @@ from stac_api.views import AssetUploadComplete
 from stac_api.views import AssetUploadDetail
 from stac_api.views import AssetUploadPartsList
 from stac_api.views import AssetUploadsList
+from stac_api.views import CollectionAssetDetail
+from stac_api.views import CollectionAssetsList
 from stac_api.views import CollectionDetail
 from stac_api.views import CollectionList
 from stac_api.views import ConformancePageDetail
@@ -41,7 +43,19 @@ item_urls = [
     path("<item_name>/assets/", include(asset_urls))
 ]
 
+collection_asset_urls = [
+    path("<asset_name>", CollectionAssetDetail.as_view(), name='collection-asset-detail'),
+]
+
 collection_urls = [
+    path("<collection_name>", CollectionDetail.as_view(), name='collection-detail'),
+    path("<collection_name>/items", ItemsList.as_view(), name='items-list'),
+    path("<collection_name>/items/", include(item_urls)),
+    path("<collection_name>/assets", CollectionAssetsList.as_view(), name='collection-assets-list'),
+    path("<collection_name>/assets/", include(collection_asset_urls))
+]
+
+collection_urls_v09 = [
     path("<collection_name>", CollectionDetail.as_view(), name='collection-detail'),
     path("<collection_name>/items", ItemsList.as_view(), name='items-list'),
     path("<collection_name>/items/", include(item_urls))
@@ -58,7 +72,7 @@ urlpatterns = [
             path("conformance", ConformancePageDetail.as_view(), name='conformance'),
             path("search", SearchList.as_view(), name='search-list'),
             path("collections", CollectionList.as_view(), name='collections-list'),
-            path("collections/", include(collection_urls)),
+            path("collections/", include(collection_urls_v09)),
             path("update-extent", recalculate_extent)
         ],
                  "v0.9"),

--- a/app/stac_api/views.py
+++ b/app/stac_api/views.py
@@ -30,6 +30,7 @@ from stac_api.exceptions import UploadNotInProgressError
 from stac_api.models import Asset
 from stac_api.models import AssetUpload
 from stac_api.models import Collection
+from stac_api.models import CollectionAsset
 from stac_api.models import Item
 from stac_api.models import LandingPage
 from stac_api.pagination import ExtApiPagination
@@ -38,6 +39,7 @@ from stac_api.s3_multipart_upload import MultipartUpload
 from stac_api.serializers import AssetSerializer
 from stac_api.serializers import AssetUploadPartsSerializer
 from stac_api.serializers import AssetUploadSerializer
+from stac_api.serializers import CollectionAssetSerializer
 from stac_api.serializers import CollectionSerializer
 from stac_api.serializers import ConformancePageSerializer
 from stac_api.serializers import ItemSerializer
@@ -45,6 +47,7 @@ from stac_api.serializers import LandingPageSerializer
 from stac_api.serializers_utils import get_relation_links
 from stac_api.utils import call_calculate_extent
 from stac_api.utils import get_asset_path
+from stac_api.utils import get_collection_asset_path
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import is_api_version_1
 from stac_api.utils import select_s3_bucket
@@ -106,6 +109,31 @@ def get_item_etag(request, *args, **kwargs):
             Item.objects.filter(
                 collection__name=kwargs['collection_name'], name=kwargs['item_name']
             ).query
+        )
+
+    return tag
+
+
+def get_collection_asset_etag(request, *args, **kwargs):
+    '''Get the ETag for a collection asset object
+
+    The ETag is an UUID4 computed on each object changes
+    '''
+    tag = get_etag(
+        CollectionAsset.objects.filter(
+            collection__name=kwargs['collection_name'], name=kwargs['asset_name']
+        )
+    )
+
+    if settings.DEBUG_ENABLE_DB_EXPLAIN_ANALYZE:
+        logger.debug(
+            "Output of EXPLAIN.. ANALYZE from get_collection_asset_etag():\n%s",
+            CollectionAsset.objects.filter(name=kwargs['asset_name']
+                                          ).explain(verbose=True, analyze=True)
+        )
+        logger.debug(
+            "The corresponding SQL statement:\n%s",
+            CollectionAsset.objects.filter(name=kwargs['asset_name']).query
         )
 
     return tag
@@ -527,6 +555,34 @@ class AssetsList(generics.GenericAPIView):
         return response
 
 
+class CollectionAssetsList(generics.GenericAPIView):
+    name = 'collection-assets-list'  # this name must match the name in urls.py
+    serializer_class = CollectionAssetSerializer
+    pagination_class = None
+
+    def get_queryset(self):
+        # filter based on the url
+        return CollectionAsset.objects.filter(collection__name=self.kwargs['collection_name']
+                                             ).order_by('name')
+
+    def get(self, request, *args, **kwargs):
+        validate_collection(self.kwargs)
+
+        queryset = self.filter_queryset(self.get_queryset())
+        update_interval = Collection.objects.values('update_interval').get(
+            name=self.kwargs['collection_name']
+        )['update_interval']
+        serializer = self.get_serializer(queryset, many=True)
+
+        data = {
+            'assets': serializer.data,
+            'links': get_relation_links(request, self.name, [self.kwargs['collection_name']])
+        }
+        response = Response(data)
+        views_mixins.patch_cache_settings_by_update_interval(response, update_interval)
+        return response
+
+
 class AssetDetail(
     generics.GenericAPIView,
     views_mixins.UpdateInsertModelMixin,
@@ -636,6 +692,90 @@ class AssetDetail(
 
     # Here the etag is only added to support pre-conditional If-Match and If-Not-Match
     @etag(get_asset_etag)
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
+
+
+class CollectionAssetDetail(
+    generics.GenericAPIView,
+    views_mixins.UpdateInsertModelMixin,
+    views_mixins.DestroyModelMixin,
+    views_mixins.RetrieveModelDynCacheMixin
+):
+    # this name must match the name in urls.py and is used by the DestroyModelMixin
+    name = 'collection-asset-detail'
+    serializer_class = CollectionAssetSerializer
+    lookup_url_kwarg = "asset_name"
+    lookup_field = "name"
+
+    def get_queryset(self):
+        # filter based on the url
+        return CollectionAsset.objects.filter(collection__name=self.kwargs['collection_name'])
+
+    def get_serializer(self, *args, **kwargs):
+        serializer_class = self.get_serializer_class()
+        kwargs.setdefault('context', self.get_serializer_context())
+        collection = get_object_or_404(Collection, name=self.kwargs['collection_name'])
+        serializer = serializer_class(*args, **kwargs)
+
+        # for the validation the serializer needs to know the collection of the
+        # asset. In case of inserting, the asset doesn't exist and thus the collection
+        # can't be read from the instance, which is why we pass the collection manually
+        # here. See serializers.AssetBaseSerializer._validate_href_field
+        serializer.collection = collection
+        return serializer
+
+    def perform_update(self, serializer):
+        collection = get_object_or_404(Collection, name=self.kwargs['collection_name'])
+        validate_renaming(
+            serializer,
+            original_id=self.kwargs['asset_name'],
+            extra_log={
+                'request': self.request._request,  # pylint: disable=protected-access
+                'collection': self.kwargs['collection_name'],
+                'asset': self.kwargs['asset_name']
+            }
+        )
+        return serializer.save(
+            collection=collection,
+            file=get_collection_asset_path(collection, self.kwargs['asset_name'])
+        )
+
+    def perform_upsert(self, serializer, lookup):
+        collection = get_object_or_404(Collection, name=self.kwargs['collection_name'])
+        validate_renaming(
+            serializer,
+            original_id=self.kwargs['asset_name'],
+            extra_log={
+                'request': self.request._request,  # pylint: disable=protected-access
+                'collection': self.kwargs['collection_name'],
+                'asset': self.kwargs['asset_name']
+            }
+        )
+        lookup['collection__name'] = collection.name
+
+        return serializer.upsert(
+            lookup,
+            collection=collection,
+            file=get_collection_asset_path(collection, self.kwargs['asset_name'])
+        )
+
+    @etag(get_collection_asset_etag)
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    # Here the etag is only added to support pre-conditional If-Match and If-Not-Match
+    @etag(get_collection_asset_etag)
+    def put(self, request, *args, **kwargs):
+        return self.upsert(request, *args, **kwargs)
+
+    # Here the etag is only added to support pre-conditional If-Match and If-Not-Match
+    @etag(get_collection_asset_etag)
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    # Here the etag is only added to support pre-conditional If-Match and If-Not-Match
+    @etag(get_collection_asset_etag)
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
 

--- a/app/stac_api/views_test.py
+++ b/app/stac_api/views_test.py
@@ -4,6 +4,7 @@ from rest_framework import generics
 
 from stac_api.models import LandingPage
 from stac_api.views import AssetDetail
+from stac_api.views import CollectionAssetDetail
 from stac_api.views import CollectionDetail
 from stac_api.views import ItemDetail
 
@@ -35,6 +36,13 @@ class TestItemUpsertHttp500(ItemDetail):
 
 
 class TestAssetUpsertHttp500(AssetDetail):
+
+    def perform_upsert(self, serializer, lookup):
+        super().perform_upsert(serializer, lookup)
+        raise AttributeError('test exception')
+
+
+class TestCollectionAssetUpsertHttp500(CollectionAssetDetail):
 
     def perform_upsert(self, serializer, lookup):
         super().perform_upsert(serializer, lookup)

--- a/app/tests/tests_10/base_test.py
+++ b/app/tests/tests_10/base_test.py
@@ -302,6 +302,56 @@ class StacTestMixin:
             ]
             self._check_stac_links('asset.links', links, current['links'])
 
+    def check_stac_collection_asset(self, expected, current, collection, ignore=None):
+        '''Check a STAC Collection Asset data
+
+        Check if the `current` collection asset data match the `expected`. This check is a subset
+        check which means that if a value is missing from `current`, then it raises a Test Assert,
+        while if a value is in `current` but not in `expected`, the test passed. The functions
+        knows also the STAC Spec and does some check based on it.
+
+        Args:
+            expected: dict
+                Expected STAC Asset
+            current: dict
+                Current STAC Asset to test
+            ignore: list(string) | None
+                List of keys to ignore in the test
+        '''
+        if ignore is None:
+            ignore = []
+        self._check_stac_dictsubset('asset', expected, current, ignore=ignore)
+
+        # check required fields
+        for key in ['links', 'id', 'type', 'href']:
+            if key in ignore:
+                logger.info('Ignoring key %s in asset', key)
+                continue
+            self.assertIn(key, current, msg=f'Asset {key} is missing')
+        for date_field in ['created', 'updated']:
+            if key in ignore:
+                logger.info('Ignoring key %s in asset', key)
+                continue
+            self.assertIn(date_field, current, msg=f'Asset {date_field} is missing')
+            self.assertTrue(
+                fromisoformat(current[date_field]),
+                msg=f"The asset field {date_field} has an invalid date"
+            )
+        if 'links' not in ignore:
+            name = current['id']
+            links = [
+                {
+                    'rel': 'self',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}/assets/{name}'
+                },
+                TEST_LINK_ROOT,
+                {
+                    'rel': 'parent',
+                    'href': f'{TEST_LINK_ROOT_HREF}/collections/{collection}',
+                },
+            ]
+            self._check_stac_links('asset.links', links, current['links'])
+
     def _check_stac_dictsubset(self, parent_path, expected, current, ignore=None):
         for key, value in expected.items():
             path = f'{parent_path}.{key}'

--- a/app/tests/tests_10/data_factory.py
+++ b/app/tests/tests_10/data_factory.py
@@ -801,23 +801,12 @@ class CollectionAssetSample(SampleData):
     samples_dict = collection_asset_samples
     key_mapping = {
         'name': 'id',
-        'eo_gsd': 'gsd',
-        'geoadmin_variant': 'geoadmin:variant',
-        'geoadmin_lang': 'geoadmin:lang',
         'proj_epsg': 'proj:epsg',
         'media_type': 'type',
         'checksum_multihash': 'file:checksum',
         'file': 'href'
     }
-    optional_fields = [
-        'title',
-        'description',
-        'eo_gsd',
-        'geoadmin_variant',
-        'geoadmin_lang',
-        'proj_epsg',
-        'checksum_multihash'
-    ]
+    optional_fields = ['title', 'description', 'proj_epsg', 'checksum_multihash']
     read_only_fields = ['created', 'updated', 'href', 'file:checksum']
 
     def __init__(self, collection, sample='asset-1', name=None, required_only=False, **kwargs):

--- a/app/tests/tests_10/test_collection_assets_endpoint.py
+++ b/app/tests/tests_10/test_collection_assets_endpoint.py
@@ -1,0 +1,729 @@
+import logging
+from datetime import datetime
+from json import dumps
+from json import loads
+from pprint import pformat
+
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from stac_api.models import CollectionAsset
+from stac_api.utils import get_collection_asset_path
+from stac_api.utils import utc_aware
+
+from tests.tests_10.base_test import STAC_BASE_V
+from tests.tests_10.base_test import StacBaseTestCase
+from tests.tests_10.base_test import StacBaseTransactionTestCase
+from tests.tests_10.data_factory import Factory
+from tests.tests_10.utils import reverse_version
+from tests.utils import S3TestMixin
+from tests.utils import client_login
+from tests.utils import disableLogger
+from tests.utils import mock_s3_asset_file
+
+logger = logging.getLogger(__name__)
+
+
+def to_dict(input_ordered_dict):
+    return loads(dumps(input_ordered_dict))
+
+
+class CollectionAssetsEndpointTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.asset_1 = self.factory.create_collection_asset_sample(
+            collection=self.collection, name="asset-1.tiff", db_create=True
+        )
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_assets_endpoint(self):
+        collection_name = self.collection.name
+        # To test the assert ordering make sure to not create them in ascent order
+        asset_2 = self.factory.create_collection_asset_sample(
+            collection=self.collection, sample='asset-2', name="asset-2.txt", db_create=True
+        )
+        asset_3 = self.factory.create_collection_asset_sample(
+            collection=self.collection, name="asset-0.pdf", sample='asset-3', db_create=True
+        )
+        response = self.client.get(f"/{STAC_BASE_V}/collections/{collection_name}/assets")
+        self.assertStatusCode(200, response)
+        json_data = response.json()
+        logger.debug('Response (%s):\n%s', type(json_data), pformat(json_data))
+
+        self.assertIn('assets', json_data, msg='assets is missing in response')
+        self.assertEqual(
+            3, len(json_data['assets']), msg='Number of assets doesn\'t match the expected'
+        )
+
+        # Check that the output is sorted by name
+        asset_ids = [asset['id'] for asset in json_data['assets']]
+        self.assertListEqual(asset_ids, sorted(asset_ids), msg="Assets are not sorted by ID")
+
+        asset_samples = sorted([self.asset_1, asset_2, asset_3], key=lambda asset: asset['name'])
+        for i, asset in enumerate(asset_samples):
+            # self.check_stac_asset(asset.json, json_data['assets'][i], collection_name, item_name)
+            self.check_stac_collection_asset(asset.json, json_data['assets'][i], collection_name)
+
+    def test_assets_endpoint_collection_does_not_exist(self):
+        collection_name = "non-existent"
+        response = self.client.get(f"/{STAC_BASE_V}/collections/{collection_name}/assets")
+        self.assertStatusCode(404, response)
+
+    def test_single_asset_endpoint(self):
+        collection_name = self.collection.name
+        asset_name = self.asset_1["name"]
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}"
+        )
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        logger.debug('Response (%s):\n%s', type(json_data), pformat(json_data))
+
+        self.check_stac_collection_asset(self.asset_1.json, json_data, collection_name)
+
+        # The ETag change between each test call due to the created, updated time that are in the
+        # hash computation of the ETag
+        self.assertEtagHeader(None, response)
+
+
+class CollectionAssetsUnimplementedEndpointTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_unimplemented_post(self):
+        collection_name = self.collection.name
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, required_only=True
+        )
+        response = self.client.post(
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets',
+            data=asset.get_json('post'),
+            content_type="application/json"
+        )
+        self.assertStatusCode(405, response)
+
+
+class CollectionAssetsCreateEndpointTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_upsert_create_only_required(self):
+        collection_name = self.collection.name
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, required_only=True
+        )
+        path = \
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset["name"]}'
+        json_to_send = asset.get_json('put')
+        # Send a non normalized form of the type to see if it is also accepted
+        json_to_send['type'] = 'image/TIFF;application=geotiff; Profile=cloud-optimized'
+        response = self.client.put(path, data=json_to_send, content_type="application/json")
+        json_data = response.json()
+        self.assertStatusCode(201, response)
+        self.assertLocationHeader(f"{path}", response)
+        self.check_stac_collection_asset(asset.json, json_data, collection_name)
+
+        # Check the data by reading it back
+        response = self.client.get(response['Location'])
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        self.check_stac_collection_asset(asset.json, json_data, collection_name)
+
+        # make sure that the optional fields are not present
+        self.assertNotIn('proj:epsg', json_data)
+        self.assertNotIn('description', json_data)
+        self.assertNotIn('title', json_data)
+        self.assertNotIn('file:checksum', json_data)
+
+    def test_asset_upsert_create(self):
+        collection = self.collection
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, sample='asset-no-checksum', create_asset_file=False
+        )
+        asset_name = asset['name']
+
+        response = self.client.get(
+            reverse_version('collection-asset-detail', args=[collection.name, asset_name])
+        )
+        # Check that assert does not exist already
+        self.assertStatusCode(404, response)
+
+        # Check also, that the asset does not exist in the DB already
+        self.assertFalse(
+            CollectionAsset.objects.filter(name=asset_name).exists(),
+            msg="Collection asset already exists"
+        )
+
+        # Now use upsert to create the new asset
+        response = self.client.put(
+            reverse_version('collection-asset-detail', args=[collection.name, asset_name]),
+            data=asset.get_json('put'),
+            content_type="application/json"
+        )
+        json_data = response.json()
+        self.assertStatusCode(201, response)
+        self.assertLocationHeader(
+            reverse_version('collection-asset-detail', args=[collection.name, asset_name]),
+            response
+        )
+        self.check_stac_collection_asset(asset.json, json_data, collection.name)
+
+        # make sure that all optional fields are present
+        self.assertIn('proj:epsg', json_data)
+        self.assertIn('description', json_data)
+        self.assertIn('title', json_data)
+
+        # Checksum multihash is set by the AssetUpload later on
+        self.assertNotIn('file:checksum', json_data)
+
+        # Check the data by reading it back
+        response = self.client.get(response['Location'])
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        self.check_stac_collection_asset(asset.json, json_data, collection.name)
+
+    def test_asset_upsert_create_non_existing_parent_collection_in_path(self):
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, create_asset_file=False
+        )
+        asset_name = asset['name']
+
+        path = (f'/{STAC_BASE_V}/collections/non-existing-collection/assets/'
+                f'{asset_name}')
+
+        # Check that asset does not exist already
+        response = self.client.get(path)
+        self.assertStatusCode(404, response)
+
+        # Check also, that the asset does not exist in the DB already
+        self.assertFalse(
+            CollectionAsset.objects.filter(name=asset_name).exists(),
+            msg="Deleted colelction asset still found in DB"
+        )
+
+        # Now use upsert to create the new asset
+        response = self.client.put(
+            path, data=asset.get_json('post'), content_type="application/json"
+        )
+        self.assertStatusCode(404, response)
+
+    def test_asset_upsert_create_empty_string(self):
+        collection_name = self.collection.name
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, required_only=True, description='', title=''
+        )
+
+        path = \
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset["name"]}'
+        response = self.client.put(
+            path, data=asset.get_json('put'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        json_data = response.json()
+        for field in ['description', 'title']:
+            self.assertIn(field, json_data['description'], msg=f'Field {field} error missing')
+
+    def invalid_request_wrapper(self, sample_name, expected_error_messages, **extra_params):
+        collection_name = self.collection.name
+        asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, sample=sample_name, **extra_params
+        )
+
+        path = \
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset["name"]}'
+        response = self.client.put(
+            path, data=asset.get_json('put'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual(
+            expected_error_messages,
+            response.json()['description'],
+            msg='Unexpected error message',
+        )
+
+        # Make sure that the asset is not found in DB
+        self.assertFalse(
+            CollectionAsset.objects.filter(name=asset.json['id']).exists(),
+            msg="Invalid asset has been created in DB"
+        )
+
+    def test_asset_upsert_create_invalid_data(self):
+        self.invalid_request_wrapper(
+            'asset-invalid', {
+                'proj:epsg': ['A valid integer is required.'],
+                'type': ['Invalid media type "dummy"']
+            }
+        )
+
+    def test_asset_upsert_create_invalid_type(self):
+        media_type_str = "image/tiff; application=Geotiff; profile=cloud-optimized"
+        self.invalid_request_wrapper(
+            'asset-invalid-type', {'type': [f'Invalid media type "{media_type_str}"']}
+        )
+
+    def test_asset_upsert_create_type_extension_mismatch(self):
+        media_type_str = "application/gml+xml"
+        self.invalid_request_wrapper(
+            'asset-invalid-type',
+            {
+                'non_field_errors': [
+                    f"Invalid id extension '.tiff', id must match its media type {media_type_str}"
+                ]
+            },
+            media_type=media_type_str,
+            # must be overridden, else extension will automatically match the type
+            name='asset-invalid-type.tiff'
+        )
+
+
+class CollectionAssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample(db_create=True)
+        self.asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model, db_create=True
+        )
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_endpoint_patch_put_href(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        asset_sample = self.asset.copy()
+
+        put_payload = asset_sample.get_json('put')
+        put_payload['href'] = 'https://testserver/non-existing-asset'
+        patch_payload = {'href': 'https://testserver/non-existing-asset'}
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.patch(path, data=patch_payload, content_type="application/json")
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Found read-only property in payload",
+            description['href'][0],
+            msg="Unexpected error message"
+        )
+
+        response = self.client.put(path, data=put_payload, content_type="application/json")
+        self.assertStatusCode(400, response)
+        description = response.json()['description']
+        self.assertIn('href', description, msg=f'Unexpected field error {description}')
+        self.assertEqual(
+            "Found read-only property in payload",
+            description['href'][0],
+            msg="Unexpected error message"
+        )
+
+
+class CollectionAssetsUpdateEndpointTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample(db_create=True)
+        self.asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model, db_create=True
+        )
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_endpoint_put(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=asset_name,
+            sample='asset-1-updated',
+            media_type=self.asset['media_type'],
+            checksum_multihash=self.asset['checksum_multihash'],
+            create_asset_file=False
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        self.check_stac_collection_asset(changed_asset.json, json_data, collection_name)
+
+        # Check the data by reading it back
+        response = self.client.get(path)
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+        self.check_stac_collection_asset(changed_asset.json, json_data, collection_name)
+
+    def test_asset_endpoint_put_extra_payload(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=asset_name,
+            sample='asset-1-updated',
+            media_type=self.asset['media_type'],
+            checksum_multihash=self.asset['checksum_multihash'],
+            extra_attribute='not allowed',
+            create_asset_file=False
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({'extra_attribute': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+    def test_asset_endpoint_put_read_only_in_payload(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=asset_name,
+            sample='asset-1-updated',
+            media_type=self.asset['media_type'],
+            created=utc_aware(datetime.utcnow()),
+            create_asset_file=False,
+            checksum_multihash=self.asset['checksum_multihash'],
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(
+            path,
+            data=changed_asset.get_json('put', keep_read_only=True),
+            content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({
+            'created': ['Found read-only property in payload'],
+            'file:checksum': ['Found read-only property in payload']
+        },
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+    def test_asset_endpoint_put_rename_asset(self):
+        # rename should not be allowed
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        new_asset_name = "new-asset-name.txt"
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=new_asset_name,
+            sample='asset-1-updated',
+            checksum_multihash=self.asset['checksum_multihash']
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(
+            path, data=changed_asset.get_json('put'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({'id': 'Renaming is not allowed'},
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+        # Check the data by reading it back
+        response = self.client.get(
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        )
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+
+        self.assertEqual(asset_name, json_data['id'])
+
+        # Check the data that no new entry exist
+        response = self.client.get(
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{new_asset_name}'
+        )
+
+        # 404 - not found
+        self.assertStatusCode(404, response)
+
+    def test_asset_endpoint_patch_rename_asset(self):
+        # rename should not be allowed
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        new_asset_name = "new-asset-name.txt"
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model, name=new_asset_name, sample='asset-1-updated'
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.patch(
+            path, data=changed_asset.get_json('patch'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({'id': 'Renaming is not allowed'},
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+        # Check the data by reading it back
+        response = self.client.get(
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        )
+        json_data = response.json()
+        self.assertStatusCode(200, response)
+
+        self.assertEqual(asset_name, json_data['id'])
+
+        # Check the data that no new entry exist
+        response = self.client.get(
+            f'/{STAC_BASE_V}/collections/{collection_name}/assets/{new_asset_name}'
+        )
+
+        # 404 - not found
+        self.assertStatusCode(404, response)
+
+    def test_asset_endpoint_patch_extra_payload(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=asset_name,
+            sample='asset-1-updated',
+            media_type=self.asset['media_type'],
+            extra_payload='invalid'
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.patch(
+            path, data=changed_asset.get_json('patch'), content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({'extra_payload': ['Unexpected property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+    def test_asset_endpoint_patch_read_only_in_payload(self):
+        collection_name = self.collection['name']
+        asset_name = self.asset['name']
+        changed_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection.model,
+            name=asset_name,
+            sample='asset-1-updated',
+            media_type=self.asset['media_type'],
+            created=utc_aware(datetime.utcnow())
+        )
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.patch(
+            path,
+            data=changed_asset.get_json('patch', keep_read_only=True),
+            content_type="application/json"
+        )
+        self.assertStatusCode(400, response)
+        self.assertEqual({'created': ['Found read-only property in payload']},
+                         response.json()['description'],
+                         msg='Unexpected error message')
+
+    def test_asset_atomic_upsert_create_500(self):
+        sample = self.factory.create_collection_asset_sample(
+            self.collection.model, create_asset_file=True
+        )
+
+        # the dataset to update does not exist yet
+        with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True), disableLogger('stac_api.apps'):
+            response = self.client.put(
+                reverse(
+                    'test-collection-asset-detail-http-500',
+                    args=[self.collection['name'], sample['name']]
+                ),
+                data=sample.get_json('put'),
+                content_type='application/json'
+            )
+        self.assertStatusCode(500, response)
+        self.assertEqual(response.json()['description'], "AttributeError('test exception')")
+
+        # Make sure that the ressource has not been created
+        response = self.client.get(
+            reverse_version(
+                'collection-asset-detail', args=[self.collection['name'], sample['name']]
+            )
+        )
+        self.assertStatusCode(404, response)
+
+    def test_asset_atomic_upsert_update_500(self):
+        sample = self.factory.create_collection_asset_sample(
+            self.collection.model, name=self.asset['name'], create_asset_file=True
+        )
+
+        # Make sure samples is different from actual data
+        self.assertNotEqual(sample.attributes, self.asset.attributes)
+
+        # the dataset to update does not exist yet
+        with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True), disableLogger('stac_api.apps'):
+            # because we explicitely test a crash here we don't want to print a CRITICAL log on the
+            # console therefore disable it.
+            response = self.client.put(
+                reverse(
+                    'test-collection-asset-detail-http-500',
+                    args=[self.collection['name'], sample['name']]
+                ),
+                data=sample.get_json('put'),
+                content_type='application/json'
+            )
+        self.assertStatusCode(500, response)
+        self.assertEqual(response.json()['description'], "AttributeError('test exception')")
+
+        # Make sure that the ressource has not been created
+        response = self.client.get(
+            reverse_version(
+                'collection-asset-detail', args=[self.collection['name'], sample['name']]
+            )
+        )
+        self.assertStatusCode(200, response)
+        self.check_stac_collection_asset(
+            self.asset.json, response.json(), self.collection['name'], ignore=['item']
+        )
+
+
+class CollectionAssetRaceConditionTest(StacBaseTransactionTestCase):
+
+    def setUp(self):
+        self.username = 'user'
+        self.password = 'dummy-password'
+        get_user_model().objects.create_superuser(self.username, password=self.password)
+        self.factory = Factory()
+        self.collection_sample = self.factory.create_collection_sample(
+            sample='collection-2', db_create=True
+        )
+
+    def test_asset_upsert_race_condition(self):
+        workers = 5
+        status_201 = 0
+        asset_sample = self.factory.create_collection_asset_sample(
+            self.collection_sample.model,
+            sample='asset-no-checksum',
+        )
+
+        def asset_atomic_upsert_test(worker):
+            # This method run on separate thread therefore it requires to create a new client and
+            # to login it for each call.
+            client = Client()
+            client.login(username=self.username, password=self.password)
+            return client.put(
+                reverse_version(
+                    'collection-asset-detail',
+                    args=[self.collection_sample['name'], asset_sample['name']]
+                ),
+                data=asset_sample.get_json('put'),
+                content_type='application/json'
+            )
+
+        # We call the PUT asset several times in parallel with the same data to make sure
+        # that we don't have any race condition.
+        responses, errors = self.run_parallel(workers, asset_atomic_upsert_test)
+
+        for worker, response in responses:
+            if response.status_code == 201:
+                status_201 += 1
+            self.assertIn(
+                response.status_code, [200, 201],
+                msg=f'Unexpected response status code {response.status_code} for worker {worker}'
+            )
+            self.check_stac_collection_asset(
+                asset_sample.json, response.json(), self.collection_sample['name'], ignore=['item']
+            )
+        self.assertEqual(status_201, 1, msg="Not only one upsert did a create !")
+
+
+class CollectionAssetsDeleteEndpointTestCase(StacBaseTestCase, S3TestMixin):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.asset = self.factory.create_collection_asset_sample(collection=self.collection).model
+        self.client = Client()
+        client_login(self.client)
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_asset_endpoint_delete_asset(self):
+        collection_name = self.collection.name
+        asset_name = self.asset.name
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        s3_path = get_collection_asset_path(self.collection, asset_name)
+        self.assertS3ObjectExists(s3_path)
+        response = self.client.delete(path)
+        self.assertStatusCode(200, response)
+
+        # Check that is has really been deleted
+        self.assertS3ObjectNotExists(s3_path)
+        response = self.client.get(path)
+        self.assertStatusCode(404, response)
+
+        # Check that it is really not to be found in DB
+        self.assertFalse(
+            CollectionAsset.objects.filter(name=self.asset.name).exists(),
+            msg="Deleted asset still found in DB"
+        )
+
+    def test_asset_endpoint_delete_asset_invalid_name(self):
+        collection_name = self.collection.name
+        path = f"/{STAC_BASE_V}/collections/{collection_name}/assets/non-existent-asset"
+        response = self.client.delete(path)
+        self.assertStatusCode(404, response)
+
+
+class CollectionAssetsEndpointUnauthorizedTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.asset = self.factory.create_collection_asset_sample(collection=self.collection).model
+        self.client = Client()
+
+    def test_unauthorized_asset_post_put_patch_delete(self):
+        collection_name = self.collection.name
+        asset_name = self.asset.name
+
+        new_asset = self.factory.create_collection_asset_sample(collection=self.collection).json
+        updated_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, name=asset_name, sample='asset-1-updated'
+        ).get_json('post')
+
+        # make sure POST fails for anonymous user:
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets'
+        response = self.client.post(path, data=new_asset, content_type="application/json")
+        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+
+        # make sure PUT fails for anonymous user:
+
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(path, data=updated_asset, content_type="application/json")
+        self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
+
+        # make sure PATCH fails for anonymous user:
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.patch(path, data=updated_asset, content_type="application/json")
+        self.assertStatusCode(401, response, msg="Unauthorized patch was permitted.")
+
+        # make sure DELETE fails for anonymous user:
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.delete(path)
+        self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")


### PR DESCRIPTION
Add collection asset endpoints for stac v1. Endpoint to _get list_, _get single,_ _create_, _update_ and _delete_ assets.

Basically duplicated the Asset Views and Serializers for Collection Assets and adapted. The main difference is that there is obviously no item for collection assets, as well as no external url allowed. They also do not have the fields `eo_gsd`, `geoadmin_lang`, `geoadmin_variant`.

The files for views and serializers are now each over 1000 lines of code. Is there a guideline how we might split this into smaller files?