### PR TITLE
PB-1279: Fix test

### DIFF
--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -809,13 +809,12 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
 
 
 @override_settings(FEATURE_AUTH_ENABLE_APIGW=True)
-class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
+class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.factory = Factory()
-        cls.collection = cls.factory.create_collection_sample(db_create=True)
-        cls.payload = {
+    def setUp(self):
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample(db_create=True)
+        self.payload = {
             "features": [
                 {
                     "id": "item-1",
@@ -873,8 +872,6 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
                 },
             ]
         }
-
-    def setUp(self):
         self.client = Client(headers=get_auth_headers())
 
     def test_items_endpoint_post_creates_given_items_as_expected(self):
@@ -952,17 +949,6 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTestCase):
     def test_items_endpoint_post_returns_400_if_item_exists_already(self):
         collection_name = self.collection["name"]
         self.factory.create_item_sample(self.collection.model, sample='item-1', db_create=True)
-
-        # Perform a meaningless GET request in order to have a session from authentication.
-        #
-        # If we don't do this, the authentication middleware catches the HTTP 400
-        # error while trying to set up a session. The session initialization then
-        # fails with a HTML error message (not a JSON) complaining that
-        #
-        #     "The request's session was deleted before the request completed.".
-        #
-        # This is a workaround that we might be able to replace with a more proper solution.
-        self.client.get(path=f'/{STAC_BASE_V}/collections/{collection_name}/items')
 
         response = self.client.post(
             path=f'/{STAC_BASE_V}/collections/{collection_name}/items',


### PR DESCRIPTION
CC @boecklic 

Turns out this only happens during tests because of django wrapping the whole test in a transaction:

```
START TRANSACTION
    SAVE ITEM --> IntegrityError because of existing unique constraint
    SAVE SESSION --> DatabaseError because of an error occured in the current transaction
END TRANSACTION
```

Using a `TransactionalTestCase` instead of a `TestCase` solves the issue.

Posting outside works as expected:
```bash
curl \
  --include \
  --request POST \
  --header "Geoadmin-Username: apiuser" \
  --header "Geoadmin-Authenticated: true" \
  --header "Idempotency-Key: abc-123" \
  --url http://localhost:8000/api/stac/v1/collections/test/items \
  --header 'Content-Type: application/json' \
  --data '{
    "features": [{
        "id": "test.geojson",
        "assets": [{
            "id": "asset-1.txt",
            "title": "My title 1",
            "description": "My description 1",
            "type": "text/plain",
            "href": "asset-1",
            "roles": ["myrole"],
            "geoadmin:variant": "komb",
            "geoadmin:lang": "de",
            "proj:epsg": 2056,
            "gsd": 2.5
        }],
        "links": [{
            "href": "https://www.example.com/described-by-1",
            "rel": "describedBy",
            "title": "My title 1",
            "hreflang": "en"
        }],
        "geometry": {
            "type": "Point",
            "coordinates": [1.1, 1.2]
        },
        "properties": {"datetime": "2018-02-12T23:20:50Z"}
    }]
}'
```

Results in:
```bash
{"code":400,"description":"duplicate key value violates unique constraint \"stac_api_item_collection_id_name_78fbc154_uniq\"\nDETAIL:  Key (collection_id, name)=(267, test.geojson) already exists.\n"}
```