### PR TITLE
Make large uploads a little more useable.

### DIFF
--- a/app/stac_api/templates/js/admin/upload.js
+++ b/app/stac_api/templates/js/admin/upload.js
@@ -1,9 +1,4 @@
 /*************************************
-* Initialization
-**************************************/
-window.addEventListener('load', cleanUploadsInProgress)
-
-/*************************************
 * Helper functions
 **************************************/
 function setStatus(text) {
@@ -87,6 +82,7 @@ async function abortMultipartUpload(upload_id) {
 // Reads file, creates md5 and multihash.
 // Calls `createPresigned`.
 function handleFileFormSubmit() {
+    cleanUploadsInProgress();
     const fileInput = document.getElementById('id_file');
     if (fileInput.files.length == 0) {
         setError('no file selected')

--- a/app/templates/uploadtemplate.html
+++ b/app/templates/uploadtemplate.html
@@ -20,7 +20,7 @@
 
 <div class="box info">
     &#9432; This file upload will use the multipart form upload API in the background.
-    The file will be uploaded to s3 using a presigned url. Max. file size is 5GB
+    The file will be uploaded to S3 using a presigned url. Maximum file size is 536,870,903 bytes (approximately 512 MB).
 </div>
 <div id="error_box" class="box error" style="display: none">
     &#x26A0;


### PR DESCRIPTION
Specifically:
* actually attempt to abort abandoned uploads before starting a new one (does not actually work well depending on cache state but better than not working at all);
* document the actual size limit (~512MB).

This is still far from ideal but strictly before than the current state.