### PR TITLE
PB-932: Avoid UTF-8 truncation in logging

### DIFF
--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -28,7 +28,7 @@ class RequestResponseLoggingMiddleware:
         ] and request.content_type == "application/json" and not request.path.startswith(
             '/api/stac/admin'
         ):
-            extra["request.payload"] = request.body[:200].decode()
+            extra["request.payload"] = request.body.decode()[:200]
 
         logger.debug(
             "Request %s %s?%s",


### PR DESCRIPTION
The request body is in utf-8 which needs either 1 byte or 2 bytes per character
depending on the character, so we need to decode first before truncating otherwise
we might truncate in the middle of a utf-8 character and it will break the decode.