### PR TITLE
PB-1478 made asset deserialization equivalent to serialization

### DIFF
--- a/app/stac_api/serializers/utils.py
+++ b/app/stac_api/serializers/utils.py
@@ -325,6 +325,30 @@ class DictSerializer(serializers.ListSerializer):
         objects = super().to_representation(data)
         return {obj.pop(self.key_identifier): obj for obj in objects}
 
+    def to_internal_value(self, data):
+        '''Convert the dict back to a list
+
+        The ListSerializer expects a list and not a dict, hence we have to
+        convert
+
+            {
+                'object1': {'description': 'This is object 1'},
+                'object2': {'description': 'This is object 2'}
+            }
+
+        back into a list
+
+            [{
+                    'id': 'object1',
+                    'description': 'This is object 1'
+                }, {
+                    'id': 'object2',
+                    'description': 'This is object 2'
+            }]
+        '''
+        data_as_list = [value | {self.key_identifier: key} for key, value in data.items()]
+        return super().to_internal_value(data_as_list)
+
     @property
     def data(self):
         ret = super(serializers.ListSerializer, self).data

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -818,18 +818,19 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
             "features": [
                 {
                     "id": "item-1",
-                    "assets": [{
-                        "id": "asset-1.txt",
-                        "title": "My title 1",
-                        "description": "My description 1",
-                        "type": "text/plain",
-                        "href": "asset-1",
-                        "roles": ["myrole"],
-                        "geoadmin:variant": "komb",
-                        "geoadmin:lang": "de",
-                        "proj:epsg": 2056,
-                        "gsd": 2.5
-                    }],
+                    "assets": {
+                        "asset-1.txt": {
+                            "title": "My title 1",
+                            "description": "My description 1",
+                            "type": "text/plain",
+                            "href": "asset-1",
+                            "roles": ["myrole"],
+                            "geoadmin:variant": "komb",
+                            "geoadmin:lang": "de",
+                            "proj:epsg": 2056,
+                            "gsd": 2.5
+                        }
+                    },
                     "links": [{
                         'href': 'https://www.example.com/described-by-1',
                         'rel': 'describedBy',
@@ -845,18 +846,19 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                 },
                 {
                     "id": "item-2",
-                    "assets": [{
-                        "id": "asset-2.txt",
-                        "title": "My title 2",
-                        "description": "My description 2",
-                        "type": "text/plain",
-                        "href": "asset-2",
-                        "roles": ["myrole"],
-                        "geoadmin:variant": "komb",
-                        "geoadmin:lang": "de",
-                        "proj:epsg": 2056,
-                        "gsd": 2.5
-                    }],
+                    "assets": {
+                        "asset-2.txt": {
+                            "title": "My title 2",
+                            "description": "My description 2",
+                            "type": "text/plain",
+                            "href": "asset-2",
+                            "roles": ["myrole"],
+                            "geoadmin:variant": "komb",
+                            "geoadmin:lang": "de",
+                            "proj:epsg": 2056,
+                            "gsd": 2.5
+                        }
+                    },
                     "links": [{
                         'href': 'https://www.example.com/described-by-2',
                         'rel': 'describedBy',
@@ -1025,18 +1027,19 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
         max_n_items = 100
         items = [{
             "id": f"item-{i}",
-            "assets": [{
-                "id": f"asset-{i}.txt",
-                "title": f"My title {i}",
-                "description": f"My description {i}",
-                "type": "text/plain",
-                "href": f"asset-{i}",
-                "roles": ["myrole"],
-                "geoadmin:variant": "komb",
-                "geoadmin:lang": "de",
-                "proj:epsg": 2056,
-                "gsd": 2.5
-            }],
+            "assets": {
+                f"asset-{i}.txt": {
+                    "title": f"My title {i}",
+                    "description": f"My description {i}",
+                    "type": "text/plain",
+                    "href": f"asset-{i}",
+                    "roles": ["myrole"],
+                    "geoadmin:variant": "komb",
+                    "geoadmin:lang": "de",
+                    "proj:epsg": 2056,
+                    "gsd": 2.5
+                }
+            },
             "geometry": {
                 "type": "Point", "coordinates": [1.1, 1.2]
             },

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -678,18 +678,19 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             "features": [
                 {
                     "id": "item-1",
-                    "assets": [{
-                        "id": "asset-1.txt",
-                        "title": "My title 1",
-                        "description": "My description 1",
-                        "type": "text/plain",
-                        "href": "asset-1",
-                        "roles": ["myrole"],
-                        "geoadmin:variant": "komb",
-                        "geoadmin:lang": "de",
-                        "proj:epsg": 2056,
-                        "gsd": 2.5
-                    }],
+                    "assets": {
+                        "asset-1.txt": {
+                            "title": "My title 1",
+                            "description": "My description 1",
+                            "type": "text/plain",
+                            "href": "asset-1",
+                            "roles": ["myrole"],
+                            "geoadmin:variant": "komb",
+                            "geoadmin:lang": "de",
+                            "proj:epsg": 2056,
+                            "gsd": 2.5
+                        }
+                    },
                     "geometry": {
                         "type": "Point", "coordinates": [1.1, 1.2]
                     },
@@ -699,18 +700,19 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                 },
                 {
                     "id": "item-2",
-                    "assets": [{
-                        "id": "asset-2.txt",
-                        "title": "My title 2",
-                        "description": "My description 2",
-                        "type": "text/plain",
-                        "href": "asset-2",
-                        "roles": ["myrole"],
-                        "geoadmin:variant": "komb",
-                        "geoadmin:lang": "de",
-                        "proj:epsg": 2056,
-                        "gsd": 2.5
-                    }],
+                    "assets": {
+                        "asset-2.txt": {
+                            "title": "My title 2",
+                            "description": "My description 2",
+                            "type": "text/plain",
+                            "href": "asset-2",
+                            "roles": ["myrole"],
+                            "geoadmin:variant": "komb",
+                            "geoadmin:lang": "de",
+                            "proj:epsg": 2056,
+                            "gsd": 2.5
+                        }
+                    },
                     "geometry": {
                         "type": "Point", "coordinates": [2.1, 2.2]
                     },
@@ -736,6 +738,12 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             k: v for k, v in item.items() if v is not None
         } for item in actual["features"]]
 
+        # Note: we have to keep the list here for the assets
+        # since the serializer for the nested assets in his heart
+        # is a list serializer and we fool him a little with converting
+        # asset dicts to lists just before he gets to do something (see
+        # DictSerializer in serializers/utils.py) and we're just testing
+        # the serializer here and not the full chain.
         expected = {
             "features": [
                 {


### PR DESCRIPTION
nested asset deserialization accepts now the same format as the result of the serialization, i.e. a dict. This is now also compliant to the spec.

@adk-swisstopo and @asteiner-swisstopo I've put you both as reviewers, Alex initially developed but is away so I hope Adrien can review.