### PR TITLE
Remove csrf check for api gateway authentication

### DIFF
--- a/app/middleware/apigw.py
+++ b/app/middleware/apigw.py
@@ -12,10 +12,10 @@ class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
         whether it was able to authenticate the user. If it could not
         authenticate the user, the value of the header as seen on the wire is a
         single whitespace. An hexdump looks like this:
-    
+
             47 65 6f 61 64 6d 69 6e 5f 75 73 65 72 6e 61 6d 65 3a 20 0d 0a
             Geoadmin-Username:...
-    
+
         This doesn't seem possible to reproduce with curl. It is possible to
         reproduce with wget. It is unclear whether that technically counts as an
         empty value or a whitespace. It is also possible that AWS change their
@@ -29,4 +29,6 @@ class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
         apigw_auth = request.META.get("HTTP_GEOADMIN_AUTHENTICATED", "false").lower() == "true"
         if not apigw_auth and self.header in request.META:
             del request.META[self.header]
+        else:
+            setattr(request, '_dont_enforce_csrf_checks', True)
         return super().process_request(request)


### PR DESCRIPTION
Issue is that SessionAuthentication always checks csrf, if we don't use another authentication class. Before we were using the TokenAuthentication that had the Authoritation header set, so no csrf check was done. Now with the api gateway we remove the Authorization Header that would solve csrf, so django still tries to check for csrf tokens and fails.

Do you see issues if we always remove csrf check for users authenticated by apigateway? Otherwise we would need to find some other way to differentiate between "normal" users and "machine" users.