### PR TITLE
PB-1469: use v0.9 for large uploads from admin UI.

### DIFF
--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -126,7 +126,8 @@ async function createPresigned(md5, multi, file) {
                         'md5': md5,
                     }
                 ],
-                'file:checksum': multi,
+                'file:checksum': multi,  // v1
+                'checksum:multihash': multi,  // v0.9
             }),
         });
         if (!response.ok) {

--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -36,7 +36,7 @@ function hashValue(val) {
 async function cleanUploadsInProgress() {
     setStatus('checking for uploads in progress');
     // Get uploads in progress
-    const url = `/api/stac/v1/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads?status=in-progress`;
+    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads?status=in-progress`;
     try {
         const response = await fetch(url);
         if (!response.ok) {
@@ -60,7 +60,7 @@ async function cleanUploadsInProgress() {
 // Abort the upload by upload_id
 async function abortMultipartUpload(upload_id) {
     setStatus('aborting upload in progress');
-    const url = `/api/stac/v1/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${upload_id}/abort`;
+    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${upload_id}/abort`;
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -106,7 +106,7 @@ function handleFileFormSubmit() {
 // On success calls `uploadFile`.
 async function createPresigned(md5, multi, file) {
     setStatus(`Creating presigned url...`);
-    const url = `/api/stac/v1/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads`;
+    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads`;
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -168,7 +168,7 @@ async function uploadFile(data, file) {
 // On success redirects back to asset overview.
 async function completeMultipartUpload(data, etag) {
     setStatus(`Completing upload...`);
-    const url = `/api/stac/v1/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${data.upload_id}/complete`;
+    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${data.upload_id}/complete`;
     try {
         const response = await fetch(url, {
             method: 'POST',

--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -44,9 +44,9 @@ async function cleanUploadsInProgress() {
     try {
         const response = await fetch(url);
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status} ${response.statusText}`);
+            const responseText = await response.text();
+            throw new Error(`Response status: ${response.status} ${response.statusText} ${responseText}`);
         }
-
         const json = await response.json();
         if (json.uploads.length == 0) {
             setStatus('ready to upload');
@@ -73,9 +73,9 @@ async function abortMultipartUpload(upload_id) {
             },
         });
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status} ${response.statusText}`);
+            const responseText = await response.text();
+            throw new Error(`Response status: ${response.status} ${response.statusText} ${responseText}`);
         }
-
         setStatus('ready to upload');
     } catch (error) {
         console.log(error);
@@ -130,9 +130,9 @@ async function createPresigned(md5, multi, file) {
             }),
         });
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status} ${response.statusText}`);
+            const responseText = await response.text();
+            throw new Error(`Response status: ${response.status} ${response.statusText} ${responseText}`);
         }
-
         const json = await response.json();
         uploadFile(json, file)
     } catch (error) {
@@ -156,9 +156,9 @@ async function uploadFile(data, file) {
             body: file,
         });
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status} ${response.statusText}`);
+            const responseText = await response.text();
+            throw new Error(`Response status: ${response.status} ${response.statusText} ${responseText}`);
         }
-
         let etag = response.headers.get('ETag');
         completeMultipartUpload(data, etag)
     } catch (error) {
@@ -190,7 +190,8 @@ async function completeMultipartUpload(data, etag) {
             }),
         });
         if (!response.ok) {
-            throw new Error(`Response status: ${response.status} ${response.statusText}`);
+            const responseText = await response.text();
+            throw new Error(`Response status: ${response.status} ${response.statusText} ${responseText}`);
         }
 
         // Remove end of url path '/api/stac/admin/stac_api/asset/3/change/upload/'

--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -10,6 +10,10 @@ function setStatus(text) {
     document.getElementById('current_status').textContent = text;
 }
 
+function getAssetUploadUrlPrefix(collection, item, asset) {
+    return `/api/stac/v0.9/collections/${collection}/items/${item}/assets/${asset}/uploads`
+}
+
 function setError(text) {
     document.getElementById('error_box').style.display = 'block';
     document.getElementById('error').textContent = text;
@@ -36,7 +40,7 @@ function hashValue(val) {
 async function cleanUploadsInProgress() {
     setStatus('checking for uploads in progress');
     // Get uploads in progress
-    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads?status=in-progress`;
+    const url = getAssetUploadUrlPrefix(window.collection_name, window.item_name, window.asset_name) + '?status=in-progress';
     try {
         const response = await fetch(url);
         if (!response.ok) {
@@ -60,7 +64,7 @@ async function cleanUploadsInProgress() {
 // Abort the upload by upload_id
 async function abortMultipartUpload(upload_id) {
     setStatus('aborting upload in progress');
-    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${upload_id}/abort`;
+    const url = getAssetUploadUrlPrefix(window.collection_name, window.item_name, window.asset_name) + `/${upload_id}/abort`;
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -106,7 +110,7 @@ function handleFileFormSubmit() {
 // On success calls `uploadFile`.
 async function createPresigned(md5, multi, file) {
     setStatus(`Creating presigned url...`);
-    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads`;
+    const url = getAssetUploadUrlPrefix(window.collection_name, window.item_name, window.asset_name);
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -168,7 +172,7 @@ async function uploadFile(data, file) {
 // On success redirects back to asset overview.
 async function completeMultipartUpload(data, etag) {
     setStatus(`Completing upload...`);
-    const url = `/api/stac/v0.9/collections/${window.collection_name}/items/${window.item_name}/assets/${window.asset_name}/uploads/${data.upload_id}/complete`;
+    const url = getAssetUploadUrlPrefix(window.collection_name, window.item_name, window.asset_name) + `/${data.upload_id}/complete`;
     try {
         const response = await fetch(url, {
             method: 'POST',


### PR DESCRIPTION
In PB-1229 we started routing all STAC traffic through API Gateway which restricts the size of requests. In PB-1331 we updated the admin UI upload page to use S3 URLs for upload such that large requests don't go through API Gateway any more. This uses v1 API endpoints from Javascript. In PB-1281 we disabled session authentication for v1 endpoints, thus breaking admin UI upload page. In PB-1380 we opened v1 in PROD.

We prefer to not re-enable session authentication for v1 because disabling it later will be harder as (more) users would start relying on it. Current workaround involves uploading assets on behalf of users with our own script using the API.

This change updates the Javascript to use v0.9 API endpoints which still accept session-based authentication. This is a temporary workaround until we figure out a better long term fix that does not rely on v0.9.

I verified that, in conjunction with https://github.com/geoadmin/infra-terraform-bgdi/pull/795, I am able to upload files with the admin UI.