### PR TITLE
Fixed E2E tests for the localhost

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -34,3 +34,8 @@ AWS_S3_CUSTOM_DOMAIN=127.0.0.1:9090/service-stac-local
 # reachable in the web
 # this will be used by the unit tests for external assets
 EXTERNAL_TEST_ASSET_URL=https://prod-swisstopoch-hcms-sdweb.imgix.net/2024/07/04/04d3aafe-99b1-4589-934c-337583eb5564.jpeg
+
+# Those settings are required in order to run E2E tests against the localhost
+SESSION_EXPIRE_AT_BROWSER_CLOSE=False
+SESSION_COOKIE_AGE=28800
+SESSION_COOKIE_SECURE=False


### PR DESCRIPTION
Those session settings are required in order to have our E2E tests from
infra-e2e-tests repos to pass when running them using the localhost setup.

See also https://github.com/geoadmin/infra-e2e-tests/pull/344