### PR TITLE
update all paths from v0.9 to v1

### DIFF
--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -151,23 +151,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -345,13 +345,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -368,13 +368,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -706,13 +706,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -729,15 +729,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -824,9 +824,9 @@ components:
         An array of links. Can be used for pagination, e.g. by providing a link with the `next`
         relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -836,9 +836,9 @@ components:
         An array of links. Can be used for pagination, e.g. by providing a link with the `next`
         relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -222,23 +222,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections
@@ -625,13 +625,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -648,13 +648,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -954,13 +954,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -976,15 +976,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -1069,9 +1069,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -1080,9 +1080,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -265,23 +265,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections
@@ -419,7 +419,7 @@ components:
                 description: >-
                   The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                     rel: parent
             required:
               - code
@@ -729,13 +729,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -752,13 +752,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -1058,13 +1058,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -1080,15 +1080,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -1173,9 +1173,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -1184,9 +1184,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}
@@ -1979,15 +1979,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     collectionWrite:
       title: collection
@@ -2061,15 +2061,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     assetWriteExternalAsset:
       title: Asset
@@ -2114,15 +2114,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     mediaTypeWrite:
       type: string
@@ -2280,7 +2280,7 @@ components:
             $ref: "#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
     assetUpload:
       title: AssetUpload
       type: object
@@ -2464,7 +2464,7 @@ components:
             $ref: "#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
     status:
       title: Status
       description: Status of the Asset's multipart upload.

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -57,7 +57,7 @@ components:
                 description: >-
                   The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                     rel: parent
             required:
               - code

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -25,15 +25,15 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     collectionWrite:
       title: collection
@@ -107,15 +107,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     assetWriteExternalAsset:
       title: Asset
@@ -160,15 +160,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     mediaTypeWrite:
       type: string
@@ -329,7 +329,7 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
     assetUpload:
       title: AssetUpload
       type: object
@@ -514,7 +514,7 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
     status:
       title: Status
       description: Status of the Asset's multipart upload.


### PR DESCRIPTION
We still have many references (mostly in examples) to `v0.9` in the spec. They are all replaced with v1 with this PR