### PR TITLE
PB-1360 Improve internal upload workflow

### DIFF
--- a/app/stac_api/models/general.py
+++ b/app/stac_api/models/general.py
@@ -370,6 +370,13 @@ class AssetBase(models.Model):
         "-1 means that the data is not on a regular basis updated."
     )
 
+    # Depending on the value here we can determine some state of the asset:
+    # * None: The asset was created but the file doesn't actually exist on
+    #         the referenced bucket. This was determined in a one-off check run in
+    #         2025, see PB-1091
+    # * 0:    The asset was created, but the file has not yet been uploaded
+    # * -1:   This is an external asset, thus we write -1 as we can't yet determine
+    #         the file size of external assets
     file_size = models.BigIntegerField(default=0, null=True, blank=True)
 
     def __str__(self):

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -218,6 +218,8 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         Returns: tuple
             Asset instance and True if created otherwise false
         """
+        data = validated_data
+        data['file_size'] = -1 if validated_data['is_external'] else 0
         asset, created = Asset.objects.update_or_create(**look_up, defaults=validated_data)
         return asset, created
 

--- a/app/tests/tests_10/test_external_assets_endpoint.py
+++ b/app/tests/tests_10/test_external_assets_endpoint.py
@@ -61,6 +61,7 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         created_asset = Asset.objects.last()
         self.assertEqual(created_asset.file, asset_data['href'])
         self.assertTrue(created_asset.is_external)
+        self.assertTrue(created_asset.file_size, -1)
 
     @responses.activate
     def test_create_asset_validate_external_url(self):
@@ -104,6 +105,7 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         created_asset = Asset.objects.last()
         self.assertEqual(created_asset.file, asset_data['href'])
         self.assertTrue(created_asset.is_external)
+        self.assertTrue(created_asset.file_size, -1)
 
     @responses.activate
     def test_create_asset_validate_external_url_not_found(self):
@@ -217,6 +219,7 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         updated_asset = Asset.objects.last()
         self.assertEqual(updated_asset.file, asset_data['href'])
         self.assertTrue(updated_asset.is_external)
+        self.assertTrue(updated_asset.file_size, -1)
 
     def test_get_asset_with_external_url(self):
         collection = self.collection


### PR DESCRIPTION
Providing the means to filter out assets that are 

a) in progress, where the asset is created but the upload isn't done yet

b) that weren't found on the s3 bucket while updating the `file_size` in the cronjob (see https://github.com/geoadmin/service-stac/pull/484 and https://github.com/geoadmin/service-stac/pull/464/files for reference)

This filter will start making sense after the file_size update cronjob ran through (should be the case by the end of the week). After that, every file that has a `file_size` of 0 will signify that it isn't uploaded yet. 

Slightly adjusting the process for external assets: we set the file size to -1 as we currently can't determine the real size. Could maybe be done by refactoring the check asset call out of the validator, in order to parse the [content-range header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range) and save the info to `file_size`.