### PR TITLE
Updated all paths from v0.9 to v1 in openapi spec

### DIFF
--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -168,23 +168,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -356,13 +356,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -379,13 +379,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -717,13 +717,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -740,15 +740,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -779,13 +779,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
     collectionAssets:
       title: Assets
@@ -814,13 +814,13 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     itemAssets:
       title: Assets
@@ -899,9 +899,9 @@ components:
         An array of links. Can be used for pagination, e.g. by providing a link with the `next`
         relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -911,9 +911,9 @@ components:
         An array of links. Can be used for pagination, e.g. by providing a link with the `next`
         relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -246,23 +246,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections
@@ -659,13 +659,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -682,13 +682,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -988,13 +988,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -1010,15 +1010,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -1049,13 +1049,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
     collectionAssets:
       title: Assets
@@ -1084,13 +1084,13 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     itemAssets:
       title: Assets
@@ -1167,9 +1167,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -1178,9 +1178,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -282,23 +282,23 @@ components:
             description: Catalog of Swiss Geodata Downloads
             id: ch
             links:
-              - href: http://data.geo.admin.ch/api/stac/v0.9/
+              - href: http://data.geo.admin.ch/api/stac/v1/
                 rel: self
                 type: application/json
                 title: this document
-              - href: http://data.geo.admin.ch/api/stac/v0.9/static/api.html
+              - href: http://data.geo.admin.ch/api/stac/v1/static/api.html
                 rel: service-doc
                 type: text/html
                 title: the API documentation
-              - href: http://data.geo.admin.ch/api/stac/v0.9/conformance
+              - href: http://data.geo.admin.ch/api/stac/v1/conformance
                 rel: conformance
                 type: application/json
                 title: OGC API conformance classes implemented by this server
-              - href: http://data.geo.admin.ch/api/stac/v0.9/collections
+              - href: http://data.geo.admin.ch/api/stac/v1/collections
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: http://data.geo.admin.ch/api/stac/v0.9/search
+              - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
                 type: application/json
                 title: Search across feature collections
@@ -419,7 +419,7 @@ components:
                 description: >-
                   The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                     rel: parent
             required:
               - code
@@ -739,13 +739,13 @@ components:
               items:
                 $ref: "#/components/schemas/link"
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9
+                - href: https://data.geo.admin.ch/api/stac/v1
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
                   rel: items
                 - href: https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/free-geodata.html
                   rel: license
@@ -762,13 +762,13 @@ components:
           items:
             $ref: "#/components/schemas/link"
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections
+            - href: https://data.geo.admin.ch/api/stac/v1/collections
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections?cursor=10cd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections?cursor=10cd
               rel: previous
       required:
         - links
@@ -1068,13 +1068,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr50-263-2016
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
         - $ref: "#/components/schemas/itemBase"
     items:
@@ -1090,15 +1090,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10ab
               rel: next
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items?cursor=10acd
               rel: previous
         type:
           enum:
@@ -1129,13 +1129,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
     collectionAssets:
       title: Assets
@@ -1164,13 +1164,13 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     itemAssets:
       title: Assets
@@ -1247,9 +1247,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
       items:
         $ref: "#/components/schemas/link"
@@ -1258,9 +1258,9 @@ components:
       description: >-
         An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.
       example:
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search
+        - href: https://data.geo.admin.ch/api/stac/v1/search
           rel: self
-        - href: https://data.geo.admin.ch/api/stac/v0.9/search?cursor=10ab
+        - href: https://data.geo.admin.ch/api/stac/v1/search?cursor=10ab
           rel: next
           method: POST
           body: {}
@@ -2051,13 +2051,13 @@ components:
                 $ref: "#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
     assets:
       title: Assets
@@ -2072,15 +2072,15 @@ components:
             $ref: "#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     collectionWrite:
       title: collection
@@ -2154,15 +2154,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     assetWriteExternalAsset:
       title: Asset
@@ -2207,15 +2207,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     mediaTypeWrite:
       type: string
@@ -2373,7 +2373,7 @@ components:
             $ref: "#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
     assetUpload:
       title: AssetUpload
       type: object
@@ -2557,7 +2557,7 @@ components:
             $ref: "#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
     status:
       title: Status
       description: Status of the Asset's multipart upload.
@@ -4032,7 +4032,7 @@ paths:
                     file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
                 links:
                   - rel: next
-                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+                    href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -4396,7 +4396,7 @@ paths:
                     file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
                 links:
                   - rel: next
-                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+                    href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":

--- a/spec/transaction/components/responses.yaml
+++ b/spec/transaction/components/responses.yaml
@@ -40,7 +40,7 @@ components:
                 description: >-
                   The array contain at least a link to the parent resource (`rel: parent`).
                 example:
-                  - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                  - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                     rel: parent
             required:
               - code

--- a/spec/transaction/components/schemas.yaml
+++ b/spec/transaction/components/schemas.yaml
@@ -22,13 +22,13 @@ components:
                 $ref: "../../components/schemas.yaml#/components/schemas/link"
               type: array
               example:
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
                   rel: self
-                - href: https://data.geo.admin.ch/api/stac/v0.9/
+                - href: https://data.geo.admin.ch/api/stac/v1/
                   rel: root
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
                   rel: parent
-                - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
                   rel: collection
     assets:
       title: Assets
@@ -43,15 +43,15 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           type: array
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     collectionWrite:
       title: collection
@@ -125,15 +125,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     assetWriteExternalAsset:
       title: Asset
@@ -178,15 +178,15 @@ components:
           type: array
           readOnly: true
           example:
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff
               rel: self
-            - href: https://data.geo.admin.ch/api/stac/v0.9/
+            - href: https://data.geo.admin.ch/api/stac/v1/
               rel: root
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: parent
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019
               rel: item
-            - href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
+            - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale
               rel: collection
     mediaTypeWrite:
       type: string
@@ -347,7 +347,7 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
     assetUpload:
       title: AssetUpload
       type: object
@@ -532,7 +532,7 @@ components:
             $ref: "../../components/schemas.yaml#/components/schemas/link"
           example:
             - rel: next
-              href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
+              href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads/upload-id/parts?limit=50&offset=50
     status:
       title: Status
       description: Status of the Asset's multipart upload.

--- a/spec/transaction/paths.yaml
+++ b/spec/transaction/paths.yaml
@@ -615,7 +615,7 @@ paths:
                     file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
                 links:
                   - rel: next
-                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+                    href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
         "400":
           $ref: "../components/responses.yaml#/components/responses/BadRequest"
         "404":
@@ -991,7 +991,7 @@ paths:
                     file:checksum: 12200ADEC47F803A8CF1055ED36750B3BA573C79A3AF7DA6D6F5A2AED03EA16AF3BC
                 links:
                   - rel: next
-                    href: https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
+                    href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/items/smr200-200-4-2019/assets/smr50-263-2016-2056-kgrs-2.5.tiff/uploads?cursor=0d34
         "400":
           $ref: "../components/responses.yaml#/components/responses/BadRequest"
         "404":


### PR DESCRIPTION
We still have many references (mostly in examples) to v0.9 in the spec.
They are all replaced with v1 with this PR using a search and replace.

This PR superseed #520.