### PR TITLE
PB-1210: Set default file path for assets - #patch

### DIFF
--- a/app/stac_api/models.py
+++ b/app/stac_api/models.py
@@ -628,6 +628,19 @@ class AssetBase(models.Model):
     def __str__(self):
         return self.name
 
+    def get_asset_path(self):
+        # Method must be implemented by Asset and CollectionAsset separately.
+        raise NotImplementedError("get_asset_path() not implemented")
+
+    def save(self, *args, **kwargs):
+        # Default file value to the asset path.
+        #
+        # This is the behaviour when creating an asset via PUT API endpoint.
+        # But we need to set this here so it also applies in the admin UI.
+        if not bool(self.file):
+            self.file = self.get_asset_path()
+        super().save(*args, **kwargs)
+
     def delete(self, *args, **kwargs):  # pylint: disable=signature-differs
         try:
             super().delete(*args, **kwargs)

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -272,6 +272,9 @@ class AdminBaseTestCase(TestCase):
             Asset.objects.filter(item=item, name=data["name"]).exists(),
             msg="Admin page asset added not found in DB"
         )
+        asset = Asset.objects.get(item=item, name=data["name"])
+        # Assert that the filename is set to the value in name
+        self.assertEqual(asset.filename, data['name'])
 
         data = {
             "item": item.id,


### PR DESCRIPTION
When assets are created via admin GUI there is no file path set. If the file is then uploaded via API using the multipart upload, the file path will never be set on the asset.

This aligns the admin GUI behaviour with that of creating an asset via API PUT.