### PR TITLE
PB-1009: trust API Gateway to authenticate users.

### DIFF
--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -65,3 +65,23 @@ MANAGED_BUCKET_COLLECTION_PATTERNS = env.list(
 AWS_SETTINGS['managed']['access_type'] = "key"
 AWS_SETTINGS['managed']['ACCESS_KEY_ID'] = env("LEGACY_AWS_ACCESS_KEY_ID")
 AWS_SETTINGS['managed']['SECRET_ACCESS_KEY'] = env("LEGACY_AWS_SECRET_ACCESS_KEY")
+
+# API Gateway integration PB-1009
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.RemoteUserBackend",
+    # We keep ModelBackend as fallback until we have moved all users to Cognito.
+    "django.contrib.auth.backends.ModelBackend",
+]
+MIDDLEWARE += [
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "middleware.apigw.ApiGatewayMiddleware",
+]
+# By default sessions expire after two weeks.
+# Sessions are only useful for user tracking in the admin UI. For security
+# reason we should expire these sessions as soon as possible. Given the use
+# case, it seems reasonable to log out users after 8h of inactivity or whenever
+# they restart their browser.
+SESSION_COOKIE_AGE = 60 * 60 * 8
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_COOKIE_SAMESITE = "Strict"
+SESSION_COOKIE_SECURE = True

--- a/app/middleware/apigw.py
+++ b/app/middleware/apigw.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
+
+
+class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
+    header = "HTTP_GEOADMIN_USERNAME"

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -336,6 +336,20 @@ class AdminTestCase(AdminBaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
+    def test_login_header(self):
+        response = self.client.get("/api/stac/admin/", headers={"Geoadmin-Username": self.username})
+        self.assertEqual(response.status_code, 200, msg="Admin page login with header failed")
+
+    def test_login_header_noheader(self):
+        response = self.client.get("/api/stac/admin/")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
+
+    def test_login_header_wronguser(self):
+        response = self.client.get("/api/stac/admin/", headers={"Geoadmin-Username": "wronguser"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
+
 
 #--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
We are delegating the authentication to API Gateway which sets the
`Geoadmin-Username` header. However due to how API Gateway and JWT-based
authentication work, the header is only set at login time. It is on the service
to keep track of the user afterwards.

This change updates service-stac in Dev to trust the `Geoadmin-Username` header
if it is present. Then service-stac persists the user across their whole session.

Relevant documentation is at https://docs.djangoproject.com/en/5.1/howto/auth-remote-user/