### PR TITLE
PB-1406: Make cognito authenticated users superuser

### DIFF
--- a/app/middleware/api_gateway_middleware.py
+++ b/app/middleware/api_gateway_middleware.py
@@ -29,4 +29,8 @@ class ApiGatewayUserBackend(RemoteUserBackend):
         if not settings.FEATURE_AUTH_ENABLE_APIGW:
             return None
 
-        return super().authenticate(request, remote_user)
+        user = super().authenticate(request, remote_user)
+        if user:
+            user.is_superuser = True
+            user.save()
+        return user

--- a/app/tests/tests_09/test_geoadmin_header_auth.py
+++ b/app/tests/tests_09/test_geoadmin_header_auth.py
@@ -2,7 +2,6 @@ import logging
 
 from parameterized import parameterized
 
-from django.contrib.auth import get_user_model
 from django.test import Client
 from django.test import override_settings
 
@@ -15,19 +14,19 @@ logger = logging.getLogger(__name__)
 
 @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class GeoadminHeadersAuthForPutEndpointTestCase(StacBaseTestCase):
-    valid_username = "another_test_user"
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client(enforce_csrf_checks=True)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample()
-        get_user_model().objects.create_superuser(self.valid_username)
 
     @parameterized.expand([
-        (valid_username, "true", 201),
+        ("another_test_user", "true", 201),
+        ("another_test_user", "false", 401),
+        ("another_test_user", "", 401),
         (None, None, 401),
-        (valid_username, "false", 401),
-        ("wronguser", "true", 403),
+        (None, "false", 401),
+        (None, "true", 401),
     ])
     def test_collection_upsert_create_with_geoadmin_header_auth(
         self, username_header, authenticated_header, expected_response_code

--- a/app/tests/tests_10/test_asset_upload_endpoint.py
+++ b/app/tests/tests_10/test_asset_upload_endpoint.py
@@ -26,7 +26,6 @@ from tests.tests_10.base_test import StacBaseTransactionTestCase
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.utils import reverse_version
 from tests.utils import S3TestMixin
-from tests.utils import client_login
 from tests.utils import get_file_like_object
 from tests.utils import mock_s3_asset_file
 
@@ -52,7 +51,6 @@ class AssetUploadBaseTest(StacBaseTestCase, S3TestMixin):
     @mock_s3_asset_file
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(collection=self.collection).model
@@ -182,6 +180,7 @@ class AssetUploadBaseTest(StacBaseTestCase, S3TestMixin):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
 
     def test_asset_upload_create_abort_multipart(self):
@@ -193,6 +192,9 @@ class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -208,6 +210,9 @@ class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_abort_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={},
             content_type="application/json"
         )
@@ -238,6 +243,9 @@ class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -253,6 +261,9 @@ class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -288,6 +299,7 @@ class AssetUploadCreateEndpointTestCase(AssetUploadBaseTest):
         self.assertEqual(len(response['Uploads']), 1, msg='More or less uploads found on S3')
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, S3TestMixin):
 
     @mock_s3_asset_file
@@ -320,6 +332,9 @@ class AssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, S3TestMixi
             client.login(username=self.username, password=self.password)
             return client.post(
                 path,
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data={
                     'number_parts': number_parts,
                     'file:checksum': checksum_multihash,
@@ -342,6 +357,7 @@ class AssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, S3TestMixi
             self.assertEqual(response.json()['description'], "Upload already in progress")
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
 
     def upload_asset_with_dyn_cache(self, update_interval=None):
@@ -353,6 +369,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -371,6 +390,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -387,6 +409,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -404,6 +429,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -437,6 +465,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -454,6 +485,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -476,6 +510,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like_compress)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -496,6 +533,9 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         )
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -508,6 +548,7 @@ class AssetUpload1PartEndpointTestCase(AssetUploadBaseTest):
         self.assertEqual(size_compress, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUpload2PartEndpointTestCase(AssetUploadBaseTest):
 
     def test_asset_upload_2_parts_md5_integrity(self):
@@ -522,6 +563,9 @@ class AssetUpload2PartEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -538,6 +582,9 @@ class AssetUpload2PartEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -548,6 +595,7 @@ class AssetUpload2PartEndpointTestCase(AssetUploadBaseTest):
         self.assertEqual(size, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
     def test_asset_upload_invalid_content_encoding(self):
@@ -561,6 +609,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -584,6 +635,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
         file_like, checksum_multihash = get_file_like_object(size)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts, 'file:checksum': checksum_multihash
             },
@@ -601,6 +655,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts, 'file:checksum': checksum_multihash
             },
@@ -611,7 +668,12 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
     def test_asset_upload_create_empty_payload(self):
         response = self.client.post(
-            self.get_create_multipart_upload_path(), data={}, content_type="application/json"
+            self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data={},
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual(
@@ -627,6 +689,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 0,
                 "file:checksum": 'abcdef',
@@ -652,6 +717,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 101, "file:checksum": 'abcdef', 'md5_parts': md5_parts
             },
@@ -670,6 +738,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [],
@@ -693,6 +764,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 3,
                 "md5_parts": [{
@@ -722,6 +796,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [{
@@ -751,6 +828,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [
@@ -782,6 +862,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -797,6 +880,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -823,6 +909,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -838,6 +927,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': [{
                 'etag': 'dummy', 'part_number': 1
             }]},
@@ -868,6 +960,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -884,6 +979,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -902,6 +1000,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -916,6 +1017,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size // 2, 1)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -935,6 +1039,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -950,6 +1057,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={},
             content_type="application/json"
         )
@@ -958,6 +1068,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': []},
             content_type="application/json"
         )
@@ -966,6 +1079,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': ["dummy-etag"]},
             content_type="application/json"
         )
@@ -997,6 +1113,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1012,6 +1131,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -1019,6 +1141,9 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -1029,6 +1154,7 @@ class AssetUploadInvalidEndpointTestCase(AssetUploadBaseTest):
         self.assertEqual(size, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUploadDeleteInProgressEndpointTestCase(AssetUploadBaseTest):
 
     def test_delete_asset_upload_in_progress(self):
@@ -1040,6 +1166,9 @@ class AssetUploadDeleteInProgressEndpointTestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1050,7 +1179,12 @@ class AssetUploadDeleteInProgressEndpointTestCase(AssetUploadBaseTest):
         self.assertStatusCode(201, response)
         upload_id = response.json()['upload_id']
 
-        response = self.client.delete(self.get_delete_asset_path())
+        response = self.client.delete(
+            self.get_delete_asset_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(400, response)
         self.assertEqual(
             response.json()['description'], ['Asset asset-1.tiff has still an upload in progress']
@@ -1065,10 +1199,20 @@ class AssetUploadDeleteInProgressEndpointTestCase(AssetUploadBaseTest):
             msg='Asset has been deleted'
         )
 
-        response = self.client.post(self.get_abort_multipart_upload_path(upload_id))
+        response = self.client.post(
+            self.get_abort_multipart_upload_path(upload_id),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
-        response = self.client.delete(self.get_delete_asset_path())
+        response = self.client.delete(
+            self.get_delete_asset_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
         self.assertFalse(
@@ -1212,6 +1356,7 @@ class GetAssetUploadsEndpointTestCase(AssetUploadBaseTest):
             self.assertEqual(upload['status'], AssetUpload.Status.ABORTED)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetUploadListPartsEndpointTestCase(AssetUploadBaseTest):
 
     def test_asset_upload_list_parts(self):
@@ -1224,6 +1369,9 @@ class AssetUploadListPartsEndpointTestCase(AssetUploadBaseTest):
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1278,6 +1426,9 @@ class AssetUploadListPartsEndpointTestCase(AssetUploadBaseTest):
         # Complete the upload
         response = self.client.post(
             self.get_complete_multipart_upload_path(upload_id),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -1287,6 +1438,7 @@ class AssetUploadListPartsEndpointTestCase(AssetUploadBaseTest):
         self.assertEqual(size, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ExternalAssetUploadtestCase(AssetUploadBaseTest):
 
     def test_create_multipart_upload_on_external_asset(self):
@@ -1304,6 +1456,9 @@ class ExternalAssetUploadtestCase(AssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,

--- a/app/tests/tests_10/test_assets_endpoint.py
+++ b/app/tests/tests_10/test_assets_endpoint.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import logging
 from base64 import b64encode
 from datetime import datetime
@@ -24,7 +25,6 @@ from tests.tests_10.base_test import StacBaseTransactionTestCase
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.utils import reverse_version
 from tests.utils import S3TestMixin
-from tests.utils import client_login
 from tests.utils import disableLogger
 from tests.utils import mock_s3_asset_file
 
@@ -139,6 +139,7 @@ class AssetsEndpointTestCase(StacBaseTestCase):
         self.assertStatusCode(404, response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsUnimplementedEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -147,7 +148,6 @@ class AssetsUnimplementedEndpointTestCase(StacBaseTestCase):
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(collection=self.collection).model
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_unimplemented_post(self):
@@ -156,12 +156,16 @@ class AssetsUnimplementedEndpointTestCase(StacBaseTestCase):
         asset = self.factory.create_asset_sample(item=self.item, required_only=True)
         response = self.client.post(
             f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets',
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset.get_json('post'),
             content_type="application/json"
         )
         self.assertStatusCode(405, response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsCreateEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -170,7 +174,6 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(collection=self.collection).model
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_upsert_create_only_required(self):
@@ -182,7 +185,14 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         json_to_send = asset.get_json('put')
         # Send a non normalized form of the type to see if it is also accepted
         json_to_send['type'] = 'image/TIFF;application=geotiff; Profile=cloud-optimized'
-        response = self.client.put(path, data=json_to_send, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=json_to_send,
+            content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(201, response)
         self.assertLocationHeader(f"{path}", response)
@@ -223,6 +233,9 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         # Now use upsert to create the new asset
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_name]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset.get_json('put'),
             content_type="application/json"
         )
@@ -273,7 +286,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
 
         # Now use upsert to create the new asset
         response = self.client.put(
-            path, data=asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(404, response)
 
@@ -298,7 +316,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
 
         # Now use upsert to create the new asset
         response = self.client.put(
-            path, data=asset.get_json('post'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('post'),
+            content_type="application/json"
         )
         self.assertStatusCode(404, response)
 
@@ -317,7 +340,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         path = \
             f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset["name"]}'
         response = self.client.put(
-            path, data=asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         json_data = response.json()
@@ -332,7 +360,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         path = \
             f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset["name"]}'
         response = self.client.put(
-            path, data=asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual(
@@ -389,7 +422,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         path = \
             f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset["name"]}'
         response = self.client.put(
-            path, data=asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(201, response)
 
@@ -401,7 +439,12 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         path = \
             f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset["name"]}'
         response = self.client.put(
-            path, data=asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual(
@@ -417,6 +460,7 @@ class AssetsCreateEndpointTestCase(StacBaseTestCase):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsWriteEndpointAssetFileTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -425,7 +469,6 @@ class AssetsWriteEndpointAssetFileTestCase(StacBaseTestCase):
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(collection=self.collection).model
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     # NOTE: Unfortunately this test cannot be done with the moto mocking.
@@ -452,6 +495,7 @@ class AssetsWriteEndpointAssetFileTestCase(StacBaseTestCase):
     #     )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -463,7 +507,6 @@ class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
         )
         self.asset = self.factory.create_asset_sample(item=self.item.model, db_create=True)
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_endpoint_patch_put_href(self):
@@ -477,7 +520,14 @@ class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
         patch_payload = {'href': 'https://testserver/non-existing-asset'}
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
-        response = self.client.patch(path, data=patch_payload, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=patch_payload,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
         description = response.json()['description']
         self.assertIn('href', description, msg=f'Unexpected field error {description}')
@@ -487,7 +537,14 @@ class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
             msg="Unexpected error message"
         )
 
-        response = self.client.put(path, data=put_payload, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=put_payload,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
         description = response.json()['description']
         self.assertIn('href', description, msg=f'Unexpected field error {description}')
@@ -498,6 +555,7 @@ class AssetsUpdateEndpointAssetFileTestCase(StacBaseTestCase):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -509,7 +567,6 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
         )
         self.asset = self.factory.create_asset_sample(item=self.item.model, db_create=True)
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_endpoint_put(self):
@@ -527,7 +584,12 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.put(
-            path, data=changed_asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=changed_asset.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -555,7 +617,12 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.put(
-            path, data=changed_asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=changed_asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual({'extra_attribute': ['Unexpected property in payload']},
@@ -579,6 +646,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.put(
             path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=changed_asset.get_json('put', keep_read_only=True),
             content_type="application/json"
         )
@@ -605,7 +675,12 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.put(
-            path, data=changed_asset.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=changed_asset.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual({'id': 'Renaming is not allowed'},
@@ -643,7 +718,12 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.patch(
-            path, data=changed_asset.get_json('patch'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=changed_asset.get_json('patch'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual({'id': 'Renaming is not allowed'},
@@ -683,7 +763,12 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
 
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.patch(
-            path, data=changed_asset.get_json('patch'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=changed_asset.get_json('patch'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual({'extra_payload': ['Unexpected property in payload']},
@@ -705,6 +790,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         response = self.client.patch(
             path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=changed_asset.get_json('patch', keep_read_only=True),
             content_type="application/json"
         )
@@ -723,6 +811,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
                     'test-asset-detail-http-500',
                     args=[self.collection['name'], self.item['name'], sample['name']]
                 ),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -754,6 +845,9 @@ class AssetsUpdateEndpointTestCase(StacBaseTestCase):
                     'test-asset-detail-http-500',
                     args=[self.collection['name'], self.item['name'], sample['name']]
                 ),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -812,6 +906,9 @@ class AssetRaceConditionTest(StacBaseTransactionTestCase):
                         asset_sample['name']
                     ]
                 ),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=asset_sample.get_json('put'),
                 content_type='application/json'
             )
@@ -837,6 +934,7 @@ class AssetRaceConditionTest(StacBaseTransactionTestCase):
         self.assertEqual(status_201, 1, msg="Not only one upsert did a create !")
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsDeleteEndpointTestCase(StacBaseTestCase, S3TestMixin):
 
     @mock_s3_asset_file
@@ -846,7 +944,6 @@ class AssetsDeleteEndpointTestCase(StacBaseTestCase, S3TestMixin):
         self.item = self.factory.create_item_sample(collection=self.collection).model
         self.asset = self.factory.create_asset_sample(item=self.item).model
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_asset_endpoint_delete_asset(self):
@@ -856,7 +953,12 @@ class AssetsDeleteEndpointTestCase(StacBaseTestCase, S3TestMixin):
         path = f'/{STAC_BASE_V}/collections/{collection_name}/items/{item_name}/assets/{asset_name}'
         s3_path = get_asset_path(self.item, asset_name)
         self.assertS3ObjectExists(s3_path)
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
         # Check that is has really been deleted
@@ -877,7 +979,12 @@ class AssetsDeleteEndpointTestCase(StacBaseTestCase, S3TestMixin):
             f"/{STAC_BASE_V}/collections/{collection_name}"
             f"/items/{item_name}/assets/non-existent-asset"
         )
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(404, response)
 
 

--- a/app/tests/tests_10/test_collection_asset_upload_endpoint.py
+++ b/app/tests/tests_10/test_collection_asset_upload_endpoint.py
@@ -26,7 +26,6 @@ from tests.tests_10.base_test import StacBaseTransactionTestCase
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.utils import reverse_version
 from tests.utils import S3TestMixin
-from tests.utils import client_login
 from tests.utils import get_file_like_object
 from tests.utils import mock_s3_asset_file
 
@@ -52,7 +51,6 @@ class CollectionAssetUploadBaseTest(StacBaseTestCase, S3TestMixin):
     @mock_s3_asset_file
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample().model
         self.asset = self.factory.create_collection_asset_sample(
@@ -182,6 +180,7 @@ class CollectionAssetUploadBaseTest(StacBaseTestCase, S3TestMixin):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def test_asset_upload_create_abort_multipart(self):
@@ -193,6 +192,9 @@ class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest)
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -208,6 +210,9 @@ class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest)
 
         response = self.client.post(
             self.get_abort_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={},
             content_type="application/json"
         )
@@ -241,6 +246,9 @@ class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest)
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -256,6 +264,9 @@ class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest)
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -293,6 +304,7 @@ class CollectionAssetUploadCreateEndpointTestCase(CollectionAssetUploadBaseTest)
         self.assertEqual(len(response['Uploads']), 1, msg='More or less uploads found on S3')
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, S3TestMixin):
 
     @mock_s3_asset_file
@@ -326,6 +338,9 @@ class CollectionAssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, 
             client.login(username=self.username, password=self.password)
             return client.post(
                 path,
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data={
                     'number_parts': number_parts,
                     'file:checksum': checksum_multihash,
@@ -348,6 +363,7 @@ class CollectionAssetUploadCreateRaceConditionTest(StacBaseTransactionTestCase, 
             self.assertEqual(response.json()['description'], "Upload already in progress")
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def upload_asset_with_dyn_cache(self, update_interval=None):
@@ -359,6 +375,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -377,6 +396,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -393,6 +415,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -410,6 +435,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -443,6 +471,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -460,6 +491,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size, number_parts)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -482,6 +516,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         md5_parts = [{'part_number': 1, 'md5': base64_md5(file_like_compress)}]
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -502,6 +539,9 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         )
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -514,6 +554,7 @@ class CollectionAssetUpload1PartEndpointTestCase(CollectionAssetUploadBaseTest):
         self.assertEqual(size_compress, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUpload2PartEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def test_asset_upload_2_parts_md5_integrity(self):
@@ -528,6 +569,9 @@ class CollectionAssetUpload2PartEndpointTestCase(CollectionAssetUploadBaseTest):
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -544,6 +588,9 @@ class CollectionAssetUpload2PartEndpointTestCase(CollectionAssetUploadBaseTest):
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -554,6 +601,7 @@ class CollectionAssetUpload2PartEndpointTestCase(CollectionAssetUploadBaseTest):
         self.assertEqual(size, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def test_asset_upload_invalid_content_encoding(self):
@@ -567,6 +615,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'md5_parts': md5_parts,
@@ -590,6 +641,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
         file_like, checksum_multihash = get_file_like_object(size)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts, 'file:checksum': checksum_multihash
             },
@@ -607,6 +661,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts, 'file:checksum': checksum_multihash
             },
@@ -617,7 +674,12 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
     def test_asset_upload_create_empty_payload(self):
         response = self.client.post(
-            self.get_create_multipart_upload_path(), data={}, content_type="application/json"
+            self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data={},
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
         self.assertEqual(
@@ -633,6 +695,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 0,
                 "file:checksum": 'abcdef',
@@ -658,6 +723,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 101, "file:checksum": 'abcdef', 'md5_parts': md5_parts
             },
@@ -676,6 +744,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [],
@@ -699,6 +770,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 3,
                 "md5_parts": [{
@@ -728,6 +802,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [{
@@ -757,6 +834,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': 2,
                 "md5_parts": [
@@ -788,6 +868,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -803,6 +886,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -829,6 +915,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -844,6 +933,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': [{
                 'etag': 'dummy', 'part_number': 1
             }]},
@@ -874,6 +966,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -890,6 +985,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -908,6 +1006,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -922,6 +1023,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
         parts = self.s3_upload_parts(json_data['upload_id'], file_like, size // 2, 1)
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -941,6 +1045,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -956,6 +1063,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={},
             content_type="application/json"
         )
@@ -964,6 +1074,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': []},
             content_type="application/json"
         )
@@ -972,6 +1085,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': ["dummy-etag"]},
             content_type="application/json"
         )
@@ -1003,6 +1119,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1018,6 +1137,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -1025,6 +1147,9 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
 
         response = self.client.post(
             self.get_complete_multipart_upload_path(json_data['upload_id']),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )
@@ -1035,6 +1160,7 @@ class CollectionAssetUploadInvalidEndpointTestCase(CollectionAssetUploadBaseTest
         self.assertEqual(size, self.asset.file_size)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUploadDeleteInProgressEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def test_delete_asset_upload_in_progress(self):
@@ -1046,6 +1172,9 @@ class CollectionAssetUploadDeleteInProgressEndpointTestCase(CollectionAssetUploa
 
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1056,7 +1185,12 @@ class CollectionAssetUploadDeleteInProgressEndpointTestCase(CollectionAssetUploa
         self.assertStatusCode(201, response)
         upload_id = response.json()['upload_id']
 
-        response = self.client.delete(self.get_delete_asset_path())
+        response = self.client.delete(
+            self.get_delete_asset_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(400, response)
         self.assertEqual(
             response.json()['description'],
@@ -1070,10 +1204,20 @@ class CollectionAssetUploadDeleteInProgressEndpointTestCase(CollectionAssetUploa
             msg='Collection Asset has been deleted'
         )
 
-        response = self.client.post(self.get_abort_multipart_upload_path(upload_id))
+        response = self.client.post(
+            self.get_abort_multipart_upload_path(upload_id),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
-        response = self.client.delete(self.get_delete_asset_path())
+        response = self.client.delete(
+            self.get_delete_asset_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
         self.assertFalse(
@@ -1084,6 +1228,7 @@ class CollectionAssetUploadDeleteInProgressEndpointTestCase(CollectionAssetUploa
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class GetCollectionAssetUploadsEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def create_dummies_uploads(self):
@@ -1216,6 +1361,7 @@ class GetCollectionAssetUploadsEndpointTestCase(CollectionAssetUploadBaseTest):
             self.assertEqual(upload['status'], CollectionAssetUpload.Status.ABORTED)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionAssetUploadListPartsEndpointTestCase(CollectionAssetUploadBaseTest):
 
     def test_asset_upload_list_parts(self):
@@ -1228,6 +1374,9 @@ class CollectionAssetUploadListPartsEndpointTestCase(CollectionAssetUploadBaseTe
         md5_parts = create_md5_parts(number_parts, offset, file_like)
         response = self.client.post(
             self.get_create_multipart_upload_path(),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={
                 'number_parts': number_parts,
                 'file:checksum': checksum_multihash,
@@ -1282,6 +1431,9 @@ class CollectionAssetUploadListPartsEndpointTestCase(CollectionAssetUploadBaseTe
         # Complete the upload
         response = self.client.post(
             self.get_complete_multipart_upload_path(upload_id),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'parts': parts},
             content_type="application/json"
         )

--- a/app/tests/tests_10/test_collections_endpoint.py
+++ b/app/tests/tests_10/test_collections_endpoint.py
@@ -23,7 +23,6 @@ from tests.tests_10.data_factory import CollectionFactory
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.data_factory import SampleData
 from tests.tests_10.utils import reverse_version
-from tests.utils import client_login
 from tests.utils import disableLogger
 from tests.utils import mock_s3_asset_file
 
@@ -117,11 +116,11 @@ class CollectionsEndpointTestCase(StacBaseTestCase):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionsUnImplementedEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample()
         self.maxDiff = None  # pylint: disable=invalid-name
@@ -129,17 +128,20 @@ class CollectionsUnImplementedEndpointTestCase(StacBaseTestCase):
     def test_collections_post_unimplemented(self):
         response = self.client.post(
             f"/{STAC_BASE_V}/collections",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=self.collection.get_json('post'),
             content_type='application/json'
         )
         self.assertStatusCode(405, response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionsCreateEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample()
         self.maxDiff = None  # pylint: disable=invalid-name
@@ -150,6 +152,9 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
         # the dataset to update does not exist yet
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{sample['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type='application/json'
         )
@@ -163,6 +168,9 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{collection['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=collection.get_json('put'),
             content_type='application/json'
         )
@@ -177,7 +185,12 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
 
         path = f"/{STAC_BASE_V}/collections/{collection['name']}"
         response = self.client.put(
-            path, data=collection.get_json('put'), content_type='application/json'
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=collection.get_json('put'),
+            content_type='application/json'
         )
         response_json = response.json()
         logger.debug(response_json)
@@ -195,6 +208,9 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{collection['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=collection.get_json('put'),
             content_type='application/json'
         )
@@ -218,7 +234,12 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
 
         path = f"/{STAC_BASE_V}/collections/{collection_sample['name']}"
         response = self.client.put(
-            path, data=collection_sample.get_json('put'), content_type='application/json'
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=collection_sample.get_json('put'),
+            content_type='application/json'
         )
         self.assertStatusCode(201, response)
         self.assertLocationHeader(f'{path}', response)
@@ -259,6 +280,9 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
         # Publish the collection
         response = self.client.patch(
             f"/{STAC_BASE_V}/collections/{collection.name}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data={'published': True},
             content_type='application/json'
         )
@@ -283,6 +307,9 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
         with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True), disableLogger('stac_api.apps'):
             response = self.client.put(
                 reverse('test-collection-detail-http-500', args=[sample['name']]),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -294,11 +321,11 @@ class CollectionsCreateEndpointTestCase(StacBaseTestCase):
         self.assertStatusCode(404, response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.collection_factory = CollectionFactory()
         self.collection = self.collection_factory.create_sample(db_create=True)
         self.maxDiff = None  # pylint: disable=invalid-name
@@ -310,6 +337,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{sample['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type='application/json'
         )
@@ -329,6 +359,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{sample['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type='application/json'
         )
@@ -346,6 +379,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{sample['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put', keep_read_only=True),
             content_type='application/json'
         )
@@ -364,6 +400,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
         self.assertNotEqual(self.collection['name'], sample['name'])
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{self.collection['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type='application/json'
         )
@@ -390,6 +429,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
         self.assertNotEqual('', f'{self.collection["title"]}')
         response = self.client.put(
             f"/{STAC_BASE_V}/collections/{sample['name']}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type='application/json'
         )
@@ -408,6 +450,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
 
         response = self.client.patch(
             f"/{STAC_BASE_V}/collections/{collection_name}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=payload_json,
             content_type='application/json'
         )
@@ -427,6 +472,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
         # for start the payload has no description
         response = self.client.patch(
             f"/{STAC_BASE_V}/collections/{collection_name}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=payload_json,
             content_type='application/json'
         )
@@ -442,6 +490,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
         self.assertNotEqual(self.collection['license'], payload_json['license'])
         response = self.client.patch(
             f"/{STAC_BASE_V}/collections/{collection_name}",
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=payload_json,
             content_type='application/json'
         )
@@ -464,6 +515,9 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
             # console therefore disable it.
             response = self.client.put(
                 reverse('test-collection-detail-http-500', args=[sample['name']]),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -476,11 +530,11 @@ class CollectionsUpdateEndpointTestCase(StacBaseTestCase):
         self.check_stac_collection(self.collection.json, response.json())
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionsDeleteEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client()
-        client_login(self.client)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample(db_create=True)
         self.item = self.factory.create_item_sample(self.collection.model, db_create=True)
@@ -489,7 +543,12 @@ class CollectionsDeleteEndpointTestCase(StacBaseTestCase):
     def test_authorized_collection_delete(self):
 
         path = reverse_version('collection-detail', args=[self.collection["name"]])
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
 
         self.assertStatusCode(400, response)
         self.assertEqual(
@@ -500,7 +559,11 @@ class CollectionsDeleteEndpointTestCase(StacBaseTestCase):
         item_path = reverse_version(
             'item-detail', args=[self.collection["name"], self.item['name']]
         )
-        response = self.client.delete(item_path)
+        response = self.client.delete(
+            item_path, headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            }
+        )
         self.assertStatusCode(200, response)
 
         # try the collection delete again
@@ -669,11 +732,11 @@ class CollectionsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
         self.run_test(401, headers=headers)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class CollectionLinksEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -686,7 +749,14 @@ class CollectionLinksEndpointTestCase(StacBaseTestCase):
         data = self.collection_data.get_json('put')
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -706,7 +776,14 @@ class CollectionLinksEndpointTestCase(StacBaseTestCase):
         }]
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -747,7 +824,14 @@ class CollectionLinksEndpointTestCase(StacBaseTestCase):
         }]
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 400)
         content = response.json()

--- a/app/tests/tests_10/test_external_assets_endpoint.py
+++ b/app/tests/tests_10/test_external_assets_endpoint.py
@@ -2,16 +2,17 @@ import responses
 
 from django.conf import settings
 from django.test import Client
+from django.test import override_settings
 
 from stac_api.models.item import Asset
 
 from tests.tests_10.base_test import StacBaseTestCase
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.utils import reverse_version
-from tests.utils import client_login
 from tests.utils import mock_s3_asset_file
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -20,7 +21,6 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(collection=self.collection).model
         self.client = Client()
-        client_login(self.client)
         self.maxDiff = None  # pylint: disable=invalid-name
 
     def test_create_asset_with_external_url(self):
@@ -37,6 +37,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset, which isn't allowed
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -50,6 +53,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset, now it's allowed
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -94,6 +100,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -137,6 +146,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -180,6 +192,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -208,6 +223,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
 
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset.attr_name]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type='application/json'
         )
@@ -254,6 +272,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -286,6 +307,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset with an existing one
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -296,6 +320,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset with an existing one
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -327,6 +354,9 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         # create the asset with an existing one
         response = self.client.put(
             reverse_version('asset-detail', args=[collection.name, item.name, asset_data['id']]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=asset_data,
             content_type="application/json"
         )
@@ -348,7 +378,10 @@ class AssetsExternalAssetEndpointTestCase(StacBaseTestCase):
         )
 
         response = self.client.delete(
-            reverse_version('asset-detail', args=[collection.name, item.name, asset.attr_name])
+            reverse_version('asset-detail', args=[collection.name, item.name, asset.attr_name]),
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            }
         )
 
         self.assertStatusCode(200, response)

--- a/app/tests/tests_10/test_generic_api.py
+++ b/app/tests/tests_10/test_generic_api.py
@@ -15,7 +15,6 @@ from tests.tests_10.base_test import STAC_BASE_V
 from tests.tests_10.base_test import StacBaseTestCase
 from tests.tests_10.data_factory import Factory
 from tests.utils import S3TestMixin
-from tests.utils import client_login
 from tests.utils import disableLogger
 from tests.utils import get_http_error_description
 from tests.utils import mock_s3_asset_file
@@ -193,6 +192,7 @@ class ApiPaginationTestCase(StacBaseTestCase):
                 )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ApiETagPreconditionTestCase(StacBaseTestCase):
 
     @mock_s3_asset_file
@@ -252,7 +252,6 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
                 self.assertStatusCode(412, response4)
 
     def test_put_precondition(self):
-        client_login(self.client)
         for (endpoint, sample) in [
             (
                 f'collections/{self.collection["name"]}',
@@ -285,7 +284,10 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.put(
                     f"/{STAC_BASE_V}/{endpoint}",
-                    sample.get_json('put'),
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
+                    data=sample.get_json('put'),
                     content_type="application/json",
                     HTTP_IF_MATCH='"abc"'
                 )
@@ -293,15 +295,16 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.put(
                     f"/{STAC_BASE_V}/{endpoint}",
-                    sample.get_json('put'),
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
+                    data=sample.get_json('put'),
                     content_type="application/json",
                     HTTP_IF_MATCH=self.get_etag(endpoint)
                 )
                 self.assertStatusCode(200, response)
 
     def test_wrong_media_type(self):
-        client_login(self.client)
-
         for (request_methods, endpoint, data) in [
             (
                 ['put', 'patch'],
@@ -325,12 +328,16 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
                 client_requests = [getattr(self.client, method) for method in request_methods]
                 for client_request in client_requests:
                     response = client_request(
-                        f"/{STAC_BASE_V}/{endpoint}", data=data, content_type="plain/text"
+                        f"/{STAC_BASE_V}/{endpoint}",
+                        headers={
+                            "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                        },
+                        data=data,
+                        content_type="plain/text"
                     )
                     self.assertStatusCode(415, response)
 
     def test_patch_precondition(self):
-        client_login(self.client)
         for (endpoint, data) in [
             (
                 f'collections/{self.collection["name"]}',
@@ -358,7 +365,10 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.patch(
                     f"/{STAC_BASE_V}/{endpoint}",
-                    data,
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
+                    data=data,
                     content_type="application/json",
                     HTTP_IF_MATCH='"abc"'
                 )
@@ -366,14 +376,16 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.patch(
                     f"/{STAC_BASE_V}/{endpoint}",
-                    data,
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
+                    data=data,
                     content_type="application/json",
                     HTTP_IF_MATCH=self.get_etag(endpoint)
                 )
                 self.assertStatusCode(200, response)
 
     def test_delete_precondition(self):
-        client_login(self.client)
         for endpoint in [
             f'collections/{self.collection["name"]}/items/{self.item["name"]}'
             f'/assets/{self.asset["name"]}',
@@ -385,6 +397,9 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.delete(
                     f"/{STAC_BASE_V}/{endpoint}",
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
                     content_type="application/json",
                     HTTP_IF_MATCH='"abc"'
                 )
@@ -394,6 +409,9 @@ class ApiETagPreconditionTestCase(StacBaseTestCase):
 
                 response = self.client.delete(
                     f"/{STAC_BASE_V}/{endpoint}",
+                    headers={
+                        "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                    },
                     content_type="application/json",
                     HTTP_IF_MATCH=etag1
                 )

--- a/app/tests/tests_10/test_geoadmin_header_auth.py
+++ b/app/tests/tests_10/test_geoadmin_header_auth.py
@@ -2,7 +2,6 @@ import logging
 
 from parameterized import parameterized
 
-from django.contrib.auth import get_user_model
 from django.test import Client
 from django.test import override_settings
 
@@ -15,19 +14,19 @@ logger = logging.getLogger(__name__)
 
 @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class GeoadminHeadersAuthForPutEndpointTestCase(StacBaseTestCase):
-    valid_username = "another_test_user"
 
     def setUp(self):  # pylint: disable=invalid-name
         self.client = Client(enforce_csrf_checks=True)
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample()
-        get_user_model().objects.create_superuser(self.valid_username)
 
     @parameterized.expand([
-        (valid_username, "true", 201),
+        ("another_test_user", "true", 201),
+        ("another_test_user", "false", 401),
+        ("another_test_user", "", 401),
         (None, None, 401),
-        (valid_username, "false", 401),
-        ("wronguser", "true", 403),
+        (None, "false", 401),
+        (None, "true", 401),
     ])
     def test_collection_upsert_create_with_geoadmin_header_auth(
         self, username_header, authenticated_header, expected_response_code

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -28,7 +28,6 @@ from tests.tests_10.data_factory import CollectionFactory
 from tests.tests_10.data_factory import Factory
 from tests.tests_10.data_factory import ItemFactory
 from tests.tests_10.utils import reverse_version
-from tests.utils import client_login
 from tests.utils import disableLogger
 from tests.utils import mock_s3_asset_file
 
@@ -447,6 +446,7 @@ class ItemsDatetimeQueryPaginationEndpointTestCase(StacBaseTestCase):
         self._navigate_to_previous_items(['item-yesterday-1', 'item-2', 'item-1'], json_response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsUnImplementedEndpointTestCase(StacBaseTestCase):
 
     @classmethod
@@ -456,18 +456,21 @@ class ItemsUnImplementedEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
 
     def test_item_post_unimplemented(self):
         sample = self.factory.create_item_sample(self.collection)
         response = self.client.post(
             f'/{STAC_BASE_V}/collections/{self.collection.name}/items',
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('post'),
             content_type="application/json"
         )
         self.assertStatusCode(405, response)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsCreateEndpointTestCase(StacBaseTestCase):
 
     @classmethod
@@ -477,13 +480,17 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
 
     def test_item_upsert_create(self):
         sample = self.factory.create_item_sample(self.collection)
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{sample.json["id"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(201, response)
@@ -493,7 +500,12 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
         sample = self.factory.create_item_sample(self.collection, required_only=True)
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{sample["name"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(201, response)
@@ -512,6 +524,9 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
         sample = self.factory.create_item_sample(self.collection, required_only=True)
         response = self.client.put(
             f'/{STAC_BASE_V}/collections/non-existing-collection/items/{sample.json["id"]}',
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
             data=sample.get_json('put'),
             content_type="application/json"
         )
@@ -524,6 +539,9 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
         with self.settings(DEBUG_PROPAGATE_API_EXCEPTIONS=True), disableLogger('stac_api.apps'):
             response = self.client.put(
                 reverse('test-item-detail-http-500', args=[self.collection.name, sample['name']]),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -540,7 +558,14 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
         data = self.factory.create_item_sample(self.collection,
                                                sample='item-invalid').get_json('put')
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{data["id"]}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         # Make sure that the item is not found in DB
@@ -557,7 +582,14 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
             properties_end_datetime=None
         ).get_json('put')
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{data["id"]}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         # Make sure that the item is not found in DB
@@ -567,6 +599,7 @@ class ItemsCreateEndpointTestCase(StacBaseTestCase):
         )
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsUpdateEndpointTestCase(StacBaseTestCase):
 
     @classmethod
@@ -579,7 +612,6 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
 
     def test_item_endpoint_put(self):
         sample = self.factory.create_item_sample(
@@ -587,7 +619,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -605,7 +642,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         self.assertStatusCode(400, response)
 
@@ -614,7 +656,14 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             self.collection.model, sample='item-2', name=self.item['name'], created=datetime.now()
         ).get_json('put')
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_put_update_to_datetime_range(self):
@@ -629,7 +678,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -656,7 +710,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             }
         )
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -674,7 +733,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             }
         )
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(200, response)
@@ -689,7 +753,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
         )
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
         response = self.client.put(
-            path, data=sample.get_json('put'), content_type="application/json"
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=sample.get_json('put'),
+            content_type="application/json"
         )
         json_data = response.json()
         self.assertStatusCode(400, response)
@@ -714,7 +783,14 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
     def test_item_endpoint_patch(self):
         data = {"properties": {"title": "patched title"}}
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(self.item['name'], json_data['id'])
@@ -740,7 +816,14 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
 
         # Remove properties_title
         data = {"properties": {"title": None}}
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(200, response)
         self.assertEqual(self.item['name'], json_data['id'])
@@ -756,23 +839,51 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
     def test_item_endpoint_patch_extra_payload(self):
         data = {"crazy:stuff": "not allowed"}
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_patch_read_only_in_payload(self):
         data = {"created": utc_aware(datetime.utcnow())}
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_patch_invalid_datetimes(self):
         data = {"properties": {"datetime": "patched title",}}
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
         data = {"properties": {"start_datetime": "2020-10-28T13:05:10Z",}}
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         self.assertStatusCode(400, response)
 
     def test_item_endpoint_patch_rename_item(self):
@@ -780,7 +891,14 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             "id": f'new-{self.item["name"]}',
         }
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
-        response = self.client.patch(path, data=data, content_type="application/json")
+        response = self.client.patch(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
         json_data = response.json()
         self.assertStatusCode(400, response)
         self.assertEqual(json_data['description'], {'id': 'Renaming is not allowed'})
@@ -815,6 +933,9 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
                 reverse(
                     'test-item-detail-http-500', args=[self.collection['name'], sample['name']]
                 ),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=sample.get_json('put'),
                 content_type='application/json'
             )
@@ -851,6 +972,9 @@ class ItemRaceConditionTest(StacBaseTransactionTestCase):
                 reverse_version(
                     'item-detail', args=[collection_sample['name'], item_sample['name']]
                 ),
+                headers={
+                    "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+                },
                 data=item_sample.get_json('put'),
                 content_type='application/json'
             )
@@ -870,6 +994,7 @@ class ItemRaceConditionTest(StacBaseTransactionTestCase):
         self.assertEqual(status_201, 1, msg="Not only one upsert did a create !")
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsDeleteEndpointTestCase(StacBaseTestCase):
 
     @classmethod
@@ -879,7 +1004,6 @@ class ItemsDeleteEndpointTestCase(StacBaseTestCase):
     @mock_s3_asset_file
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
         self.collection = self.factory.create_collection_sample().model
         self.item = self.factory.create_item_sample(self.collection, sample='item-1').model
         self.asset = self.factory.create_asset_sample(self.item, sample='asset-1').model
@@ -887,19 +1011,34 @@ class ItemsDeleteEndpointTestCase(StacBaseTestCase):
     def test_item_endpoint_delete_item(self):
         # Check that deleting, while assets are present, is not allowed
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(400, response)
         self.assertEqual(response.json()['description'], ['Deleting Item with assets not allowed'])
 
         # delete asset first
         asset_path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}' \
              f'/assets/{self.asset.name}'
-        response = self.client.delete(asset_path)
+        response = self.client.delete(
+            asset_path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
         # try item delete again
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(200, response)
 
         # Check that is has really been deleted
@@ -913,7 +1052,12 @@ class ItemsDeleteEndpointTestCase(StacBaseTestCase):
 
     def test_item_endpoint_delete_item_invalid_name(self):
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/unknown-item'
-        response = self.client.delete(path)
+        response = self.client.delete(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+        )
         self.assertStatusCode(404, response)
 
 
@@ -1020,11 +1164,11 @@ class ItemsDisabledAuthenticationEndpointTestCase(StacBaseTestCase):
         self.run_test(401, headers=headers)
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsLinksEndpointTestCase(StacBaseTestCase):
 
     def setUp(self):
         self.client = Client()
-        client_login(self.client)
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -1041,7 +1185,14 @@ class ItemsLinksEndpointTestCase(StacBaseTestCase):
         data = self.item_data.get_json('put')
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -1061,7 +1212,14 @@ class ItemsLinksEndpointTestCase(StacBaseTestCase):
         }]
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -1101,7 +1259,14 @@ class ItemsLinksEndpointTestCase(StacBaseTestCase):
         }]
 
         path = f'/{STAC_BASE_V}/collections/{self.collection.name}/items/{self.item.name}'
-        response = self.client.put(path, data=data, content_type="application/json")
+        response = self.client.put(
+            path,
+            headers={
+                "Geoadmin-Username": "apiuser", "Geoadmin-Authenticated": "true"
+            },
+            data=data,
+            content_type="application/json"
+        )
 
         self.assertEqual(response.status_code, 400)
         content = response.json()


### PR DESCRIPTION
Currently `RemoteUserBackend` creates an authenticated user if it not already exists (`create_unknown_user` is set by default). I suggest we generally set the superuser flag for the cognito authenticated users until we implement proper authorization. The other possibility would be to set `create_unknown_user` and create the users by hand (auth-attempts for non-existing users will then return 401 instead of 403).

I also updated the tests for v1 to use the new authentication method, as this is what we want to use there so it doesn't make much sense to use another authentication method in the test.

What do you think?