### PR TITLE
PB-1279 Batch create endpoint for items/assets

### DIFF
--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -515,3 +515,11 @@ class ItemListSerializer(serializers.Serializer):
         '''Convert to a dict like `{"features": [item1, item2, ...]}`.'''
         items_serialized = [ItemSerializer(item, context=self.context).data for item in instance]
         return {"features": items_serialized}
+
+    @override
+    def validate(self, attrs):
+        max_n_items = 100
+        if len(attrs["features"]) > max_n_items:
+            raise serializers.ValidationError({"features": f"More than {max_n_items} features"})
+
+        return super().validate(attrs)

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -475,13 +475,6 @@ class ItemListSerializer(serializers.Serializer):
         '''Create items in bulk from the given list of items.'''
         collection = validated_data["collection"]
 
-        update_fields = [
-            field.name
-            for field in Item._meta.get_fields()
-            if not field.is_relation and not field.primary_key
-        ]
-
-        existing_items = []
         new_items = []
         links_data_list = []
         for item_in in validated_data["features"]:
@@ -489,21 +482,7 @@ class ItemListSerializer(serializers.Serializer):
             links_data_list.append(links_data)
 
             item = Item(**item_in, collection=collection)
-
-            existing_item_query = Item.objects.filter(collection=collection, name=item_in["name"])
-            if existing_item_query.exists():
-                # Convert QuerySet to Item for bulk_update()
-                existing_item = list(existing_item_query.in_bulk().values())[0]
-
-                for field in update_fields:
-                    if field in item_in:
-                        setattr(existing_item, field, item_in[field])
-                existing_items.append(existing_item)
-            else:
-                new_items.append(item)
-
-        if existing_items:
-            Item.objects.bulk_update(existing_items, update_fields)
+            new_items.append(item)
 
         items_created = Item.objects.bulk_create(new_items)
 

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 from datetime import timedelta
+from typing import override
 
 from django.core.exceptions import ValidationError as CoreValidationError
 from django.utils.translation import gettext_lazy as _
@@ -471,6 +472,7 @@ class ItemListSerializer(serializers.Serializer):
     # with the payload of the getFeatures endpoint.
     features = ItemSerializer(many=True)
 
+    @override
     def create(self, validated_data):
         '''Create items in bulk from the given list of items.'''
         collection = validated_data["collection"]
@@ -504,6 +506,11 @@ class ItemListSerializer(serializers.Serializer):
 
         return items_created
 
+    @override
+    def update(self, instance, validated_data):
+        raise NotImplementedError("Update not supported.")
+
+    @override
     def to_representation(self, instance):
         '''Convert to a dict like `{"features": [item1, item2, ...]}`.'''
         items_serialized = [ItemSerializer(item, context=self.context).data for item in instance]

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -476,19 +476,21 @@ class ItemListSerializer(serializers.Serializer):
         collection = validated_data["collection"]
 
         new_items = []
-        links_data_list = []
+        links_per_item = {}
         for item_in in validated_data["features"]:
-            links_data = item_in.pop('links', [])
-            links_data_list.append(links_data)
-
+            links = item_in.pop('links', [])
+            links_per_item[item_in["name"]] = links
             item = Item(**item_in, collection=collection)
             new_items.append(item)
 
         items_created = Item.objects.bulk_create(new_items)
 
-        for item, links_data in zip(items_created, links_data_list):
+        for item in items_created:
             update_or_create_links(
-                instance_type="item", model=ItemLink, instance=item, links_data=links_data
+                instance_type="item",
+                model=ItemLink,
+                instance=item,
+                links_data=links_per_item[item.name]
             )
         return items_created
 

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -372,7 +372,7 @@ class ItemSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
     type = serializers.SerializerMethodField()
     collection = serializers.SlugRelatedField(slug_field='name', read_only=True)
     bbox = BboxSerializer(source='*', read_only=True)
-    assets = AssetsForItemSerializer(many=True)
+    assets = AssetsForItemSerializer(many=True, required=False)
     stac_extensions = serializers.SerializerMethodField()
     stac_version = serializers.SerializerMethodField()
 

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -473,20 +473,39 @@ class ItemListSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         '''Create items in bulk from the given list of items.'''
-        items = []
+        collection = validated_data["collection"]
+
+        update_fields = [
+            field.name
+            for field in Item._meta.get_fields()
+            if not field.is_relation and not field.primary_key
+        ]
+
+        existing_items = []
+        new_items = []
         links_data_list = []
         for item_in in validated_data["features"]:
             links_data = item_in.pop('links', [])
-            item = Item(**item_in, collection=validated_data["collection"])
-            items.append(item)
+            links_data_list.append(links_data)
 
-        update_fields = [field.name for field in Item._meta.get_fields() if not field.is_relation]
-        unique_fields = ["id"]
-        update_fields = list(set(update_fields) - set(unique_fields))
+            item = Item(**item_in, collection=collection)
 
-        items_created = Item.objects.bulk_create(
-            items, update_conflicts=True, update_fields=update_fields, unique_fields=unique_fields
-        )
+            existing_item_query = Item.objects.filter(collection=collection, name=item_in["name"])
+            if existing_item_query.exists():
+                # Convert QuerySet to Item for bulk_update()
+                existing_item = list(existing_item_query.in_bulk().values())[0]
+
+                for field in update_fields:
+                    if field in item_in:
+                        setattr(existing_item, field, item_in[field])
+                existing_items.append(existing_item)
+            else:
+                new_items.append(item)
+
+        if existing_items:
+            Item.objects.bulk_update(existing_items, update_fields)
+
+        items_created = Item.objects.bulk_create(new_items)
 
         for item, links_data in zip(items_created, links_data_list):
             update_or_create_links(

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -34,7 +34,7 @@ def validate_json_payload(serializer):
     ]
 
     errors = {}
-    for key in serializer.initial_data.keys():
+    for key in serializer.get_initial().keys():
         if key not in expected_payload:
             logger.error('Found unexpected payload %s', key)
             errors[key] = _("Unexpected property in payload")

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -34,7 +34,12 @@ def validate_json_payload(serializer):
     ]
 
     errors = {}
-    for key in serializer.get_initial().keys():
+
+    # Nested serializers may not have initial_data set at this point
+    if not hasattr(serializer, "initial_data"):
+        return
+
+    for key in serializer.initial_data.keys():
         if key not in expected_payload:
             logger.error('Found unexpected payload %s', key)
             errors[key] = _("Unexpected property in payload")

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -157,10 +157,8 @@ class ItemsList(generics.GenericAPIView):
                 return Response(data=message, status=status.HTTP_400_BAD_REQUEST)
 
             collection = Collection.objects.get(name=self.kwargs['collection_name'])
-            items = serializer.save(collection=collection)
-
-            return_status = status.HTTP_201_CREATED if len(items) > 0 else status.HTTP_200_OK
-            return Response(serializer.data, status=return_status)
+            serializer.save(collection=collection)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
         except Collection.DoesNotExist as exception:
             code = status.HTTP_404_NOT_FOUND
             message = {"code": code, "description": str(exception)}

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -157,9 +157,10 @@ class ItemsList(generics.GenericAPIView):
                 return Response(data=message, status=status.HTTP_400_BAD_REQUEST)
 
             collection = Collection.objects.get(name=self.kwargs['collection_name'])
-            serializer.save(collection=collection)
+            items = serializer.save(collection=collection)
 
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
+            return_status = status.HTTP_201_CREATED if len(items) > 0 else status.HTTP_200_OK
+            return Response(serializer.data, status=return_status)
         except Collection.DoesNotExist as exception:
             code = status.HTTP_404_NOT_FOUND
             message = {"code": code, "description": str(exception)}

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -8,6 +8,7 @@ from django.db.models import Subquery
 from django.utils import timezone
 
 from rest_framework import generics
+from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework_condition import etag
@@ -16,6 +17,7 @@ from stac_api.models.collection import Collection
 from stac_api.models.item import Asset
 from stac_api.models.item import Item
 from stac_api.serializers.item import AssetSerializer
+from stac_api.serializers.item import ItemListSerializer
 from stac_api.serializers.item import ItemSerializer
 from stac_api.serializers.utils import get_relation_links
 from stac_api.utils import get_asset_path
@@ -143,6 +145,15 @@ class ItemsList(generics.GenericAPIView):
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        serializer = ItemListSerializer(data=request.data, context={"request": request})
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        collection = Collection.objects.get(name=self.kwargs['collection_name'])
+        serializer.save(collection=collection)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class ItemDetail(

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -149,6 +149,9 @@ class ItemsList(generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         try:
+            # Currently we only check that this header parameter is part of the request.
+            # We don't do anything with it. The idea is that, like this, we already
+            # have it in our interface from the get-go and the users don't need to change later.
             idempotency_key_param = "Idempotency-Key"
             idempotency_key = request.headers.get(idempotency_key_param)
             if not idempotency_key:

--- a/app/tests/tests_09/test_items_endpoint.py
+++ b/app/tests/tests_09/test_items_endpoint.py
@@ -414,27 +414,6 @@ class ItemsDatetimeQueryPaginationEndpointTestCase(StacBaseTestCase):
         self._navigate_to_previous_items(['item-yesterday-1', 'item-2', 'item-1'], json_response)
 
 
-class ItemsUnImplementedEndpointTestCase(StacBaseTestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.factory = Factory()
-        cls.collection = cls.factory.create_collection_sample().model
-
-    def setUp(self):
-        self.client = Client()
-        client_login(self.client)
-
-    def test_item_post_unimplemented(self):
-        sample = self.factory.create_item_sample(self.collection)
-        response = self.client.post(
-            f'/{STAC_BASE_V}/collections/{self.collection.name}/items',
-            data=sample.get_json('post'),
-            content_type="application/json"
-        )
-        self.assertStatusCode(405, response)
-
-
 class ItemsCreateEndpointTestCase(StacBaseTestCase):
 
     @classmethod

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -1108,6 +1108,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         self.assertEqual(response_json["description"], "No header parameter 'Idempotency-Key'")
 
 
+@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemRaceConditionTest(StacBaseTransactionTestCase):
 
     def setUp(self):

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -448,27 +448,6 @@ class ItemsDatetimeQueryPaginationEndpointTestCase(StacBaseTestCase):
 
 
 @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
-class ItemsUnImplementedEndpointTestCase(StacBaseTestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.factory = Factory()
-        cls.collection = cls.factory.create_collection_sample().model
-
-    def setUp(self):
-        self.client = Client(headers=get_auth_headers())
-
-    def test_item_post_unimplemented(self):
-        sample = self.factory.create_item_sample(self.collection)
-        response = self.client.post(
-            f'/{STAC_BASE_V}/collections/{self.collection.name}/items',
-            data=sample.get_json('post'),
-            content_type="application/json"
-        )
-        self.assertStatusCode(405, response)
-
-
-@override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
 class ItemsCreateEndpointTestCase(StacBaseTestCase):
 
     @classmethod

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -917,6 +917,36 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         self.assertEqual(response_json["code"], 404)
         self.assertEqual(response_json["description"], "Collection matching query does not exist.")
 
+    def test_items_endpoint_post_returns_400_if_payload_malformed(self):
+        collection_name = self.collection["name"]
+        payload = {"teachers": []}
+        response = self.client.post(
+            path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
+            data=payload,
+            content_type="application/json"
+        )
+        response_json = response.json()
+
+        self.assertStatusCode(400, response)
+        self.assertEqual(response_json["code"], 400)
+        self.assertEqual(
+            response_json["description"],
+            "{'features': [ErrorDetail(string='This field is required.', code='required')]}"
+        )
+
+    def test_items_endpoint_post_returns_200_if_no_items_provided(self):
+        collection_name = self.collection["name"]
+        payload = {"features": []}
+        response = self.client.post(
+            path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
+            data=payload,
+            content_type="application/json",
+        )
+        response_json = response.json()
+
+        self.assertStatusCode(200, response)
+        self.assertEqual(response_json, payload)
+
 
 class ItemRaceConditionTest(StacBaseTransactionTestCase):
 

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -945,7 +945,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             #
             # So we only inspect the second line.
             response_json["description"].split("\n")[1],
-            "DETAIL:  Key (collection_id, name)=(1, item-1) already exists."
+            f"DETAIL:  Key (collection_id, name)=({self.collection.model.id}, item-1) already exists."
         )
 
     def test_items_endpoint_post_returns_404_if_collection_does_not_exist(self):

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -871,7 +871,8 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=self.payload,
-            content_type="application/json"
+            content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -931,7 +932,8 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=self.payload,
-            content_type="application/json"
+            content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -953,7 +955,8 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=self.payload,
-            content_type="application/json"
+            content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -967,7 +970,8 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=payload,
-            content_type="application/json"
+            content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -985,6 +989,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=payload,
             content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -1020,6 +1025,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=payload,
             content_type="application/json",
+            headers={"Idempotency-Key": "abc-123"},
         )
         response_json = response.json()
 
@@ -1029,6 +1035,36 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             response_json["description"],
             f"{{'features': [ErrorDetail(string='More than {max_n_items} features', code='invalid')]}}"
         )
+
+    def test_items_endpoint_post_returns_400_if_no_idempotency_key(self):
+        collection_name = self.collection["name"]
+
+        response = self.client.post(
+            path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
+            data=self.payload,
+            content_type="application/json",
+            headers={},
+        )
+        response_json = response.json()
+
+        self.assertStatusCode(400, response)
+        self.assertEqual(response_json["code"], 400)
+        self.assertEqual(response_json["description"], "No header parameter 'Idempotency-Key'")
+
+    def test_items_endpoint_post_returns_400_if_idempotency_key_empty(self):
+        collection_name = self.collection["name"]
+
+        response = self.client.post(
+            path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
+            data=self.payload,
+            content_type="application/json",
+            headers={"Idempotency-Key": ""},
+        )
+        response_json = response.json()
+
+        self.assertStatusCode(400, response)
+        self.assertEqual(response_json["code"], 400)
+        self.assertEqual(response_json["description"], "No header parameter 'Idempotency-Key'")
 
 
 class ItemRaceConditionTest(StacBaseTransactionTestCase):

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -875,7 +875,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         }
 
     def setUp(self):
-        self.client = Client()
+        self.client = Client(headers=get_auth_headers())
 
     def test_items_endpoint_post_creates_given_items_as_expected(self):
         collection_name = self.collection["name"]

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -831,6 +831,12 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                         "proj:epsg": 2056,
                         "gsd": 2.5
                     }],
+                    "links": [{
+                        'href': 'https://www.example.com/described-by-1',
+                        'rel': 'describedBy',
+                        'title': 'My title 1',
+                        'hreflang': 'en',
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [1.1, 1.2]
                     },
@@ -851,6 +857,12 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                         "geoadmin:lang": "de",
                         "proj:epsg": 2056,
                         "gsd": 2.5
+                    }],
+                    "links": [{
+                        'href': 'https://www.example.com/described-by-2',
+                        'rel': 'describedBy',
+                        'title': 'My title 2',
+                        'hreflang': 'en',
                     }],
                     "geometry": {
                         "type": "Point", "coordinates": [2.1, 2.2]
@@ -891,6 +903,12 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                             "type": "text/plain",
                         },
                     },
+                    "links": [{
+                        'href': 'https://www.example.com/described-by-1',
+                        'rel': 'describedBy',
+                        'title': 'My title 1',
+                        'hreflang': 'en',
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [1.1, 1.2]
                     },
@@ -909,6 +927,12 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                             "type": "text/plain",
                         },
                     },
+                    "links": [{
+                        'href': 'https://www.example.com/described-by-2',
+                        'rel': 'describedBy',
+                        'title': 'My title 2',
+                        'hreflang': 'en',
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [2.1, 2.2]
                     },

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -840,6 +840,18 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             "features": [
                 {
                     "id": "item-1",
+                    "assets": [{
+                        "id": "asset-1.txt",
+                        "title": "My title 1",
+                        "description": "My description 1",
+                        "type": "text/plain",
+                        "href": "asset-1",
+                        "roles": ["myrole"],
+                        "geoadmin:variant": "komb",
+                        "geoadmin:lang": "de",
+                        "proj:epsg": 2056,
+                        "gsd": 2.5
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [1.1, 1.2]
                     },
@@ -849,6 +861,18 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                 },
                 {
                     "id": "item-2",
+                    "assets": [{
+                        "id": "asset-2.txt",
+                        "title": "My title 2",
+                        "description": "My description 2",
+                        "type": "text/plain",
+                        "href": "asset-2",
+                        "roles": ["myrole"],
+                        "geoadmin:variant": "komb",
+                        "geoadmin:lang": "de",
+                        "proj:epsg": 2056,
+                        "gsd": 2.5
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [2.1, 2.2]
                     },
@@ -874,9 +898,50 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
 
         self.assertStatusCode(201, response)
 
+        expected = {
+            "features": [
+                {
+                    "id": "item-1",
+                    "assets": {
+                        "asset-1.txt": {
+                            "gsd": 2.5,
+                            "geoadmin:variant": "komb",
+                            "href": "http://testserver/asset-1",
+                            "proj:epsg": 2056,
+                            "type": "text/plain",
+                        },
+                    },
+                    "geometry": {
+                        "type": "Point", "coordinates": [1.1, 1.2]
+                    },
+                    "properties": {
+                        "datetime": "2018-02-12T23:20:50Z",
+                    },
+                },
+                {
+                    "id": "item-2",
+                    "assets": {
+                        "asset-2.txt": {
+                            "gsd": 2.5,
+                            "geoadmin:variant": "komb",
+                            "href": "http://testserver/asset-2",
+                            "proj:epsg": 2056,
+                            "type": "text/plain",
+                        },
+                    },
+                    "geometry": {
+                        "type": "Point", "coordinates": [2.1, 2.2]
+                    },
+                    "properties": {
+                        "datetime": "2019-01-13T13:30:00Z",
+                    },
+                },
+            ]
+        }
+
         for actual_item in response_json["features"]:
             expected_item = [
-                item for item in self.payload["features"] if item["id"] == actual_item["id"]
+                item for item in expected["features"] if item["id"] == actual_item["id"]
             ][0]
             self.check_stac_item(expected_item, actual_item, collection=collection_name)
 

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -953,6 +953,17 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         collection_name = self.collection["name"]
         self.factory.create_item_sample(self.collection.model, sample='item-1', db_create=True)
 
+        # Perform a meaningless GET request in order to have a session from authentication.
+        #
+        # If we don't do this, the authentication middleware catches the HTTP 400
+        # error while trying to set up a session. The session initialization then
+        # fails with a HTML error message (not a JSON) complaining that
+        #
+        #     "The request's session was deleted before the request completed.".
+        #
+        # This is a workaround that we might be able to replace with a more proper solution.
+        self.client.get(path=f'/{STAC_BASE_V}/collections/{collection_name}/items')
+
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',
             data=self.payload,

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -978,7 +978,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             "{'features': [ErrorDetail(string='This field is required.', code='required')]}"
         )
 
-    def test_items_endpoint_post_returns_200_if_no_items_provided(self):
+    def test_items_endpoint_post_returns_201_if_no_items_provided(self):
         collection_name = self.collection["name"]
         payload = {"features": []}
         response = self.client.post(
@@ -988,7 +988,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         )
         response_json = response.json()
 
-        self.assertStatusCode(200, response)
+        self.assertStatusCode(201, response)
         self.assertEqual(response_json, payload)
 
 

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -948,7 +948,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             # So we only inspect the second line.
             response_json["description"].split("\n")[1],
             (
-                f"DETAIL:  Key (collection_id, name)=({self.collection.model.id}, item-1)"
+                f"DETAIL:  Key (collection_id, name)=({self.collection.model.id}, item-1) "
                 f"already exists."
             )
         )
@@ -1037,7 +1037,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         self.assertEqual(
             response_json["description"],
             (
-                f"{{'features': [ErrorDetail(string='More than {max_n_items} features',"
+                f"{{'features': [ErrorDetail(string='More than {max_n_items} features', "
                 f"code='invalid')]}}"
             )
         )

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -947,7 +947,10 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
             #
             # So we only inspect the second line.
             response_json["description"].split("\n")[1],
-            f"DETAIL:  Key (collection_id, name)=({self.collection.model.id}, item-1) already exists."
+            (
+                f"DETAIL:  Key (collection_id, name)=({self.collection.model.id}, item-1)"
+                f"already exists."
+            )
         )
 
     def test_items_endpoint_post_returns_404_if_collection_does_not_exist(self):
@@ -1033,7 +1036,10 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
         self.assertEqual(response_json["code"], 400)
         self.assertEqual(
             response_json["description"],
-            f"{{'features': [ErrorDetail(string='More than {max_n_items} features', code='invalid')]}}"
+            (
+                f"{{'features': [ErrorDetail(string='More than {max_n_items} features',"
+                f"code='invalid')]}}"
+            )
         )
 
     def test_items_endpoint_post_returns_400_if_no_idempotency_key(self):

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -17,7 +17,6 @@ from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory
 
-from stac_api.models import get_asset_path
 from stac_api.serializers.collection import CollectionSerializer
 from stac_api.serializers.item import AssetSerializer
 from stac_api.serializers.item import ItemListSerializer
@@ -679,6 +678,18 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             "features": [
                 {
                     "id": "item-1",
+                    "assets": [{
+                        "id": "asset-1.txt",
+                        "title": "My title 1",
+                        "description": "My description 1",
+                        "type": "text/plain",
+                        "href": "asset-1",
+                        "roles": ["myrole"],
+                        "geoadmin:variant": "komb",
+                        "geoadmin:lang": "de",
+                        "proj:epsg": 2056,
+                        "gsd": 2.5
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [1.1, 1.2]
                     },
@@ -688,6 +699,18 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                 },
                 {
                     "id": "item-2",
+                    "assets": [{
+                        "id": "asset-2.txt",
+                        "title": "My title 2",
+                        "description": "My description 2",
+                        "type": "text/plain",
+                        "href": "asset-2",
+                        "roles": ["myrole"],
+                        "geoadmin:variant": "komb",
+                        "geoadmin:lang": "de",
+                        "proj:epsg": 2056,
+                        "gsd": 2.5
+                    }],
                     "geometry": {
                         "type": "Point", "coordinates": [2.1, 2.2]
                     },
@@ -717,19 +740,43 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             "features": [
                 {
                     "name": "item-1",
+                    "assets": [{
+                        "name": "asset-1.txt",
+                        "title": "My title 1",
+                        "media_type": "text/plain",
+                        "file": "asset-1",
+                        "description": "My description 1",
+                        "roles": ["myrole"],
+                        "eo_gsd": 2.5,
+                        "proj_epsg": 2056,
+                        "geoadmin_variant": "komb",
+                        "geoadmin_lang": "de",
+                    },],
                     "geometry": Point(1.1, 1.2, srid=4326),
                     "properties_datetime":
                         datetime(2018, 2, 12, 23, 20, 50, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
                 },
                 {
                     "name": "item-2",
+                    "assets": [{
+                        "name": "asset-2.txt",
+                        "title": "My title 2",
+                        "media_type": "text/plain",
+                        "file": "asset-2",
+                        "description": "My description 2",
+                        "roles": ["myrole"],
+                        "eo_gsd": 2.5,
+                        "proj_epsg": 2056,
+                        "geoadmin_variant": "komb",
+                        "geoadmin_lang": "de",
+                    },],
                     "geometry": Point(2.1, 2.2, srid=4326),
                     "properties_datetime":
                         datetime(2019, 1, 13, 13, 30, 0, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
                 },
             ]
         }
-        self.assertEqual(expected, actual)
+        self.assertDictEqual(expected, actual)
 
     def test_itemlistserializer_serializes_list_of_items_as_expected(self):
         request_mocker = request_with_resolver(
@@ -743,7 +790,25 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
 
         actual = serializer.data
 
-        expected = self.payload
+        expected = self.payload.copy()
+        expected["features"][0]["assets"] = {
+            "asset-1.txt": {
+                "gsd": 2.5,
+                "geoadmin:variant": "komb",
+                "href": "http://testserver/asset-1",
+                "proj:epsg": 2056,
+                "type": "text/plain",
+            },
+        }
+        expected["features"][1]["assets"] = {
+            "asset-2.txt": {
+                "gsd": 2.5,
+                "geoadmin:variant": "komb",
+                "href": "http://testserver/asset-2",
+                "proj:epsg": 2056,
+                "type": "text/plain",
+            },
+        }
         for item_actual, item_expected in zip(actual["features"], expected["features"]):
             self.check_stac_item(item_expected, item_actual, self.collection.model.name)
 

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -7,15 +7,17 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from pprint import pformat
+import zoneinfo
 
 from django.urls import resolve
+from django.contrib.gis.geos import Point
 
 from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory
 
 from stac_api.serializers.collection import CollectionSerializer
-from stac_api.serializers.item import AssetSerializer
+from stac_api.serializers.item import AssetSerializer, ItemListSerializer
 from stac_api.serializers.item import ItemSerializer
 from stac_api.serializers.item import ItemsPropertiesSerializer
 from stac_api.utils import get_asset_path
@@ -662,6 +664,85 @@ class ItemsPropertiesSerializerTestCase(unittest.TestCase):
         self.assertEqual(actual["forecast:duration"], "P0DT04H00M00S")
         self.assertEqual(actual["forecast:variable"], data["forecast:variable"])
         self.assertEqual(actual["forecast:perturbed"], data["forecast:perturbed"])
+
+
+class ItemListDeserializationTestCase(StacBaseTestCase):
+
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=invalid-name
+        cls.data_factory = Factory()
+        cls.collection = cls.data_factory.create_collection_sample(db_create=True)
+        cls.payload = {
+            "features": [
+                {
+                    "id": "item-1",
+                    "geometry": {
+                        "type": "Point", "coordinates": [1.1, 1.2]
+                    },
+                    "properties": {
+                        "datetime": "2018-02-12T23:20:50Z",
+                    },
+                },
+                {
+                    "id": "item-2",
+                    "geometry": {
+                        "type": "Point", "coordinates": [2.1, 2.2]
+                    },
+                    "properties": {
+                        "datetime": "2019-01-13T13:30:00Z",
+                    },
+                },
+            ]
+        }
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_itemlistserializer_deserializes_list_of_items_as_expected(self):
+        serializer = ItemListSerializer(data=self.payload)
+
+        self.assertTrue(serializer.is_valid())
+
+        actual = serializer.validated_data
+
+        # ignore None values which are added by default
+        actual["features"] = [{
+            k: v for k, v in item.items() if v is not None
+        } for item in actual["features"]]
+
+        expected = {
+            "features": [
+                {
+                    "name": "item-1",
+                    "geometry": Point(1.1, 1.2, srid=4326),
+                    "properties_datetime":
+                        datetime(2018, 2, 12, 23, 20, 50, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
+                },
+                {
+                    "name": "item-2",
+                    "geometry": Point(2.1, 2.2, srid=4326),
+                    "properties_datetime":
+                        datetime(2019, 1, 13, 13, 30, 0, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
+                },
+            ]
+        }
+        self.assertEqual(expected, actual)
+
+    def test_itemlistserializer_serializes_list_of_items_as_expected(self):
+        request_mocker = request_with_resolver(
+            f'/{STAC_BASE_V}/collections/{self.collection.model.name}/items'
+        )
+        serializer = ItemListSerializer(data=self.payload, context={'request': request_mocker})
+
+        self.assertTrue(serializer.is_valid())
+
+        serializer.save(collection=self.collection.model)
+
+        actual = serializer.data
+
+        expected = self.payload
+        for item_actual, item_expected in zip(actual["features"], expected["features"]):
+            self.check_stac_item(item_expected, item_actual, self.collection.model.name)
 
 
 class AssetSerializationTestCase(StacBaseTestCase):

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -760,7 +760,6 @@ components:
                 $ref: "#/components/schemas/assetType"
           - $ref: "#/components/schemas/assetBase"
       type: object
-      readOnly: true
       example:
         smr50-263-2016-2056-kgrs-2.5.tiff:
           file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -1007,7 +1007,6 @@ components:
                 $ref: "#/components/schemas/assetType"
           - $ref: "#/components/schemas/assetBase"
       type: object
-      readOnly: true
       example:
         smr50-263-2016-2056-kgrs-2.5.tiff:
           file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -1111,7 +1111,6 @@ components:
                 $ref: "#/components/schemas/assetType"
           - $ref: "#/components/schemas/assetBase"
       type: object
-      readOnly: true
       example:
         smr50-263-2016-2056-kgrs-2.5.tiff:
           file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -2012,7 +2012,7 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
-    collectionUpsertItems:
+    collectionCreateItems:
       type: object
       properties:
         features:
@@ -3167,43 +3167,6 @@ paths:
           $ref: "#/components/responses/PreconditionFailed"
         "500":
           $ref: "#/components/responses/ServerError"
-    post:
-      tags:
-        - Data Management
-      summary: Bulk update or create features
-      description: |
-        Create or update ("upsert") multiple features in a collection at once.
-        If a feature already exists, it is updated with the differences to the feature in the request.
-
-        Equivalently, one could create the features and their corresponding assets with individual API calls.
-        Uploading features that belong together in bulks has two advantages:
-
-           1. Less communication overhead than individual calls.
-           2. Less partial uploads to mess with: Either all features are uploaded or none.
-
-        A maximum of 100 features per call is allowed.
-      operationId: bulkUpsertItems
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/IdempotencyKey"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/collectionUpsertItems"
-      responses:
-        "200":
-          description: Collection has been successfully updated.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/collectionUpsertItems"
-        "403":
-          $ref: "#/components/responses/PermissionDenied"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items:
     get:
       description: >-
@@ -3232,6 +3195,44 @@ paths:
       summary: Fetch features
       tags:
         - Data
+    post:
+      tags:
+        - Data Management
+      summary: Bulk create features
+      description: |
+        Create multiple features in a collection at once.
+
+        Equivalently, one could create the features and their corresponding assets with individual API calls.
+        Uploading features that belong together in bulks has two advantages:
+
+           1. Less communication overhead than individual calls.
+           2. Less partial uploads to mess with: Either all features are uploaded or none is.
+
+        A maximum of 100 features per call is allowed.
+      operationId: bulkCreateItems
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/collectionCreateItems"
+      responses:
+        "201":
+          description: Features and assets have been successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/collectionCreateItems"
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}:
     get:
       description: >-

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -57,7 +57,7 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
-    collectionUpsertItems:
+    collectionCreateItems:
       type: object
       properties:
         features:

--- a/spec/transaction/paths.yaml
+++ b/spec/transaction/paths.yaml
@@ -107,43 +107,6 @@ paths:
           $ref: "../components/responses.yaml#/components/responses/PreconditionFailed"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
-    post:
-      tags:
-        - Data Management
-      summary: Bulk update or create features
-      description: |
-        Create or update ("upsert") multiple features in a collection at once.
-        If a feature already exists, it is updated with the differences to the feature in the request.
-
-        Equivalently, one could create the features and their corresponding assets with individual API calls.
-        Uploading features that belong together in bulks has two advantages:
-
-           1. Less communication overhead than individual calls.
-           2. Less partial uploads to mess with: Either all features are uploaded or none.
-
-        A maximum of 100 features per call is allowed.
-      operationId: bulkUpsertItems
-      parameters:
-        - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-        - $ref: "./components/parameters.yaml#/components/parameters/IdempotencyKey"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "./components/schemas.yaml#/components/schemas/collectionUpsertItems"
-      responses:
-        "200":
-          description: Collection has been successfully updated.
-          content:
-            application/json:
-              schema:
-                $ref: "./components/schemas.yaml#/components/schemas/collectionUpsertItems"
-        "403":
-          $ref: "../components/responses.yaml#/components/responses/PermissionDenied"
-        "404":
-          $ref: "../components/responses.yaml#/components/responses/NotFound"
-        "500":
-          $ref: "../components/responses.yaml#/components/responses/ServerError"
   "/collections/{collectionId}/assets":
     get:
       description: >-
@@ -294,6 +257,46 @@ paths:
           $ref: "../components/responses.yaml#/components/responses/NotFound"
         "412":
           $ref: "../components/responses.yaml#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "../components/responses.yaml#/components/responses/ServerError"
+
+  "/collections/{collectionId}/items":
+    post:
+      tags:
+        - Data Management
+      summary: Bulk create features
+      description: |
+        Create multiple features in a collection at once.
+
+        Equivalently, one could create the features and their corresponding assets with individual API calls.
+        Uploading features that belong together in bulks has two advantages:
+
+           1. Less communication overhead than individual calls.
+           2. Less partial uploads to mess with: Either all features are uploaded or none is.
+
+        A maximum of 100 features per call is allowed.
+      operationId: bulkCreateItems
+      parameters:
+        - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
+        - $ref: "./components/parameters.yaml#/components/parameters/IdempotencyKey"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./components/schemas.yaml#/components/schemas/collectionCreateItems"
+      responses:
+        "201":
+          description: Features and assets have been successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "./components/schemas.yaml#/components/schemas/collectionCreateItems"
+        "400":
+          $ref: "../components/responses.yaml#/components/responses/InvalidParameter"
+        "403":
+          $ref: "../components/responses.yaml#/components/responses/PermissionDenied"
+        "404":
+          $ref: "../components/responses.yaml#/components/responses/NotFound"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
 


### PR DESCRIPTION
Add a new POST endpoint to `collections/{collectionId}/items` that lets you create multiple Items together with their assets at in one go.

Explicitly handled HTTP return status:

- 201 Created: Successful creation
  (!) Even for empty list of items
- 400 Bad Request:
   - Payload malformed
   - Item exists already
   - Over 100 items
   - No or empty HTTP header parameter "Idempotency-Key"
- 404 Not Found: Collection not found

Example payload:

```json
{
  "features": [
    {
      "id": "feature-1",
      "links": [...],
      "assets": {
        "asset-1-1.txt": {...},
        "asset-1-2.txt": {...},
      },
      "geometry": {...},
      "properties": {...},
      "stac_extensions": [...]
    },
    {
      "id": "feature-2",
      "links": [...],
      "assets": {
        "asset-2-1.txt": {...},
        "asset-2-2.txt": {...},
      },
      "geometry": {...},
      "properties": {...},
      "stac_extensions": [...]
    }
  ]
}
```

The API specs:

1. Build with
   ```sh
   make build-specs
   ```

2. Serve with
   
   ```sh
   make serve-specs
   ```

3. In the API specs, navigate to Data Management > "Bulk create features":

    http://0.0.0.0:8090/apitransactional.html#tag/Data-Management/operation/bulkCreateItems

![pb-1279-api-specs-bulkCreateItems](https://github.com/user-attachments/assets/1d280d7e-bc1b-409b-9faf-5b9180958575)


Design decisions:

1. **Only allow bulk creation, not updating.** This is because creation is probably the main use case. Including updates would be possible but it would make the code even more complicated for no real performance gain over individual requests. For the creation of several objects at once we can make use of Django's [`bulk_create()`](https://docs.djangoproject.com/en/5.1/ref/models/querysets/#bulk-create). For the update, however, we cannot just use [`bulk_update()`](https://docs.djangoproject.com/en/5.1/ref/models/querysets/#bulk-update) as we don't necessarily update the same field for all items. So we would have to resort to an iteration, finding out what actually changed. We agreed to leave out the update functionality and check with MeteoSchweiz how this fits their workflow in practice.
2. **Assets as part of an item are set as writeable**, before they were read-only. So before you could only create them individually, now you can create them as part of an item. This affects other endpoints but we agreed that this would not be a problem.
3. **Header parameter `"Idempotency-Key"`**: We require it even though it's not used currently in order to have a more stable interface.
4. **Response format**: `{"code": 1234, "description": "..."}` as it's given in the other API spec examples.

Implementation details:

1. Serializer `ItemListSerializer`
   1. `to_representation()`: Not sure if I'm doing something wrong but for a nested serializer you apparently need to explicitly tell it to wrap the items into a dictionary.
   2. `update()`: The linter forced me to implement this. As we currently don't support updating, I mark this with a `NotImplementedError`.
   3. `validate()`: I wanted to do this a "[field-level validation](https://www.django-rest-framework.org/api-guide/serializers/#field-level-validation)". So only validate the "features" field with something like `validate_features()` instead of a whole `validate()`. But as far as I understand, this does not allow me to call `super().validate_features()`. So I still use `validate()`.
2. Smaller changes:
   1. The update/creation of links is copied from somewhere similar but I must admit that I don't fully see through this. Please review carefully.
   2. `validate_json_payload()`: For reasons I don't understand the `initial_data` (holding the raw input payload) is not properly set for a nested serializer, like `ItemListSerializer` is. Resorting to the dedicated `Serializer.get_initial()` helped for the new serializer but it broke others. In [the DRF docs](https://www.django-rest-framework.org/api-guide/serializers/#accessing-the-initial-data-and-instance) it says "If the data keyword argument is not passed then the .initial_data attribute will not exist.". So we check for that.
   3. `ItemsUnImplementedEndpointTestCase`: This was introduced explictly in [BGDIINF_SB-1725](https://jira.swisstopo.ch/browse/BGDIINF_SB-1725) in 2021. Felt safe to remove now that this endpoint exists.
3. API Specs: Had to be adapted since [PB-1279](https://jira.swisstopo.ch/browse/PB-1279) because we changed some details.
   1. Move the endpoint from `collections/{collectionId}` to `collections/{collectionId}/items`. So it mirrors the "[Fetch features](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data/operation/getFeatures)" GET endpoint with a payload like `{"features": [item1, item2, ...]}`.
   2. Include "assets": Change `components.schemas.itemAssets.readOnly` to `false`. This affects many other endpoints. Curiously, the change is not visible in any of their payload examples because the examples are hard-coded at endpoint level and don't rely on their components.
   3. Adapt the ID of the endpoint from `collectionUpsertItems` to `collectionCreateItems` as we no longer update.

CC @schtibe 
