### PR TITLE
PB-929 : added Cognito username logging for requests

### DIFF
--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -51,6 +51,7 @@ filters:
       - request.method
       - request.headers
       - request.META
+      - request.user.username
     exclude_keys:
       - request.headers.Authorization
       - request.headers.Proxy-Authorization


### PR DESCRIPTION
The user's username is now logged whenever a request is made. This works for all authenticated requests which use the Geoadmin-Username (Cognito) header.

Preview : 
`'user' : { 'username' : 'apiuser' }`