### PR TITLE
PB-1469: fix charset conversion for large file upload.

### DIFF
--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -103,7 +103,7 @@ function handleFileFormSubmit() {
         hashValue(binary)
             .then(multihash => createPresigned(md5, multihash, binary))
     };
-    reader.readAsText(file);
+    reader.readAsArrayBuffer(file);
 }
 
 // Create a new asset upload to get a presigned url.

--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -98,7 +98,7 @@ function handleFileFormSubmit() {
         const binary = event.target.result;
 
         // Create md5 hash, base64 encoded
-        const md5 = CryptoJS.MD5(binary).toString(CryptoJS.enc.Base64);
+        const md5 = CryptoJS.MD5(CryptoJS.lib.WordArray.create(binary)).toString(CryptoJS.enc.Base64);
         // Create multihash and call to create presigned url
         hashValue(binary)
             .then(multihash => createPresigned(md5, multihash, binary))

--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -21,7 +21,7 @@ function setError(text) {
 
 function hashValue(val) {
     return crypto.subtle
-        .digest('SHA-256', new TextEncoder('utf-8').encode(val))
+        .digest('SHA-256', val)
         .then(h => {
             const prefix = '1220'; // for sha2-256 according to https://multiformats.io/multihash/
             let hexes = [],


### PR DESCRIPTION
There are multiple problems preventing non-ASCII files from being uploaded correctly. Specifically:
* the content of the file was converted to UTF-8 before upload;
* the content of the file was converted to UTF-8 before MD5 hashing (for S3);
* the content of the file was converted to UTF-8 before SHA-256 hashing (for STAC).

None of these conversion was appropriate and resulted in mangled file and incorrect hashes. This PR removes them.