### PR TITLE
PB-1293 Add docs for endpoint bulkUpsertItems

### DIFF
--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -1798,6 +1798,121 @@ components:
       type: string
       format: date-time
       readOnly: true
+  parameters:
+    assetQuery:
+      description: >-
+        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
+      in: query
+      name: assetQuery
+      required: false
+      schema:
+        type: string
+    bbox:
+      explode: false
+      in: query
+      name: bbox
+      required: false
+      schema:
+        $ref: "#/components/schemas/bbox"
+      style: form
+    collectionId:
+      description: Local identifier of a collection
+      in: path
+      name: collectionId
+      required: true
+      schema:
+        type: string
+    collectionsArray:
+      explode: false
+      in: query
+      name: collections
+      required: false
+      schema:
+        $ref: "#/components/schemas/collectionsArray"
+    datetime:
+      explode: false
+      in: query
+      name: datetime
+      required: false
+      schema:
+        $ref: "#/components/schemas/datetimeQuery"
+      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
+      style: form
+    featureId:
+      description: Local identifier of a feature
+      in: path
+      name: featureId
+      required: true
+      schema:
+        type: string
+    assetObjectHref:
+      name: assetObjectHref
+      in: path
+      description: Full URL to asset object including protocol, host and path
+      required: true
+      schema:
+        type: string
+    ids:
+      description: >-
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
+      explode: false
+      in: query
+      name: ids
+      required: false
+      schema:
+        $ref: "#/components/schemas/ids"
+    limit:
+      explode: false
+      in: query
+      name: limit
+      required: false
+      schema:
+        $ref: "#/components/schemas/limit"
+      style: form
+    query:
+      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
+      in: query
+      name: query
+      required: false
+      schema:
+        type: string
+    IfNoneMatch:
+      name: If-None-Match
+      in: header
+      schema:
+        type: string
+      description: >-
+        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
+
+
+        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    IfMatch:
+      name: If-Match
+      in: header
+      schema:
+        type: string
+      description: >-
+        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
+
+
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    provider:
+      name: provider
+      in: query
+      description: Filter collections by the name of the provider. Supports partial and case-insensitive matching.
+      required: false
+      schema:
+        type: string
+  headers:
+    ETag:
+      schema:
+        type: string
+      description: >-
+        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+      required: true
   responses:
     Collection:
       headers:
@@ -2003,118 +2118,3 @@ components:
           example:
             code: 500
             description: "Internal server error"
-  parameters:
-    assetQuery:
-      description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
-      in: query
-      name: assetQuery
-      required: false
-      schema:
-        type: string
-    bbox:
-      explode: false
-      in: query
-      name: bbox
-      required: false
-      schema:
-        $ref: "#/components/schemas/bbox"
-      style: form
-    collectionId:
-      description: Local identifier of a collection
-      in: path
-      name: collectionId
-      required: true
-      schema:
-        type: string
-    collectionsArray:
-      explode: false
-      in: query
-      name: collections
-      required: false
-      schema:
-        $ref: "#/components/schemas/collectionsArray"
-    datetime:
-      explode: false
-      in: query
-      name: datetime
-      required: false
-      schema:
-        $ref: "#/components/schemas/datetimeQuery"
-      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
-      style: form
-    featureId:
-      description: Local identifier of a feature
-      in: path
-      name: featureId
-      required: true
-      schema:
-        type: string
-    assetObjectHref:
-      name: assetObjectHref
-      in: path
-      description: Full URL to asset object including protocol, host and path
-      required: true
-      schema:
-        type: string
-    ids:
-      description: >-
-        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
-      explode: false
-      in: query
-      name: ids
-      required: false
-      schema:
-        $ref: "#/components/schemas/ids"
-    limit:
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        $ref: "#/components/schemas/limit"
-      style: form
-    query:
-      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
-      in: query
-      name: query
-      required: false
-      schema:
-        type: string
-    IfNoneMatch:
-      name: If-None-Match
-      in: header
-      schema:
-        type: string
-      description: >-
-        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
-
-
-        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-    IfMatch:
-      name: If-Match
-      in: header
-      schema:
-        type: string
-      description: >-
-        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
-
-
-        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-    provider:
-      name: provider
-      in: query
-      description: Filter collections by the name of the provider. Supports partial and case-insensitive matching.
-      required: false
-      schema:
-        type: string
-  headers:
-    ETag:
-      schema:
-        type: string
-      description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-      required: true

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -3462,7 +3462,7 @@ components:
     collectionUpsertItems:
       type: object
       properties:
-        items:
+        features:
           type: array
           items:
             $ref: "#/components/schemas/item"

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -529,6 +529,43 @@ paths:
           $ref: "#/components/responses/PreconditionFailed"
         "500":
           $ref: "#/components/responses/ServerError"
+    post:
+      tags:
+        - Data Management
+      summary: Bulk update or create features
+      description: |
+        Create or update ("upsert") multiple features in a collection at once.
+        If a feature already exists, it is updated with the differences to the feature in the request.
+
+        Equivalently, one could create the features and their corresponding assets with individual API calls.
+        Uploading features that belong together in bulks has two advantages:
+
+           1. Less communication overhead than individual calls.
+           2. Less partial uploads to mess with: Either all features are uploaded or none.
+
+        A maximum of 100 features per call is allowed.
+      operationId: bulkUpsertItems
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/collectionUpsertItems"
+      responses:
+        "200":
+          description: Collection has been successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/collectionUpsertItems"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items:
     get:
       description: >-
@@ -3422,6 +3459,13 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
+    collectionUpsertItems:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/item"
     assetWrite:
       title: Asset
       description: The `property name` defines the ID of the Asset.
@@ -3997,6 +4041,164 @@ components:
         the collections "external asset whitelist".
       example: |
         http://bundesamt.admin.ch/ch.bundesamt.data/no_specific_structure.png
+  parameters:
+    assetQuery:
+      description: >-
+        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
+      in: query
+      name: assetQuery
+      required: false
+      schema:
+        type: string
+    bbox:
+      explode: false
+      in: query
+      name: bbox
+      required: false
+      schema:
+        $ref: "#/components/schemas/bbox"
+      style: form
+    collectionId:
+      description: Local identifier of a collection
+      in: path
+      name: collectionId
+      required: true
+      schema:
+        type: string
+    collectionsArray:
+      explode: false
+      in: query
+      name: collections
+      required: false
+      schema:
+        $ref: "#/components/schemas/collectionsArray"
+    datetime:
+      explode: false
+      in: query
+      name: datetime
+      required: false
+      schema:
+        $ref: "#/components/schemas/datetimeQuery"
+      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
+      style: form
+    featureId:
+      description: Local identifier of a feature
+      in: path
+      name: featureId
+      required: true
+      schema:
+        type: string
+    assetObjectHref:
+      name: assetObjectHref
+      in: path
+      description: Full URL to asset object including protocol, host and path
+      required: true
+      schema:
+        type: string
+    ids:
+      description: >-
+        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
+      explode: false
+      in: query
+      name: ids
+      required: false
+      schema:
+        $ref: "#/components/schemas/ids"
+    limit:
+      explode: false
+      in: query
+      name: limit
+      required: false
+      schema:
+        $ref: "#/components/schemas/limit"
+      style: form
+    query:
+      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
+      in: query
+      name: query
+      required: false
+      schema:
+        type: string
+    IfNoneMatch:
+      name: If-None-Match
+      in: header
+      schema:
+        type: string
+      description: >-
+        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
+
+
+        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    IfMatch:
+      name: If-Match
+      in: header
+      schema:
+        type: string
+      description: >-
+        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
+
+
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    provider:
+      name: provider
+      in: query
+      description: Filter collections by the name of the provider. Supports partial and case-insensitive matching.
+      required: false
+      schema:
+        type: string
+    assetId:
+      name: assetId
+      in: path
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
+    uploadId:
+      name: uploadId
+      in: path
+      description: Local identifier of an asset's upload.
+      required: true
+      schema:
+        type: string
+    presignedUrl:
+      name: presignedUrl
+      in: path
+      description: >-
+        Presigned url returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
+
+        Note: the url returned by the above endpoint is the full url including scheme, host and path
+      required: true
+      schema:
+        type: string
+    IfMatchWrite:
+      name: If-Match
+      in: header
+      schema:
+        type: string
+      description: >-
+        The RFC7232 `If-Match` header field makes the PUT/PATCH/DEL request method conditional. It is composed of a comma separated list of ETags or value "*".
+
+
+        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that he would overwrite another changes of the resource.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      schema:
+        type: string
+      description: >-
+        A unique ID for the operation. This allows making the operation idempotent, so more fault tolerant. See IETF draft [draft-ietf-httpapi-idempotency-key-header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/).
+      example: "8e03978e-40d5-43e8-bc93-6894a57f9324"
+  headers:
+    ETag:
+      schema:
+        type: string
+      description: >-
+        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
+      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+      required: true
   responses:
     Collection:
       headers:
@@ -4263,156 +4465,6 @@ components:
             required:
               - code
               - links
-  parameters:
-    assetQuery:
-      description: >-
-        Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
-      in: query
-      name: assetQuery
-      required: false
-      schema:
-        type: string
-    bbox:
-      explode: false
-      in: query
-      name: bbox
-      required: false
-      schema:
-        $ref: "#/components/schemas/bbox"
-      style: form
-    collectionId:
-      description: Local identifier of a collection
-      in: path
-      name: collectionId
-      required: true
-      schema:
-        type: string
-    collectionsArray:
-      explode: false
-      in: query
-      name: collections
-      required: false
-      schema:
-        $ref: "#/components/schemas/collectionsArray"
-    datetime:
-      explode: false
-      in: query
-      name: datetime
-      required: false
-      schema:
-        $ref: "#/components/schemas/datetimeQuery"
-      example: 2018-02-12T00%3A00%3A00Z%2F2018-03-18T12%3A31%3A12Z
-      style: form
-    featureId:
-      description: Local identifier of a feature
-      in: path
-      name: featureId
-      required: true
-      schema:
-        type: string
-    assetObjectHref:
-      name: assetObjectHref
-      in: path
-      description: Full URL to asset object including protocol, host and path
-      required: true
-      schema:
-        type: string
-    ids:
-      description: >-
-        Array of Item ids to return. All other filter parameters that further restrict the number of search results are ignored
-      explode: false
-      in: query
-      name: ids
-      required: false
-      schema:
-        $ref: "#/components/schemas/ids"
-    limit:
-      explode: false
-      in: query
-      name: limit
-      required: false
-      schema:
-        $ref: "#/components/schemas/limit"
-      style: form
-    query:
-      description: Query for properties in items. Use the JSON form of the queryFilter used in POST.
-      in: query
-      name: query
-      required: false
-      schema:
-        type: string
-    IfNoneMatch:
-      name: If-None-Match
-      in: header
-      schema:
-        type: string
-      description: >-
-        The RFC7232 `If-None-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
-
-
-        The server compares the client's ETags (sent with `If-None-Match`) with the ETag for its current version of the resource, and if both values match (that is, the resource has not changed), the server sends back a `304 Not Modified` status, without a body, which tells the client that the cached version of the response is still good to use (fresh).
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-    IfMatch:
-      name: If-Match
-      in: header
-      schema:
-        type: string
-      description: >-
-        The RFC7232 `If-Match` header field makes the GET request method conditional. It is composed of a comma separated list of ETags or value "*".
-
-
-        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that the cached version of the response is not good to use anymore.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-    provider:
-      name: provider
-      in: query
-      description: Filter collections by the name of the provider. Supports partial and case-insensitive matching.
-      required: false
-      schema:
-        type: string
-    assetId:
-      name: assetId
-      in: path
-      description: Local identifier of an asset.
-      required: true
-      schema:
-        type: string
-    uploadId:
-      name: uploadId
-      in: path
-      description: Local identifier of an asset's upload.
-      required: true
-      schema:
-        type: string
-    presignedUrl:
-      name: presignedUrl
-      in: path
-      description: >-
-        Presigned url returned by [Create a new Asset's multipart upload](#operation/createAssetUpload).
-
-        Note: the url returned by the above endpoint is the full url including scheme, host and path
-      required: true
-      schema:
-        type: string
-    IfMatchWrite:
-      name: If-Match
-      in: header
-      schema:
-        type: string
-      description: >-
-        The RFC7232 `If-Match` header field makes the PUT/PATCH/DEL request method conditional. It is composed of a comma separated list of ETags or value "*".
-
-
-        The server compares the client's ETags (sent with `If-Match`) with the ETag for its current version of the resource, and if both values don't match (that is, the resource has changed), the server sends back a `412 Precondition Failed` status, without a body, which tells the client that he would overwrite another changes of the resource.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-  headers:
-    ETag:
-      schema:
-        type: string
-      description: >-
-        The RFC7232 ETag header field in a response provides the current entity- tag for the selected resource. An entity-tag is an opaque identifier for different versions of a resource over time, regardless whether multiple versions are valid at the same time. An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
-      example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
-      required: true
   examples:
     inprogress:
       summary: In progress upload example

--- a/spec/transaction/components/parameters.yaml
+++ b/spec/transaction/components/parameters.yaml
@@ -41,3 +41,13 @@ components:
         the server sends back a `412 Precondition Failed` status, without a body, which tells the client that
         he would overwrite another changes of the resource.
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      schema:
+        type: string
+      description: >-
+        A unique ID for the operation.
+        This allows making the operation idempotent, so more fault tolerant.
+        See IETF draft [draft-ietf-httpapi-idempotency-key-header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/).
+      example: "8e03978e-40d5-43e8-bc93-6894a57f9324"

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -57,6 +57,13 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
+    collectionUpsertItems:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "../../components/schemas.yaml#/components/schemas/item"
     assetWrite:
       title: Asset
       description: The `property name` defines the ID of the Asset.

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -60,7 +60,7 @@ components:
     collectionUpsertItems:
       type: object
       properties:
-        items:
+        features:
           type: array
           items:
             $ref: "../../components/schemas.yaml#/components/schemas/item"

--- a/spec/transaction/paths.yaml
+++ b/spec/transaction/paths.yaml
@@ -107,6 +107,43 @@ paths:
           $ref: "../components/responses.yaml#/components/responses/PreconditionFailed"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
+    post:
+      tags:
+        - Data Management
+      summary: Bulk update or create features
+      description: |
+        Create or update ("upsert") multiple features in a collection at once.
+        If a feature already exists, it is updated with the differences to the feature in the request.
+
+        Equivalently, one could create the features and their corresponding assets with individual API calls.
+        Uploading features that belong together in bulks has two advantages:
+
+           1. Less communication overhead than individual calls.
+           2. Less partial uploads to mess with: Either all features are uploaded or none.
+
+        A maximum of 100 features per call is allowed.
+      operationId: bulkUpsertItems
+      parameters:
+        - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
+        - $ref: "./components/parameters.yaml#/components/parameters/IdempotencyKey"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./components/schemas.yaml#/components/schemas/collectionUpsertItems"
+      responses:
+        "200":
+          description: Collection has been successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "./components/schemas.yaml#/components/schemas/collectionUpsertItems"
+        "403":
+          $ref: "../components/responses.yaml#/components/responses/PermissionDenied"
+        "404":
+          $ref: "../components/responses.yaml#/components/responses/NotFound"
+        "500":
+          $ref: "../components/responses.yaml#/components/responses/ServerError"
   "/collections/{collectionId}/assets":
     get:
       description: >-


### PR DESCRIPTION
This adds a section for a new endpoint in the OpenAPI docs:
- endpoint: `POST collections/{collectionId}`
- docs on local web server: http://0.0.0.0:8090/apitransactional.html#tag/Data-Management/operation/bulkUpsertItems

Some notes:
1. The term "bulk" was used instead of "batch" after looking up the difference in [a blog post](https://www.codementor.io/blog/batch-endpoints-6olbjay1hd):
   > It should be noted that some people, such as [John Apostolidis](http://apostolidis.me/bulk-operations/), make a hard distinction between bulk processing (applying the same operation to multiple entries) and batch processing (applying potentially different operations to different entries). While it makes sense to have this distinction, in reality, the two ideas are often conflated and used interchangeably. "Batch" is often regarded as the more general term (processing batches of requests or batches of data), and "bulk" as a subset of batch (batching data, but not operations).
3. Like the other endpoints, the public text uses the term "features", not "items". Internally, we still call it "items" (e.g. `bulkUpsertItems`).
4. The non-success response codes (403, 404, 500) are copied from a similar endpoint. Not sure how explicitly every possible case that is ultimately covered by DRF has to be listed here. Also, not sure if 403 should already by there if there is no auth yet?
5. `Idempotency-Key`: We won't check for this in a first round but we agreed to already place it there. A link to [the IETF draft for the parameter](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) was added. Note that the draft is marked as "expired", so not sure if this is really the best source to cite. Or if this is really the right param ID to use?
6. The generated file `openapi.yaml` also has changes even though the files/parts it derives from have no changes. The changes are only reshuffling content, the displayed text should be the same. Possibly a missing update of the file in a different PR?

To explore the updated docs in your browser:
1. Build the specs:
   ```bash
   make build-specs
   ```
7. Run the web server:
    ```
    make serve-specs
   ```
8. Open the page in your web browser:
    http://0.0.0.0:8090/apitransactional.html#tag/Data-Management/operation/bulkUpsertItems

In a screenshot:
![pb-1293-openapi-bulkupsertitems-v1](https://github.com/user-attachments/assets/6c5464f9-be1d-4ee5-a9fa-507d99c713c0)

CC @benschs @schtibe 
