### PR TITLE
 PB-1486: Made the Collection Asset(s) endpoint(s) public in openapi spec

### DIFF
--- a/spec/components/parameters.yaml
+++ b/spec/components/parameters.yaml
@@ -1,6 +1,13 @@
 openapi: 3.0.3
 components:
   parameters:
+    assetId:
+      name: assetId
+      in: path
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
     assetQuery:
       description: >-
         Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter

--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -69,6 +69,23 @@ components:
         selected collections that should be returned in the response, the page size.
         Each page include links to support paging (link relation `next` and/or
         `previous`).
+    CollectionAssets:
+      description: >-
+        The response is a document consisting of all assets of the collection.
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas.yaml#/components/schemas/collectionAssets"
+    CollectionAsset:
+      description: >-
+        The response is a document consisting of one asset of the collection.
+      headers:
+        ETag:
+          $ref: "./headers.yaml#/components/headers/ETag"
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas.yaml#/components/schemas/collectionAsset"
     ConformanceDeclaration:
       content:
         application/json:

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -1,6 +1,17 @@
 openapi: 3.0.3
 components:
   schemas:
+    assetId:
+      type: string
+      pattern: ^[a-z0-9.-_]+$
+      title: ID
+      description: >-
+        The asset id uniquely identifies the asset for an item
+
+
+        **Note**: `id` must be unique for the item and must be identical to the
+        filename.
+      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assetQuery:
      additionalProperties:
        $ref: "#/components/schemas/assetQueryProp"
@@ -747,6 +758,70 @@ components:
         - features
         - type
       type: object
+    collectionAsset:
+      allOf:
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              $ref: "#/components/schemas/assetId"
+            type:
+              $ref: "#/components/schemas/assetType"
+        - $ref: "#/components/schemas/assetBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
+    collectionAssets:
+      title: Assets
+      description: List of Assets attached to this collection.
+      type: object
+      required:
+        - assets
+        - links
+      properties:
+        assets:
+          items:
+            allOf:
+              - type: object
+                required:
+                  - type
+                  - id
+                properties:
+                  id:
+                    $ref: "#/components/schemas/assetId"
+                  type:
+                    $ref: "#/components/schemas/assetType"
+              - $ref: "#/components/schemas/assetBase"
+          type: array
+        links:
+          items:
+            $ref: "#/components/schemas/link"
+          type: array
+          example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     itemAssets:
       title: Assets
       description: List of Assets attached to this feature.

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -130,7 +130,51 @@ paths:
       summary: Fetch a single feature
       tags:
         - Data
+  "/collections/{collectionId}/assets":
+    get:
+      description: >-
+        Fetch collection assets of the collection with id `collectionId`.
 
+        These assets do not belong to any item.
+      operationId: getCollectionAssets
+      parameters:
+        - $ref: "./components/parameters.yaml#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "./components/responses.yaml#/components/responses/CollectionAssets"
+        "400":
+          $ref: "./components/responses.yaml#/components/responses/InvalidParameter"
+        "404":
+          $ref: "./components/responses.yaml#/components/responses/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/components/responses/ServerError"
+      summary: Fetch all collection assets for a collection
+      tags:
+        - Data
+  /collections/{collectionId}/assets/{assetId}:
+    get:
+      summary: Fetch a single collection asset
+      tags:
+        - Data
+      description: >-
+        Fetch the collection asset with id `assetId` of the collection with id `collectionId`.
+      operationId: getCollectionAsset
+      parameters:
+        - $ref: "./components/parameters.yaml#/components/parameters/collectionId"
+        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "./components/parameters.yaml#/components/parameters/IfMatch"
+        - $ref: "./components/parameters.yaml#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          $ref: "./components/responses.yaml#/components/responses/CollectionAsset"
+        "304":
+          $ref: "./components/responses.yaml#/components/responses/NotModified"
+        "404":
+          $ref: "./components/responses.yaml#/components/responses/NotFound"
+        "412":
+          $ref: "./components/responses.yaml#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "./components/responses.yaml#/components/responses/ServerError"
   /{assetObjectHref}:
     servers:
       - url: http://data.geo.admin.ch/

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -9,6 +9,13 @@ components:
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
       required: true
   parameters:
+    assetId:
+      name: assetId
+      in: path
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
     assetQuery:
       description: >-
         Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
@@ -166,6 +173,23 @@ components:
         * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
 
         The `limit` parameter may be used to control the subset of the selected collections that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
+    CollectionAssets:
+      description: >-
+        The response is a document consisting of all assets of the collection.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/collectionAssets"
+    CollectionAsset:
+      description: >-
+        The response is a document consisting of one asset of the collection.
+      headers:
+        ETag:
+          $ref: "#/components/headers/ETag"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/collectionAsset"
     ConformanceDeclaration:
       content:
         application/json:
@@ -321,6 +345,16 @@ components:
             code: 500
             description: "Internal server error"
   schemas:
+    assetId:
+      type: string
+      pattern: ^[a-z0-9.-_]+$
+      title: ID
+      description: >-
+        The asset id uniquely identifies the asset for an item
+
+
+        **Note**: `id` must be unique for the item and must be identical to the filename.
+      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assetQuery:
       additionalProperties:
         $ref: "#/components/schemas/assetQueryProp"
@@ -994,6 +1028,70 @@ components:
         - features
         - type
       type: object
+    collectionAsset:
+      allOf:
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              $ref: "#/components/schemas/assetId"
+            type:
+              $ref: "#/components/schemas/assetType"
+        - $ref: "#/components/schemas/assetBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
+    collectionAssets:
+      title: Assets
+      description: List of Assets attached to this collection.
+      type: object
+      required:
+        - assets
+        - links
+      properties:
+        assets:
+          items:
+            allOf:
+              - type: object
+                required:
+                  - type
+                  - id
+                properties:
+                  id:
+                    $ref: "#/components/schemas/assetId"
+                  type:
+                    $ref: "#/components/schemas/assetType"
+              - $ref: "#/components/schemas/assetBase"
+          type: array
+        links:
+          items:
+            $ref: "#/components/schemas/link"
+          type: array
+          example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     itemAssets:
       title: Assets
       description: List of Assets attached to this feature.
@@ -1972,6 +2070,51 @@ paths:
       summary: Fetch a single feature
       tags:
         - Data
+  /collections/{collectionId}/assets:
+    get:
+      description: >-
+        Fetch collection assets of the collection with id `collectionId`.
+
+        These assets do not belong to any item.
+      operationId: getCollectionAssets
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "#/components/responses/CollectionAssets"
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch all collection assets for a collection
+      tags:
+        - Data
+  /collections/{collectionId}/assets/{assetId}:
+    get:
+      summary: Fetch a single collection asset
+      tags:
+        - Data
+      description: >-
+        Fetch the collection asset with id `assetId` of the collection with id `collectionId`.
+      operationId: getCollectionAsset
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          $ref: "#/components/responses/CollectionAsset"
+        "304":
+          $ref: "#/components/responses/NotModified"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /{assetObjectHref}:
     servers:
       - url: http://data.geo.admin.ch/

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -9,6 +9,13 @@ components:
       example: "d01af8b8ebbf899e30095be8754b377ddb0f0ed0f7fddbc33ac23b0d1969736b"
       required: true
   parameters:
+    assetId:
+      name: assetId
+      in: path
+      description: Local identifier of an asset.
+      required: true
+      schema:
+        type: string
     assetQuery:
       description: >-
         Query for properties in assets (e.g. mediatype). Use the JSON form of the assetQueryFilter used in POST.
@@ -115,13 +122,6 @@ components:
       required: false
       schema:
         type: string
-    assetId:
-      name: assetId
-      in: path
-      description: Local identifier of an asset.
-      required: true
-      schema:
-        type: string
     uploadId:
       name: uploadId
       in: path
@@ -209,6 +209,23 @@ components:
         * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').
 
         The `limit` parameter may be used to control the subset of the selected collections that should be returned in the response, the page size. Each page include links to support paging (link relation `next` and/or `previous`).
+    CollectionAssets:
+      description: >-
+        The response is a document consisting of all assets of the collection.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/collectionAssets"
+    CollectionAsset:
+      description: >-
+        The response is a document consisting of one asset of the collection.
+      headers:
+        ETag:
+          $ref: "#/components/headers/ETag"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/collectionAsset"
     ConformanceDeclaration:
       content:
         application/json:
@@ -370,26 +387,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/assets"
-    CollectionAssets:
-      description: >-
-        The response is a document consisting of all assets of the collection.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/assets"
     Asset:
       description: >-
         The response is a document consisting of one asset of the feature.
-      headers:
-        ETag:
-          $ref: "#/components/headers/ETag"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/assetWrite"
-    CollectionAsset:
-      description: >-
-        The response is a document consisting of one asset of the collection.
       headers:
         ETag:
           $ref: "#/components/headers/ETag"
@@ -425,6 +425,16 @@ components:
               - code
               - links
   schemas:
+    assetId:
+      type: string
+      pattern: ^[a-z0-9.-_]+$
+      title: ID
+      description: >-
+        The asset id uniquely identifies the asset for an item
+
+
+        **Note**: `id` must be unique for the item and must be identical to the filename.
+      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assetQuery:
       additionalProperties:
         $ref: "#/components/schemas/assetQueryProp"
@@ -1098,6 +1108,70 @@ components:
         - features
         - type
       type: object
+    collectionAsset:
+      allOf:
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              $ref: "#/components/schemas/assetId"
+            type:
+              $ref: "#/components/schemas/assetType"
+        - $ref: "#/components/schemas/assetBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
+    collectionAssets:
+      title: Assets
+      description: List of Assets attached to this collection.
+      type: object
+      required:
+        - assets
+        - links
+      properties:
+        assets:
+          items:
+            allOf:
+              - type: object
+                required:
+                  - type
+                  - id
+                properties:
+                  id:
+                    $ref: "#/components/schemas/assetId"
+                  type:
+                    $ref: "#/components/schemas/assetType"
+              - $ref: "#/components/schemas/assetBase"
+          type: array
+        links:
+          items:
+            $ref: "#/components/schemas/link"
+          type: array
+          example:
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+              rel: self
+            - href: https://data.geo.admin.ch/api/stac/v0.9/
+              rel: root
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: parent
+            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+              rel: collection
     itemAssets:
       title: Assets
       description: List of Assets attached to this feature.
@@ -1956,16 +2030,6 @@ components:
       type: string
       format: date-time
       readOnly: true
-    assetId:
-      type: string
-      pattern: ^[a-z0-9.-_]+$
-      title: ID
-      description: >-
-        The asset id uniquely identifies the asset for an item
-
-
-        **Note**: `id` must be unique for the item and must be identical to the filename.
-      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assets:
       title: Assets
       type: object
@@ -2042,7 +2106,7 @@ components:
         file:checksum:
           $ref: "#/components/schemas/checksumMultihashReadOnly"
         roles:
-          $ref: '#/components/schemas/roles'
+          $ref: "#/components/schemas/roles"
         geoadmin:variant:
           $ref: "#/components/schemas/geoadminVariant"
         geoadmin:lang:
@@ -2095,7 +2159,7 @@ components:
         file:checksum:
           $ref: "#/components/schemas/checksumMultihashReadOnly"
         roles:
-          $ref: '#/components/schemas/roles'
+          $ref: "#/components/schemas/roles"
         geoadmin:variant:
           $ref: "#/components/schemas/geoadminVariant"
         geoadmin:lang:
@@ -3404,6 +3468,155 @@ paths:
           $ref: "#/components/responses/PreconditionFailed"
         "500":
           $ref: "#/components/responses/ServerError"
+  /collections/{collectionId}/assets:
+    get:
+      description: >-
+        Fetch collection assets of the collection with id `collectionId`.
+
+        These assets do not belong to any item.
+      operationId: getCollectionAssets
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "#/components/responses/CollectionAssets"
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch all collection assets for a collection
+      tags:
+        - Data
+  /collections/{collectionId}/assets/{assetId}:
+    get:
+      summary: Fetch a single collection asset
+      tags:
+        - Data
+      description: >-
+        Fetch the collection asset with id `assetId` of the collection with id `collectionId`.
+      operationId: getCollectionAsset
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          $ref: "#/components/responses/CollectionAsset"
+        "304":
+          $ref: "#/components/responses/NotModified"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    put:
+      summary: Update or create a collection asset
+      description: >-
+        Update or create a collection asset with Id `assetId` with a complete asset definition. If the asset doesn't exist it is then created.
+
+
+        *Note: to upload an asset file see [Collection Asset Upload Management](#tag/Collection-Asset-Upload-Management)*
+      operationId: putCollectionAsset
+      tags:
+        - Data Management
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetWrite"
+      responses:
+        "200":
+          description: Asset has been successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetWrite"
+        "201":
+          description: Asset has been newly created.
+          headers:
+            Location:
+              description: A link to the asset
+              schema:
+                type: string
+                format: url
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetWrite"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    patch:
+      summary: Update an existing collection asset by Id with a partial asset definition
+      description: >-
+        Use this method to update an existing collection asset. Requires a JSON fragment (containing the fields to be updated) to be submitted.
+
+
+        *Note: to upload an asset file see [Collection Asset Upload Management](#tag/Collection-Asset-Upload-Management)*
+      operationId: patchCollectionAsset
+      tags:
+        - Data Management
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/assetWrite"
+      responses:
+        "200":
+          description: Returns the updated Asset.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/assetWrite"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    delete:
+      summary: Delete an existing collection asset by Id
+      description: >-
+        Use this method to delete an existing collection asset.
+
+        **NOTE: Asset file on S3 will be also removed !**
+      operationId: deleteCollectionAsset
+      tags:
+        - Data Management
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+        - $ref: "#/components/parameters/assetId"
+        - $ref: "#/components/parameters/IfMatchWrite"
+      responses:
+        "200":
+          $ref: "#/components/responses/DeletedResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /{assetObjectHref}:
     servers:
       - url: http://data.geo.admin.ch/
@@ -3584,155 +3797,6 @@ paths:
       summary: Search STAC items with full-featured filtering.
       tags:
         - STAC
-  /collections/{collectionId}/assets:
-    get:
-      description: >-
-        Fetch collection assets of the collection with id `collectionId`.
-
-        These assets do not belong to any item.
-      operationId: getCollectionAssets
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-      responses:
-        "200":
-          $ref: "#/components/responses/CollectionAssets"
-        "400":
-          $ref: "#/components/responses/InvalidParameter"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/ServerError"
-      summary: Fetch all collection assets for a collection
-      tags:
-        - Data
-  /collections/{collectionId}/assets/{assetId}:
-    get:
-      description: >-
-        Fetch the collection asset with id `assetId` of the collection with id `collectionId`.
-      operationId: getCollectionAsset
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/assetId"
-        - $ref: "#/components/parameters/IfMatch"
-        - $ref: "#/components/parameters/IfNoneMatch"
-      responses:
-        "200":
-          $ref: "#/components/responses/CollectionAsset"
-        "304":
-          $ref: "#/components/responses/NotModified"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "412":
-          $ref: "#/components/responses/PreconditionFailed"
-        "500":
-          $ref: "#/components/responses/ServerError"
-      summary: Fetch a single collection asset
-      tags:
-        - Data
-    put:
-      summary: Update or create a collection asset
-      description: >-
-        Update or create a collection asset with Id `assetId` with a complete asset definition. If the asset doesn't exist it is then created.
-
-
-        *Note: to upload an asset file see [Collection Asset Upload Management](#tag/Collection-Asset-Upload-Management)*
-      operationId: putCollectionAsset
-      tags:
-        - Data Management
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/assetId"
-        - $ref: "#/components/parameters/IfMatchWrite"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/assetWrite"
-      responses:
-        "200":
-          description: Asset has been successfully updated.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/assetWrite"
-        "201":
-          description: Asset has been newly created.
-          headers:
-            Location:
-              description: A link to the asset
-              schema:
-                type: string
-                format: url
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/assetWrite"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "412":
-          $ref: "#/components/responses/PreconditionFailed"
-        "500":
-          $ref: "#/components/responses/ServerError"
-    patch:
-      summary: Update an existing collection asset by Id with a partial asset definition
-      description: >-
-        Use this method to update an existing collection asset. Requires a JSON fragment (containing the fields to be updated) to be submitted.
-
-
-        *Note: to upload an asset file see [Collection Asset Upload Management](#tag/Collection-Asset-Upload-Management)*
-      operationId: patchCollectionAsset
-      tags:
-        - Data Management
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/assetId"
-        - $ref: "#/components/parameters/IfMatchWrite"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/assetWrite"
-      responses:
-        "200":
-          description: Returns the updated Asset.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/assetWrite"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "412":
-          $ref: "#/components/responses/PreconditionFailed"
-        "500":
-          $ref: "#/components/responses/ServerError"
-    delete:
-      summary: Delete an existing collection asset by Id
-      description: >-
-        Use this method to delete an existing collection asset.
-
-        **NOTE: Asset file on S3 will be also removed !**
-      operationId: deleteCollectionAsset
-      tags:
-        - Data Management
-      parameters:
-        - $ref: "#/components/parameters/collectionId"
-        - $ref: "#/components/parameters/assetId"
-        - $ref: "#/components/parameters/IfMatchWrite"
-      responses:
-        "200":
-          $ref: "#/components/responses/DeletedResource"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "412":
-          $ref: "#/components/responses/PreconditionFailed"
-        "500":
-          $ref: "#/components/responses/ServerError"
   /collections/{collectionId}/items/{featureId}/assets:
     get:
       description: >-

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -396,7 +396,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/assetWrite"
+            $ref: "#/components/schemas/asset"
     DeletedResource:
       description: Status of the delete resource
       content:
@@ -2030,13 +2030,42 @@ components:
       type: string
       format: date-time
       readOnly: true
+    asset:
+      allOf:
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              $ref: "#/components/schemas/assetId"
+            type:
+              $ref: "#/components/schemas/assetType"
+        - $ref: "#/components/schemas/assetBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              items:
+                $ref: "#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
     assets:
       title: Assets
       type: object
       properties:
         assets:
           items:
-            $ref: "#/components/schemas/assetWrite"
+            $ref: "#/components/schemas/asset"
           type: array
         links:
           items:

--- a/spec/transaction/components/parameters.yaml
+++ b/spec/transaction/components/parameters.yaml
@@ -1,13 +1,6 @@
 openapi: 3.0.3
 components:
   parameters:
-    assetId:
-      name: assetId
-      in: path
-      description: Local identifier of an asset.
-      required: true
-      schema:
-        type: string
     uploadId:
       name: uploadId
       in: path

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -17,7 +17,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "./schemas.yaml#/components/schemas/assetWrite"
+            $ref: "./schemas.yaml#/components/schemas/asset"
     DeletedResource:
       description: Status of the delete resource
       content:

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -8,26 +8,9 @@ components:
         application/json:
           schema:
             $ref: "./schemas.yaml#/components/schemas/assets"
-    CollectionAssets:
-      description: >-
-        The response is a document consisting of all assets of the collection.
-      content:
-        application/json:
-          schema:
-            $ref: "./schemas.yaml#/components/schemas/assets"
     Asset:
       description: >-
         The response is a document consisting of one asset of the feature.
-      headers:
-        ETag:
-          $ref: "../../components/headers.yaml#/components/headers/ETag"
-      content:
-        application/json:
-          schema:
-            $ref: "./schemas.yaml#/components/schemas/assetWrite"
-    CollectionAsset:
-      description: >-
-        The response is a document consisting of one asset of the collection.
       headers:
         ETag:
           $ref: "../../components/headers.yaml#/components/headers/ETag"

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -1,17 +1,6 @@
 openapi: 3.0.3
 components:
   schemas:
-    assetId:
-      type: string
-      pattern: ^[a-z0-9.-_]+$
-      title: ID
-      description: >-
-        The asset id uniquely identifies the asset for an item
-
-
-        **Note**: `id` must be unique for the item and must be identical to the
-        filename.
-      example: smr50-263-2016-2056-kgrs-2.5.tiff
     assets:
       title: Assets
       type: object
@@ -76,31 +65,31 @@ components:
         - links
       properties:
         id:
-          $ref: "./schemas.yaml#/components/schemas/assetId"
+          $ref: "../../components/schemas.yaml#/components/schemas/assetId"
         title:
-          $ref: "#/components/schemas/title"
+          $ref: "../../components/schemas.yaml#/components/schemas/title"
         description:
-          $ref: "#/components/schemas/description"
+          $ref: "../../components/schemas.yaml#/components/schemas/description"
         type:
           $ref: "#/components/schemas/mediaTypeWrite"
         href:
-          $ref: "#/components/schemas/href"
+          $ref: "../../components/schemas.yaml#/components/schemas/href"
         file:checksum:
-          $ref: "#/components/schemas/checksumMultihashReadOnly"
+          $ref: "../../components/schemas.yaml#/components/schemas/checksumMultihashReadOnly"
         roles:
-          $ref: '#/components/schemas/roles'
+          $ref: "../../components/schemas.yaml#/components/schemas/roles"
         "geoadmin:variant":
-          $ref: "#/components/schemas/geoadminVariant"
+          $ref: "../../components/schemas.yaml#/components/schemas/geoadminVariant"
         "geoadmin:lang":
-          $ref: "#/components/schemas/geoadminLang"
+          $ref: "../../components/schemas.yaml#/components/schemas/geoadminLang"
         "proj:epsg":
-          $ref: "#/components/schemas/projEpsg"
+          $ref: "../../components/schemas.yaml#/components/schemas/projEpsg"
         "gsd":
-          $ref: "#/components/schemas/eoGsd"
+          $ref: "../../components/schemas.yaml#/components/schemas/eoGsd"
         created:
-          $ref: "#/components/schemas/created"
+          $ref: "../../components/schemas.yaml#/components/schemas/created"
         updated:
-          $ref: "#/components/schemas/updated"
+          $ref: "../../components/schemas.yaml#/components/schemas/updated"
         links:
           items:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
@@ -129,31 +118,31 @@ components:
         - links
       properties:
         id:
-          $ref: "./schemas.yaml#/components/schemas/assetId"
+          $ref: "../../components/schemas.yaml#/components/schemas/assetId"
         title:
-          $ref: "#/components/schemas/title"
+          $ref: "../../components/schemas.yaml#/components/schemas/title"
         description:
-          $ref: "#/components/schemas/description"
+          $ref: "../../components/schemas.yaml#/components/schemas/description"
         type:
           $ref: "#/components/schemas/mediaTypeWrite"
         href:
           $ref: "#/components/schemas/hrefExternal"
         file:checksum:
-          $ref: "#/components/schemas/checksumMultihashReadOnly"
+          $ref: "../../components/schemas.yaml#/components/schemas/checksumMultihashReadOnly"
         roles:
-          $ref: '#/components/schemas/roles'
+          $ref: "../../components/schemas.yaml#/components/schemas/roles"
         "geoadmin:variant":
-          $ref: "#/components/schemas/geoadminVariant"
+          $ref: "../../components/schemas.yaml#/components/schemas/geoadminVariant"
         "geoadmin:lang":
-          $ref: "#/components/schemas/geoadminLang"
+          $ref: "../../components/schemas.yaml#/components/schemas/geoadminLang"
         "proj:epsg":
-          $ref: "#/components/schemas/projEpsg"
+          $ref: "../../components/schemas.yaml#/components/schemas/projEpsg"
         "gsd":
-          $ref: "#/components/schemas/eoGsd"
+          $ref: "../../components/schemas.yaml#/components/schemas/eoGsd"
         created:
-          $ref: "#/components/schemas/created"
+          $ref: "../../components/schemas.yaml#/components/schemas/created"
         updated:
-          $ref: "#/components/schemas/updated"
+          $ref: "../../components/schemas.yaml#/components/schemas/updated"
         links:
           items:
             $ref: "../../components/schemas.yaml#/components/schemas/link"

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -1,13 +1,42 @@
 openapi: 3.0.3
 components:
   schemas:
+    asset:
+      allOf:
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              $ref: "../../components/schemas.yaml#/components/schemas/assetId"
+            type:
+              $ref: "../../components/schemas.yaml#/components/schemas/assetType"
+        - $ref: "../../components/schemas.yaml#/components/schemas/assetBase"
+        - type: object
+          required:
+            - links
+          properties:
+            links:
+              items:
+                $ref: "../../components/schemas.yaml#/components/schemas/link"
+              type: array
+              example:
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                  rel: self
+                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                  rel: root
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                  rel: parent
+                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  rel: collection
     assets:
       title: Assets
       type: object
       properties:
         assets:
           items:
-            $ref: "#/components/schemas/assetWrite"
+            $ref: "#/components/schemas/asset"
           type: array
         links:
           items:

--- a/spec/transaction/paths.yaml
+++ b/spec/transaction/paths.yaml
@@ -107,52 +107,7 @@ paths:
           $ref: "../components/responses.yaml#/components/responses/PreconditionFailed"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
-  "/collections/{collectionId}/assets":
-    get:
-      description: >-
-        Fetch collection assets of the collection with id `collectionId`.
-
-        These assets do not belong to any item.
-      operationId: getCollectionAssets
-      parameters:
-        - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      responses:
-        "200":
-          $ref: "./components/responses.yaml#/components/responses/CollectionAssets"
-        "400":
-          $ref: "../components/responses.yaml#/components/responses/InvalidParameter"
-        "404":
-          $ref: "../components/responses.yaml#/components/responses/NotFound"
-        "500":
-          $ref: "../components/responses.yaml#/components/responses/ServerError"
-      summary: Fetch all collection assets for a collection
-      tags:
-        - Data
-
   "/collections/{collectionId}/assets/{assetId}":
-    get:
-      description: >-
-        Fetch the collection asset with id `assetId` of the collection with id `collectionId`.
-      operationId: getCollectionAsset
-      parameters:
-        - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
-        - $ref: "../components/parameters.yaml#/components/parameters/IfMatch"
-        - $ref: "../components/parameters.yaml#/components/parameters/IfNoneMatch"
-      responses:
-        "200":
-          $ref: "./components/responses.yaml#/components/responses/CollectionAsset"
-        "304":
-          $ref: "../components/responses.yaml#/components/responses/NotModified"
-        "404":
-          $ref: "../components/responses.yaml#/components/responses/NotFound"
-        "412":
-          $ref: "../components/responses.yaml#/components/responses/PreconditionFailed"
-        "500":
-          $ref: "../components/responses.yaml#/components/responses/ServerError"
-      summary: Fetch a single collection asset
-      tags:
-        - Data
     put:
       summary: Update or create a collection asset
       description: >-
@@ -166,7 +121,7 @@ paths:
         - Data Management
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       requestBody:
         content:
@@ -213,7 +168,7 @@ paths:
         - Data Management
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       requestBody:
         content:
@@ -246,7 +201,7 @@ paths:
         - Data Management
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       responses:
         "200":
@@ -481,7 +436,7 @@ paths:
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
         - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "../components/parameters.yaml#/components/parameters/IfMatch"
         - $ref: "../components/parameters.yaml#/components/parameters/IfNoneMatch"
       responses:
@@ -512,7 +467,7 @@ paths:
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
         - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       requestBody:
         content:
@@ -560,7 +515,7 @@ paths:
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
         - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       requestBody:
         content:
@@ -595,7 +550,7 @@ paths:
       parameters:
         - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
         - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-        - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+        - $ref: "../components/parameters.yaml#/components/parameters/assetId"
         - $ref: "./components/parameters.yaml#/components/parameters/IfMatchWrite"
       responses:
         "200":
@@ -613,7 +568,7 @@ paths:
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
       - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
     get:
       tags:
         - Asset Upload Management
@@ -706,14 +661,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./schemas.yaml#/components/schemas/uploadInProgress"
+                $ref: "./components/schemas.yaml#/components/schemas/uploadInProgress"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
   "/collections/{collectionId}/items/{featureId}/assets/{assetId}/uploads/{uploadId}":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
       - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     get:
       tags:
@@ -886,7 +841,7 @@ paths:
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
       - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     post:
       tags:
@@ -916,7 +871,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./schemas.yaml#/components/schemas/exception"
+                $ref: "../components/schemas.yaml#/components/schemas/exception"
               example:
                 code: 409
                 description: No upload in progress
@@ -928,7 +883,7 @@ paths:
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
       - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     post:
       tags:
@@ -954,7 +909,7 @@ paths:
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
       - $ref: "../components/parameters.yaml#/components/parameters/featureId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     get:
       tags:
@@ -989,7 +944,7 @@ paths:
   "/collections/{collectionId}/assets/{assetId}/uploads":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
     get:
       tags:
         - Collection Asset Upload Management
@@ -1082,13 +1037,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./schemas.yaml#/components/schemas/uploadInProgress"
+                $ref: "./components/schemas.yaml#/components/schemas/uploadInProgress"
         "500":
           $ref: "../components/responses.yaml#/components/responses/ServerError"
   "/collections/{collectionId}/assets/{assetId}/uploads/{uploadId}":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     get:
       tags:
@@ -1129,7 +1084,7 @@ paths:
   "/collections/{collectionId}/assets/{assetId}/uploads/{uploadId}/complete":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     post:
       tags:
@@ -1159,7 +1114,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./schemas.yaml#/components/schemas/exception"
+                $ref: "../components/schemas.yaml#/components/schemas/exception"
               example:
                 code: 409
                 description: No upload in progress
@@ -1170,7 +1125,7 @@ paths:
   "/collections/{collectionId}/assets/{assetId}/uploads/{uploadId}/abort":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     post:
       tags:
@@ -1195,7 +1150,7 @@ paths:
   "/collections/{collectionId}/assets/{assetId}/uploads/{uploadId}/parts":
     parameters:
       - $ref: "../components/parameters.yaml#/components/parameters/collectionId"
-      - $ref: "./components/parameters.yaml#/components/parameters/assetId"
+      - $ref: "../components/parameters.yaml#/components/parameters/assetId"
       - $ref: "./components/parameters.yaml#/components/parameters/uploadId"
     get:
       tags:


### PR DESCRIPTION
The endpoints collections/{collection}/assets and
    collections/{collection}/assets/{asset} where only part of the transactional
    API spec. Now they are also in the public spec.
    
    Also fixed some small issues in the collection asset spec.