### PR TITLE
Added vscode setting to run unittest from vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ nose2-junit.xml
 *.orig
 
 # IDE config files
-.vscode
 *.sublime-*
 *.code*
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "app"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
Those workspace settings are required in order to make use of vscode unittest tab. This helps debugging application.