### PR TITLE
PB-1281: Disable old authentication for STAC v1

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
 
 # API Authentication options
 FEATURE_AUTH_ENABLE_APIGW = env('FEATURE_AUTH_ENABLE_APIGW', bool, default=False)
+FEATURE_AUTH_RESTRICT_V1 = env('FEATURE_AUTH_RESTRICT_V1', bool, default=False)
 
 # Middlewares are executed in order, once for the incoming
 # request top-down, once for the outgoing response bottom up
@@ -306,9 +307,9 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'middleware.api_gateway_authentication.ApiGatewayAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
+        'middleware.rest_framework_authentication.RestrictedBasicAuthentication',
+        'middleware.rest_framework_authentication.RestrictedTokenAuthentication',
+        'middleware.rest_framework_authentication.RestrictedSessionAuthentication',
     ],
     'DEFAULT_PAGINATION_CLASS': 'stac_api.pagination.CursorPagination',
     'PAGE_SIZE': env.int('PAGE_SIZE', default=100),

--- a/app/middleware/rest_framework_authentication.py
+++ b/app/middleware/rest_framework_authentication.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+
+from rest_framework.authentication import BasicAuthentication
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.authentication import TokenAuthentication
+
+
+class RestrictedBasicAuthentication(BasicAuthentication):
+    """ A Django rest framework basic authentication class that skips v1 of STAC API. """
+
+    def authenticate(self, request):
+        if settings.FEATURE_AUTH_RESTRICT_V1 and request.path.startswith(
+            f'/{settings.STAC_BASE}/v1/'
+        ):
+            return None
+
+        return super().authenticate(request)
+
+
+class RestrictedSessionAuthentication(SessionAuthentication):
+    """ A Django rest framework session authentication class that skips v1 of STAC API. """
+
+    def authenticate(self, request):
+        if settings.FEATURE_AUTH_RESTRICT_V1 and request.path.startswith(
+            f'/{settings.STAC_BASE}/v1/'
+        ):
+            return None
+
+        return super().authenticate(request)
+
+
+class RestrictedTokenAuthentication(TokenAuthentication):
+    """ A Django rest framework token authentication class that skips v1 of STAC API. """
+
+    def authenticate(self, request):
+        if settings.FEATURE_AUTH_RESTRICT_V1 and request.path.startswith(
+            f'/{settings.STAC_BASE}/v1/'
+        ):
+            return None
+
+        return super().authenticate(request)

--- a/app/tests/tests_10/test_asset_upload_endpoint.py
+++ b/app/tests/tests_10/test_asset_upload_endpoint.py
@@ -1315,9 +1315,9 @@ class ExternalAssetUploadtestCase(AssetUploadBaseTest):
         self.assertStatusCode(400, response)
 
 
-@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
 class AssetUploadDisabledAuthenticationEndpointTestCase(AssetUploadBaseTest):
 
+    @mock_s3_asset_file
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
         self.factory = Factory()
@@ -1327,17 +1327,17 @@ class AssetUploadDisabledAuthenticationEndpointTestCase(AssetUploadBaseTest):
         self.maxDiff = None  # pylint: disable=invalid-name
         self.username = 'SherlockHolmes'
         self.password = '221B_BakerStreet'
-        self.user = get_user_model().objects.create_user(
+        self.user = get_user_model().objects.create_superuser(
             self.username, 'top@secret.co.uk', self.password
         )
 
-    def run_test(self, headers=None):
+    def run_test(self, status, headers=None):
         number_parts = 2
         file_like, checksum_multihash = get_file_like_object(1 * KB)
         offset = 1 * KB // number_parts
         md5_parts = create_md5_parts(number_parts, offset, file_like)
 
-        # Make sure POST fails if old authentication is disabled
+        # POST
         response = self.client.post(
             self.get_create_multipart_upload_path(),
             headers=headers,
@@ -1348,36 +1348,47 @@ class AssetUploadDisabledAuthenticationEndpointTestCase(AssetUploadBaseTest):
             },
             content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
-        # Make sure POST abort fails if old authentication is disabled
+        # POST abort
         response = self.client.post(
-            self.get_abort_multipart_upload_path('upload_id'),
+            self.get_abort_multipart_upload_path(response.json().get('upload_id')),
             headers=headers,
             data={},
             content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
-        # Make sure POST complete fails if old authentication is disabled
-        response = self.client.post(
-            self.get_complete_multipart_upload_path('upload_id'),
-            headers=headers,
-            data={'parts': 'parts'},
-            content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test([200, 201])
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test([200, 201], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test([200, 201], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_session_authentication(self):
         self.client.login(username=self.username, password=self.password)
-        self.run_test()
+        self.run_test(401)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_token_authentication(self):
         token = Token.objects.create(user=self.user)
         headers = {'Authorization': f'Token {token.key}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_base_authentication(self):
         token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
         headers = {'Authorization': f'Basic {token}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)

--- a/app/tests/tests_10/test_assets_endpoint.py
+++ b/app/tests/tests_10/test_assets_endpoint.py
@@ -923,7 +923,6 @@ class AssetsEndpointUnauthorizedTestCase(StacBaseTestCase):
         self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
 
 
-@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
 class AssetsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -935,54 +934,60 @@ class AssetsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
         self.client = Client()
         self.username = 'SherlockHolmes'
         self.password = '221B_BakerStreet'
-        self.user = get_user_model().objects.create_user(
+        self.user = get_user_model().objects.create_superuser(
             self.username, 'top@secret.co.uk', self.password
         )
 
-    def run_test(self, headers=None):
+    def run_test(self, status, headers=None):
         collection_name = self.collection.name
         item_name = self.item.name
         asset_name = self.asset.name
-
-        new_asset = self.factory.create_asset_sample(item=self.item).json
-        updated_asset = self.factory.create_asset_sample(
-            item=self.item, name=asset_name, sample='asset-1-updated'
-        ).get_json('post')
-
-        # Make sure POST fails if old authentication is disabled
-        path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets'
-        response = self.client.post(
-            path, headers=headers, data=new_asset, content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
-
-        # Make sure PUT fails if old authentication is disabled
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.put(
-            path, headers=headers, data=updated_asset, content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
 
-        # Make sure PATCH fails if old authentication is disabled
+        # PUT
+        response = self.client.put(path, headers=headers, data={}, content_type="application/json")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
+
+        # PATCH
         response = self.client.patch(
-            path, headers=headers, data=updated_asset, content_type="application/json"
+            path, headers=headers, data={}, content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized patch was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
-        # Make sure DELETE fails if old authentication is disabled
+        # DELETE
         response = self.client.delete(path, headers=headers)
-        self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test([200, 400])
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test([200, 400], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test([200, 400], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_session_authentication(self):
         self.client.login(username=self.username, password=self.password)
-        self.run_test()
+        self.run_test(401)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_token_authentication(self):
         token = Token.objects.create(user=self.user)
         headers = {'Authorization': f'Token {token.key}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_base_authentication(self):
         token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
         headers = {'Authorization': f'Basic {token}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)

--- a/app/tests/tests_10/test_collection_asset_upload_endpoint.py
+++ b/app/tests/tests_10/test_collection_asset_upload_endpoint.py
@@ -1291,9 +1291,9 @@ class CollectionAssetUploadListPartsEndpointTestCase(CollectionAssetUploadBaseTe
         self.assertEqual(size, self.asset.file_size)
 
 
-@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
 class CollectionAssetUploadDisabledAuthenticationEndpointTestCase(CollectionAssetUploadBaseTest):
 
+    @mock_s3_asset_file
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
         self.factory = Factory()
@@ -1304,17 +1304,17 @@ class CollectionAssetUploadDisabledAuthenticationEndpointTestCase(CollectionAsse
         self.maxDiff = None  # pylint: disable=invalid-name
         self.username = 'SherlockHolmes'
         self.password = '221B_BakerStreet'
-        self.user = get_user_model().objects.create_user(
+        self.user = get_user_model().objects.create_superuser(
             self.username, 'top@secret.co.uk', self.password
         )
 
-    def run_test(self, headers=None):
+    def run_test(self, status, headers=None):
         number_parts = 2
         file_like, checksum_multihash = get_file_like_object(1 * KB)
         offset = 1 * KB // number_parts
         md5_parts = create_md5_parts(number_parts, offset, file_like)
 
-        # Make sure POST fails if old authentication is disabled
+        # POST
         response = self.client.post(
             self.get_create_multipart_upload_path(),
             headers=headers,
@@ -1325,36 +1325,47 @@ class CollectionAssetUploadDisabledAuthenticationEndpointTestCase(CollectionAsse
             },
             content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
-        # Make sure POST abort fails if old authentication is disabled
+        # POST abort
         response = self.client.post(
-            self.get_abort_multipart_upload_path('upload_id'),
+            self.get_abort_multipart_upload_path(response.json().get('upload_id')),
             headers=headers,
             data={},
             content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+        self.assertStatusCode(status, response, msg="Unexpected status.")
 
-        # Make sure POST complete fails if old authentication is disabled
-        response = self.client.post(
-            self.get_complete_multipart_upload_path('upload_id'),
-            headers=headers,
-            data={'parts': 'parts'},
-            content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test([200, 201])
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test([200, 201], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test([200, 201], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_session_authentication(self):
         self.client.login(username=self.username, password=self.password)
-        self.run_test()
+        self.run_test(401)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_token_authentication(self):
         token = Token.objects.create(user=self.user)
         headers = {'Authorization': f'Token {token.key}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_base_authentication(self):
         token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
         headers = {'Authorization': f'Basic {token}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)

--- a/app/tests/tests_10/test_collection_asset_upload_endpoint.py
+++ b/app/tests/tests_10/test_collection_asset_upload_endpoint.py
@@ -9,6 +9,9 @@ from urllib import parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client
+from django.test import override_settings
+
+from rest_framework.authtoken.models import Token
 
 from stac_api.models.collection import CollectionAsset
 from stac_api.models.collection import CollectionAssetUpload
@@ -1286,3 +1289,72 @@ class CollectionAssetUploadListPartsEndpointTestCase(CollectionAssetUploadBaseTe
         self.assertS3ObjectExists(key)
         self.asset.refresh_from_db()
         self.assertEqual(size, self.asset.file_size)
+
+
+@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
+class CollectionAssetUploadDisabledAuthenticationEndpointTestCase(CollectionAssetUploadBaseTest):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, sample='asset-no-file'
+        ).model
+        self.maxDiff = None  # pylint: disable=invalid-name
+        self.username = 'SherlockHolmes'
+        self.password = '221B_BakerStreet'
+        self.user = get_user_model().objects.create_user(
+            self.username, 'top@secret.co.uk', self.password
+        )
+
+    def run_test(self, headers=None):
+        number_parts = 2
+        file_like, checksum_multihash = get_file_like_object(1 * KB)
+        offset = 1 * KB // number_parts
+        md5_parts = create_md5_parts(number_parts, offset, file_like)
+
+        # Make sure POST fails if old authentication is disabled
+        response = self.client.post(
+            self.get_create_multipart_upload_path(),
+            headers=headers,
+            data={
+                'number_parts': number_parts,
+                'file:checksum': checksum_multihash,
+                'md5_parts': md5_parts
+            },
+            content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+
+        # Make sure POST abort fails if old authentication is disabled
+        response = self.client.post(
+            self.get_abort_multipart_upload_path('upload_id'),
+            headers=headers,
+            data={},
+            content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+
+        # Make sure POST complete fails if old authentication is disabled
+        response = self.client.post(
+            self.get_complete_multipart_upload_path('upload_id'),
+            headers=headers,
+            data={'parts': 'parts'},
+            content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+
+    def test_disabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test()
+
+    def test_disabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test(headers=headers)
+
+    def test_disabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test(headers=headers)

--- a/app/tests/tests_10/test_collection_assets_endpoint.py
+++ b/app/tests/tests_10/test_collection_assets_endpoint.py
@@ -714,26 +714,25 @@ class CollectionAssetsEndpointUnauthorizedTestCase(StacBaseTestCase):
         # make sure POST fails for anonymous user:
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets'
         response = self.client.post(path, data=new_asset, content_type="application/json")
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+        self.assertStatusCode(401, response, msg="Unexpected status.")
 
         # make sure PUT fails for anonymous user:
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
         response = self.client.put(path, data=updated_asset, content_type="application/json")
-        self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
+        self.assertStatusCode(401, response, msg="Unexpected status.")
 
         # make sure PATCH fails for anonymous user:
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
         response = self.client.patch(path, data=updated_asset, content_type="application/json")
-        self.assertStatusCode(401, response, msg="Unauthorized patch was permitted.")
+        self.assertStatusCode(401, response, msg="Unexpected status.")
 
         # make sure DELETE fails for anonymous user:
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
         response = self.client.delete(path)
-        self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
+        self.assertStatusCode(401, response, msg="Unexpected status.")
 
 
-@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
 class CollectionAssetsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -744,53 +743,59 @@ class CollectionAssetsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
         self.client = Client()
         self.username = 'SherlockHolmes'
         self.password = '221B_BakerStreet'
-        self.user = get_user_model().objects.create_user(
+        self.user = get_user_model().objects.create_superuser(
             self.username, 'top@secret.co.uk', self.password
         )
 
-    def run_test(self, headers=None):
+    def run_test(self, status, headers=None):
         collection_name = self.collection.name
         asset_name = self.asset.name
 
-        new_asset = self.factory.create_collection_asset_sample(collection=self.collection).json
-        updated_asset = self.factory.create_collection_asset_sample(
-            collection=self.collection, name=asset_name, sample='asset-1-updated'
-        ).get_json('post')
-
-        # make sure POST fails if old authentication is disabled
-        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets'
-        response = self.client.post(
-            path, headers=headers, data=new_asset, content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
-
-        # make sure PUT fails if old authentication is disabled
+        # PUT
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
-        response = self.client.put(
-            path, headers=headers, data=updated_asset, content_type="application/json"
-        )
-        self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
+        response = self.client.put(path, headers=headers, data={}, content_type="application/json")
+        self.assertStatusCode(status, response, msg="Unauthorized put was permitted.")
 
-        # make sure PATCH fails if old authentication is disabled
+        # PATCH
         response = self.client.patch(
-            path, headers=headers, data=updated_asset, content_type="application/json"
+            path, headers=headers, data={}, content_type="application/json"
         )
-        self.assertStatusCode(401, response, msg="Unauthorized patch was permitted.")
+        self.assertStatusCode(status, response, msg="Unauthorized patch was permitted.")
 
-        # make sure DELETE fails if old authentication is disabled
+        # DELETE
         response = self.client.delete(path, headers=headers)
-        self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
+        self.assertStatusCode(status, response, msg="Unauthorized del was permitted.")
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test([200, 400])
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test([200, 400], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=False)
+    def test_enabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test([200, 400], headers=headers)
+
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_session_authentication(self):
         self.client.login(username=self.username, password=self.password)
-        self.run_test()
+        self.run_test(401)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_token_authentication(self):
         token = Token.objects.create(user=self.user)
         headers = {'Authorization': f'Token {token.key}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)
 
+    @override_settings(FEATURE_AUTH_RESTRICT_V1=True)
     def test_disabled_base_authentication(self):
         token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
         headers = {'Authorization': f'Basic {token}'}
-        self.run_test(headers=headers)
+        self.run_test(401, headers=headers)

--- a/app/tests/tests_10/test_collection_assets_endpoint.py
+++ b/app/tests/tests_10/test_collection_assets_endpoint.py
@@ -1,4 +1,5 @@
 import logging
+from base64 import b64encode
 from datetime import datetime
 from json import dumps
 from json import loads
@@ -6,7 +7,10 @@ from pprint import pformat
 
 from django.contrib.auth import get_user_model
 from django.test import Client
+from django.test import override_settings
 from django.urls import reverse
+
+from rest_framework.authtoken.models import Token
 
 from stac_api.models.collection import CollectionAsset
 from stac_api.utils import get_collection_asset_path
@@ -727,3 +731,66 @@ class CollectionAssetsEndpointUnauthorizedTestCase(StacBaseTestCase):
         path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
         response = self.client.delete(path)
         self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
+
+
+@override_settings(FEATURE_AUTH_RESTRICT_V1=True)
+class CollectionAssetsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
+
+    @mock_s3_asset_file
+    def setUp(self):  # pylint: disable=invalid-name
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.asset = self.factory.create_collection_asset_sample(collection=self.collection).model
+        self.client = Client()
+        self.username = 'SherlockHolmes'
+        self.password = '221B_BakerStreet'
+        self.user = get_user_model().objects.create_user(
+            self.username, 'top@secret.co.uk', self.password
+        )
+
+    def run_test(self, headers=None):
+        collection_name = self.collection.name
+        asset_name = self.asset.name
+
+        new_asset = self.factory.create_collection_asset_sample(collection=self.collection).json
+        updated_asset = self.factory.create_collection_asset_sample(
+            collection=self.collection, name=asset_name, sample='asset-1-updated'
+        ).get_json('post')
+
+        # make sure POST fails if old authentication is disabled
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets'
+        response = self.client.post(
+            path, headers=headers, data=new_asset, content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized post was permitted.")
+
+        # make sure PUT fails if old authentication is disabled
+        path = f'/{STAC_BASE_V}/collections/{collection_name}/assets/{asset_name}'
+        response = self.client.put(
+            path, headers=headers, data=updated_asset, content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized put was permitted.")
+
+        # make sure PATCH fails if old authentication is disabled
+        response = self.client.patch(
+            path, headers=headers, data=updated_asset, content_type="application/json"
+        )
+        self.assertStatusCode(401, response, msg="Unauthorized patch was permitted.")
+
+        # make sure DELETE fails if old authentication is disabled
+        response = self.client.delete(path, headers=headers)
+        self.assertStatusCode(401, response, msg="Unauthorized del was permitted.")
+
+    def test_disabled_session_authentication(self):
+        self.client.login(username=self.username, password=self.password)
+        self.run_test()
+
+    def test_disabled_token_authentication(self):
+        token = Token.objects.create(user=self.user)
+        headers = {'Authorization': f'Token {token.key}'}
+        self.run_test(headers=headers)
+
+    def test_disabled_base_authentication(self):
+        token = b64encode(f'{self.username}:{self.password}'.encode()).decode()
+        headers = {'Authorization': f'Basic {token}'}
+        self.run_test(headers=headers)


### PR DESCRIPTION
Disables Basic / Token / Session Auth for STAC v1 if `FEATURE_AUTH_RESTRICT_V1` is set.

Together with `FEATURE_AUTH_ENABLE_APIGW` authentication is as followed:

| Authentication | STAC v0.9                       | STAC v1.0                       |
| ---------- | ------------------------- | ------------------------- |
| Basic      | yes                       | FEATURE_AUTH_RESTRICT_V1  |
| Token      | yes                       | FEATURE_AUTH_RESTRICT_V1  |
| Session    | yes                       | FEATURE_AUTH_RESTRICT_V1  |
| ApiGateway | FEATURE_AUTH_ENABLE_APIGW | FEATURE_AUTH_ENABLE_APIGW |

