### PR TITLE
PB-1281: Add feature flag for ApiGateway authentication

### DIFF
--- a/app/config/settings_dev.py
+++ b/app/config/settings_dev.py
@@ -66,16 +66,6 @@ AWS_SETTINGS['managed']['access_type'] = "key"
 AWS_SETTINGS['managed']['ACCESS_KEY_ID'] = env("LEGACY_AWS_ACCESS_KEY_ID")
 AWS_SETTINGS['managed']['SECRET_ACCESS_KEY'] = env("LEGACY_AWS_SECRET_ACCESS_KEY")
 
-# API Gateway integration PB-1009
-AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.RemoteUserBackend",
-    # We keep ModelBackend as fallback until we have moved all users to Cognito.
-    "django.contrib.auth.backends.ModelBackend",
-]
-MIDDLEWARE += [
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "middleware.apigw.ApiGatewayMiddleware",
-]
 # By default sessions expire after two weeks.
 # Sessions are only useful for user tracking in the admin UI. For security
 # reason we should expire these sessions as soon as possible. Given the use

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -75,6 +75,9 @@ INSTALLED_APPS = [
     'stac_api.apps.StacApiConfig',
 ]
 
+# API Authentication options
+FEATURE_AUTH_ENABLE_APIGW = env('FEATURE_AUTH_ENABLE_APIGW', bool, default=False)
+
 # Middlewares are executed in order, once for the incoming
 # request top-down, once for the outgoing response bottom up
 # Note: The prometheus middlewares should always be first and
@@ -92,11 +95,18 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'middleware.apigw.ApiGatewayMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'middleware.cache_headers.CacheHeadersMiddleware',
     'middleware.exception.ExceptionLoggingMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
+]
+
+AUTHENTICATION_BACKENDS = [
+    "middleware.apigw.ApiGatewayUserBackend",
+    # We keep ModelBackend as fallback until we have moved all users to Cognito.
+    "django.contrib.auth.backends.ModelBackend",
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/app/middleware/apigw.py
+++ b/app/middleware/apigw.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
 
 
@@ -12,10 +14,10 @@ class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
         whether it was able to authenticate the user. If it could not
         authenticate the user, the value of the header as seen on the wire is a
         single whitespace. An hexdump looks like this:
-    
+
             47 65 6f 61 64 6d 69 6e 5f 75 73 65 72 6e 61 6d 65 3a 20 0d 0a
             Geoadmin-Username:...
-    
+
         This doesn't seem possible to reproduce with curl. It is possible to
         reproduce with wget. It is unclear whether that technically counts as an
         empty value or a whitespace. It is also possible that AWS change their
@@ -26,7 +28,25 @@ class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
 
         Based on discussion in https://code.djangoproject.com/ticket/35971
         """
+        if not settings.FEATURE_AUTH_ENABLE_APIGW:
+            return None
+
         apigw_auth = request.META.get("HTTP_GEOADMIN_AUTHENTICATED", "false").lower() == "true"
         if not apigw_auth and self.header in request.META:
             del request.META[self.header]
         return super().process_request(request)
+
+
+class ApiGatewayUserBackend(RemoteUserBackend):
+    """ This backend is to be used in conjunction with the ``ApiGatewayMiddleware`.
+
+    It is probably not needed to provide a custom remote user backend as our custom remote user
+    middleware will never call authenticate if the feature is not enabled. But better be safe than
+    sorry.
+    """
+
+    def authenticate(self, request, remote_user):
+        if not settings.FEATURE_AUTH_ENABLE_APIGW:
+            return None
+
+        return super().authenticate(request, remote_user)

--- a/app/tests/test_admin_page.py
+++ b/app/tests/test_admin_page.py
@@ -2,6 +2,7 @@ import logging
 from io import BytesIO
 
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from stac_api.models import Asset
@@ -47,6 +48,17 @@ class AdminTestCase(AdminBaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
+    def test_login_header_disabled(self):
+        response = self.client.get(
+            "/api/stac/admin/",
+            headers={
+                "Geoadmin-Username": self.username, "Geoadmin-Authenticated": "true"
+            }
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
+
+    @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
     def test_login_header(self):
         response = self.client.get(
             "/api/stac/admin/",
@@ -56,11 +68,13 @@ class AdminTestCase(AdminBaseTestCase):
         )
         self.assertEqual(response.status_code, 200, msg="Admin page login with header failed")
 
+    @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
     def test_login_header_noheader(self):
         response = self.client.get("/api/stac/admin/")
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
+    @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
     def test_login_header_wronguser(self):
         response = self.client.get(
             "/api/stac/admin/",
@@ -71,6 +85,7 @@ class AdminTestCase(AdminBaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
+    @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
     def test_login_header_not_authenticated(self):
         self.assertNotIn("sessionid", self.client.cookies)
         response = self.client.get(
@@ -82,6 +97,7 @@ class AdminTestCase(AdminBaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/api/stac/admin/login/?next=/api/stac/admin/", response.url)
 
+    @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
     def test_login_header_session(self):
         self.assertNotIn("sessionid", self.client.cookies)
 


### PR DESCRIPTION
Adds a flag `FEATURE_AUTH_ENABLE_APIGW` to the django settings to enable ApiGateway authentication. The flag is `false` by default (authentication is disabled) and can be set using an environment variable with the same name.

Details:
- I've moved the ApiGateway middleware and backend to `settings_prod`, as this is the base for all scenarios/builds. The middleware and new backend now check for the feature flag.
- `RemoteUserMiddleware` would add an authenticated user to the request if not already there (see [here](https://github.com/django/django/blob/4cad317ff1f9a79d54c1d5b12f1ccbd260ca009f/django/contrib/auth/middleware.py#L111)). Dropping out early in `ApiGatewayMiddleware` seems sufficient to disallow ApiGateway authentication if disabled.
- `RemoteUserMiddleware` uses `RemoteUserBackend` for the actual authentication. I've added a custom backend `ApiGatewayUserBackend` extending the `RemoteUserBackend`. Here, dropping out early makes sure remote users are never authenticated if the feature flag is disabled (see [here](https://github.com/django/django/blob/4cad317ff1f9a79d54c1d5b12f1ccbd260ca009f/django/contrib/auth/backends.py#L183)). I think this is actually not necessary as the autenticate method would never be called in this case but better safe than sorry.

> [!CAUTION]
> It seems like `RemoteUserMiddleware` has been changed in Django 5.2 and `process_request` is now `__call__()` (see 
[here](https://github.com/django/django/commit/50f89ae850f6b4e35819fe725a08c7e579bfd099#diff-0855f8c0e8b7fbb0ed4cd47469c9b75c9e8f3de04fd0415d92e05b7e682fbb1eR125)).