### PR TITLE
PB-950 Switch to using ssm params - #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,11 +431,12 @@ With the following commands it is possible to get a proper state of the database
 ## Initial Setup up the RDS database and the user
 
 Right now the initial setup on the RDS database for the stagings *dev*, *int* and *prod* can be obtained
-with the helper script `scripts/setup_rds_db.sh`. The credentials come from `gopass`. To
-setup the RDS database on int, run following command:
+with the helper script `scripts/setup_rds_db.sh`. The credentials come from `ssm`. To
+setup the RDS database on int, run following command (the PROFILE variable denotes in what account the
+parameters are stored):
 
 ```bash
-    summon -p `which summon-gopass` -D APP_ENV=int scripts/setup_rds_db.sh
+    summon -p `ssm` -D APP_ENV=int -D PROFILE=swisstopo-bgdi-dev scripts/setup_rds_db.sh
 ```
 
 **Note:** The script won't delete the existing database.

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,9 +1,11 @@
-DB_HOST: !var infra-gopass-bgdi/service-stac/$APP_ENV/db/service_stac_admin_$APP_ENV host
-DB_NAME: !var infra-gopass-bgdi/service-stac/$APP_ENV/db/service_stac_admin_$APP_ENV name
-DB_PORT: !var infra-gopass-bgdi/service-stac/$APP_ENV/db/service_stac_admin_$APP_ENV port
-DB_USER: !var infra-gopass-bgdi/service-stac/$APP_ENV/db/service_stac_admin_$APP_ENV user
-DB_PW: !var infra-gopass-bgdi/service-stac/$APP_ENV/db/service_stac_admin_$APP_ENV password
-DB_SUPER_USER: !var infra-gopass-bgdi/rds/bgdi-$APP_ENV/postgres user
-DB_SUPER_PW: !var infra-gopass-bgdi/rds/bgdi-$APP_ENV/postgres password
-AWS_ACCESS_KEY_ID: !var infra-gopass-bgdi/service-stac/$APP_ENV/s3/service-stac-tech-$APP_ENV key
-AWS_SECRET_ACCESS_KEY: !var infra-gopass-bgdi/service-stac/$APP_ENV/s3/service-stac-tech-$APP_ENV secret
+DB_NAME: !var /amazon-rds/$APP_ENV/service-stac/db_name --profile $PROFILE
+DB_USER: !var /amazon-rds/$APP_ENV/service-stac/user --profile $PROFILE
+DB_PW: !var /amazon-rds/$APP_ENV/service-stac/password --profile $PROFILE
+
+AWS_ACCESS_KEY_ID: !var /service-stac/$APP_ENV/aws_access_key_id --profile $PROFILE
+AWS_SECRET_ACCESS_KEY: !var /service-stac/$APP_ENV/aws_secret_access_key --profile $PROFILE
+
+DB_HOST: !var /amazon-rds/$APP_ENV/host/domain --profile $PROFILE
+DB_PORT: !var /amazon-rds/$APP_ENV/host/port --profile $PROFILE
+DB_SUPER_USER: !var /amazon-rds/$APP_ENV/admin/user --profile $PROFILE
+DB_SUPER_PW: !var /amazon-rds/$APP_ENV/admin/password --profile $PROFILE


### PR DESCRIPTION
Use the params from the SSM store instead of gopass for instantiating the database.

(Since we already have the databases set up this is done rather for completeness sake than actual usage. We probably won't actually use these params in the near future. Also, the Database will be [managed by TF](https://jira.swisstopo.ch/browse/PB-986))

See https://github.com/geoadmin/infra-terraform-bgdi/pull/410 for more context.