### PR TITLE
PB-1454: Disable ApiGatewayMiddleware for API calls

### DIFF
--- a/app/middleware/api_gateway_middleware.py
+++ b/app/middleware/api_gateway_middleware.py
@@ -13,12 +13,18 @@ class ApiGatewayMiddleware(PersistentRemoteUserMiddleware):
         if not settings.FEATURE_AUTH_ENABLE_APIGW:
             return None
 
+        if request.path.startswith(f'/{settings.STAC_BASE}/v'):
+            # API authentication is only done using ApiGatewayAuthentication to avoid creating a new
+            # session with each request
+            return None
+
         api_gateway.validate_username_header(request)
         return super().process_request(request)
 
 
 class ApiGatewayUserBackend(RemoteUserBackend):
-    """ This backend is to be used in conjunction with the ``ApiGatewayMiddleware`.
+    """ This backend is to be used in conjunction with the ``ApiGatewayMiddleware` and the
+    ``ApiGatewayAuthentication``.
 
     Until proper authorization is implemented, all remote users authenticated via API Gateway
     headers are treated as superusers.

--- a/app/tests/tests_09/test_geoadmin_header_auth.py
+++ b/app/tests/tests_09/test_geoadmin_header_auth.py
@@ -62,6 +62,7 @@ class GeoadminHeadersAuthForPutEndpointTestCase(StacBaseTestCase):
             headers=headers,
         )
         self.assertStatusCode(expected_response_code, response)
+        self.assertNotIn("sessionid", self.client.cookies, "Header auth created a session")
 
         if 200 <= expected_response_code < 300:
             self.check_stac_collection(sample.json, response.json())

--- a/app/tests/tests_10/test_geoadmin_header_auth.py
+++ b/app/tests/tests_10/test_geoadmin_header_auth.py
@@ -62,6 +62,7 @@ class GeoadminHeadersAuthForPutEndpointTestCase(StacBaseTestCase):
             headers=headers,
         )
         self.assertStatusCode(expected_response_code, response)
+        self.assertNotIn("sessionid", self.client.cookies, "Header auth created a session")
 
         if 200 <= expected_response_code < 300:
             self.check_stac_collection(sample.json, response.json())


### PR DESCRIPTION
`ApiGatewayMiddleware` creates a new session for every valid header it finds, which allows admin UI users to login by providing once a valid header and then provide the session cookie.

For API request, authentication is done by `ApiGatewayAuthentication`, but `ApiGatewayMiddleware` still runs on every request and creates therefore a new session with every new request (with a valid header).

This PR disables `ApiGatewayMiddleware` for all API calls (`/api/stac/v`).