### PR TITLE
PB-1495 Remove date comparison for property `expires`

### DIFF
--- a/app/stac_api/management/commands/remove_expired_items.py
+++ b/app/stac_api/management/commands/remove_expired_items.py
@@ -68,7 +68,7 @@ class Command(CustomBaseCommand):
         default_min_age = settings.DELETE_EXPIRED_ITEMS_OLDER_THAN_HOURS
         parser.add_argument(
             '--min-age-hours',
-            type=float,
+            type=int,
             default=default_min_age,
             help=f"Minimum hours the item must have been expired for (default {default_min_age})"
         )

--- a/app/stac_api/management/commands/remove_expired_items.py
+++ b/app/stac_api/management/commands/remove_expired_items.py
@@ -68,7 +68,7 @@ class Command(CustomBaseCommand):
         default_min_age = settings.DELETE_EXPIRED_ITEMS_OLDER_THAN_HOURS
         parser.add_argument(
             '--min-age-hours',
-            type=int,
+            type=float,
             default=default_min_age,
             help=f"Minimum hours the item must have been expired for (default {default_min_age})"
         )

--- a/app/stac_api/models/item.py
+++ b/app/stac_api/models/item.py
@@ -19,6 +19,7 @@ from stac_api.pgtriggers import generates_asset_upload_triggers
 from stac_api.pgtriggers import generates_item_triggers
 from stac_api.utils import get_asset_path
 from stac_api.validators import validate_eo_gsd
+from stac_api.validators import validate_expires
 from stac_api.validators import validate_geoadmin_variant
 from stac_api.validators import validate_geometry
 from stac_api.validators import validate_item_properties_datetimes
@@ -219,8 +220,8 @@ class Item(models.Model):
             self.properties_datetime,
             self.properties_start_datetime,
             self.properties_end_datetime,
-            self.properties_expires,
         )
+        validate_expires(self.properties_expires)
 
 
 class ItemLink(Link):

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -24,6 +24,7 @@ from stac_api.utils import is_api_version_1
 from stac_api.validators import normalize_and_validate_media_type
 from stac_api.validators import validate_asset_name
 from stac_api.validators import validate_asset_name_with_media_type
+from stac_api.validators import validate_expires
 from stac_api.validators import validate_geoadmin_variant
 from stac_api.validators import validate_href_url
 from stac_api.validators import validate_item_properties_datetimes
@@ -473,6 +474,8 @@ class ItemSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
                     'properties_end_datetime',
                     self.instance.properties_end_datetime if self.instance else None
                 ),
+            )
+            validate_expires(
                 attrs.get(
                     'properties_expires',
                     self.instance.properties_expires if self.instance else None

--- a/app/stac_api/validators.py
+++ b/app/stac_api/validators.py
@@ -427,18 +427,6 @@ def validate_item_properties_datetimes(
     properties_datetime = validate_datetime_format(properties_datetime)
     properties_start_datetime = validate_datetime_format(properties_start_datetime)
     properties_end_datetime = validate_datetime_format(properties_end_datetime)
-
-    # We don't check if
-    #
-    #     expires ≥ datetime
-    #
-    # or
-    #
-    #     expires ≥ end_datetime
-    #
-    # because `expires` is only used in the forecast STAC extension.
-    # For forecast data, `datetime` can be anywhere in the future, so
-    # it can be after the expiration date of the forecast data itself.
     properties_expires = validate_datetime_format(properties_expires)
 
     if properties_datetime is not None:

--- a/app/stac_api/validators.py
+++ b/app/stac_api/validators.py
@@ -427,6 +427,18 @@ def validate_item_properties_datetimes(
     properties_datetime = validate_datetime_format(properties_datetime)
     properties_start_datetime = validate_datetime_format(properties_start_datetime)
     properties_end_datetime = validate_datetime_format(properties_end_datetime)
+
+    # We don't check if
+    #
+    #     expires ≥ datetime
+    #
+    # or
+    #
+    #     expires ≥ end_datetime
+    #
+    # because `expires` is only used in the forecast STAC extension.
+    # For forecast data, `datetime` can be anywhere in the future, so
+    # it can be after the expiration date of the forecast data itself.
     properties_expires = validate_datetime_format(properties_expires)
 
     if properties_datetime is not None:
@@ -435,10 +447,6 @@ def validate_item_properties_datetimes(
                 '(start_datetime, end_datetime)'
             logger.error(message)
             raise ValidationError(_(message), code='invalid')
-        if properties_expires is not None:
-            if properties_expires < properties_datetime:
-                message = "Property expires can't refer to a date earlier than property datetime"
-                raise ValidationError(_(message), code='invalid')
 
     if properties_datetime is None:
         if properties_end_datetime is None:
@@ -453,11 +461,6 @@ def validate_item_properties_datetimes(
             message = "Property end_datetime can't refer to a date earlier than property "\
             "start_datetime"
             raise ValidationError(_(message), code='invalid')
-        if properties_expires is not None:
-            if properties_expires < properties_end_datetime:
-                message = "Property expires can't refer to a date earlier than property "\
-                "end_datetime"
-                raise ValidationError(_(message), code='invalid')
 
 
 def validate_checksum_multihash_sha256(value):

--- a/app/tests/tests_09/test_validators.py
+++ b/app/tests/tests_09/test_validators.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -5,6 +9,7 @@ from stac_api.validators import MediaType
 from stac_api.validators import get_media_type
 from stac_api.validators import normalize_and_validate_media_type
 from stac_api.validators import validate_content_encoding
+from stac_api.validators import validate_expires
 from stac_api.validators import validate_item_properties_datetimes
 
 
@@ -15,13 +20,22 @@ class TestValidators(TestCase):
             properties_datetime = None
             properties_start_datetime = "2001-22-66T08:00:00+00:00"
             properties_end_datetime = "2001-11-11T08:00:00+00:00"
-            properties_expires = None
             validate_item_properties_datetimes(
                 properties_datetime,
                 properties_start_datetime,
                 properties_end_datetime,
-                properties_expires
             )
+
+    def test_validate_expires_throws_exception_for_date_in_past(self):
+        with self.assertRaises(ValidationError):
+            validate_expires(properties_expires="2001-11-11T08:00:00+00:00")
+
+    def test_validate_expires_does_nothing_for_none(self):
+        validate_expires(properties_expires=None)
+
+    def test_validate_expires_does_nothing_for_timestamp_in_the_future(self):
+        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+        validate_expires(tomorrow)
 
     def test_validate_invalid_content_encoding(self):
         for value in [

--- a/app/tests/tests_10/test_assets_endpoint.py
+++ b/app/tests/tests_10/test_assets_endpoint.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 import logging
+import time
 from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
@@ -101,8 +102,9 @@ class AssetsEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() - timedelta(hours=1)
+            properties_expires=timezone.now() + timedelta(milliseconds=10)
         ).model
+        time.sleep(0.02)
         response = self.client.get(
             f"/{STAC_BASE_V}/collections/{collection_name}/items/{item_expired.name}/assets"
         )
@@ -131,8 +133,9 @@ class AssetsEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() - timedelta(hours=1)
+            properties_expires=timezone.now() + timedelta(milliseconds=10)
         ).model
+        time.sleep(0.02)
         asset = self.factory.create_asset_sample(item=item, db_create=True).model
         response = self.client.get(
             f"/{STAC_BASE_V}/collections/{collection_name}/items/{item.name}/assets/{asset.name}"

--- a/app/tests/tests_10/test_assets_endpoint.py
+++ b/app/tests/tests_10/test_assets_endpoint.py
@@ -138,7 +138,8 @@ class AssetsEndpointTestCase(StacBaseTestCase):
         asset = self.factory.create_asset_sample(item=item, db_create=True).model
         with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=2)):
             response = self.client.get(
-                f"/{STAC_BASE_V}/collections/{collection_name}/items/{item.name}/assets/{asset.name}"
+                f"/{STAC_BASE_V}/collections/{collection_name}/items/{item.name}/"
+                f"assets/{asset.name}"
             )
         self.assertStatusCode(404, response)
 

--- a/app/tests/tests_10/test_assets_endpoint.py
+++ b/app/tests/tests_10/test_assets_endpoint.py
@@ -1,12 +1,12 @@
 # pylint: disable=too-many-lines
 import logging
-import time
 from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
 from json import dumps
 from json import loads
 from pprint import pformat
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client
@@ -102,12 +102,12 @@ class AssetsEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=10)
+            properties_expires=timezone.now() + timedelta(hours=1)
         ).model
-        time.sleep(0.02)
-        response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{collection_name}/items/{item_expired.name}/assets"
-        )
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=2)):
+            response = self.client.get(
+                f"/{STAC_BASE_V}/collections/{collection_name}/items/{item_expired.name}/assets"
+            )
         self.assertStatusCode(404, response)
 
     def test_single_asset_endpoint(self):
@@ -133,13 +133,13 @@ class AssetsEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=10)
+            properties_expires=timezone.now() + timedelta(hours=1)
         ).model
-        time.sleep(0.02)
         asset = self.factory.create_asset_sample(item=item, db_create=True).model
-        response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{collection_name}/items/{item.name}/assets/{asset.name}"
-        )
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=2)):
+            response = self.client.get(
+                f"/{STAC_BASE_V}/collections/{collection_name}/items/{item.name}/assets/{asset.name}"
+            )
         self.assertStatusCode(404, response)
 
 

--- a/app/tests/tests_10/test_item_model.py
+++ b/app/tests/tests_10/test_item_model.py
@@ -113,6 +113,13 @@ class ItemsModelTestCase(TestCase):
             item.full_clean()
             item.save()
 
+    def test_item_create_model_raises_exception_if_expires_in_the_past(self):
+        with self.assertRaises(ValidationError):
+            yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+            item = Item(collection=self.collection, name='item-5', properties_expires=yesterday)
+            item.full_clean()
+            item.save()
+
     def test_item_create_model_expires_can_be_before_datetime(self):
         today = datetime.utcnow()
         yesterday = today - timedelta(days=1)

--- a/app/tests/tests_10/test_item_model.py
+++ b/app/tests/tests_10/test_item_model.py
@@ -121,27 +121,27 @@ class ItemsModelTestCase(TestCase):
             item.save()
 
     def test_item_create_model_expires_can_be_before_datetime(self):
-        today = datetime.utcnow()
-        yesterday = today - timedelta(days=1)
+        today = datetime.utcnow() + timedelta(milliseconds=100)
+        tomorrow = today + timedelta(days=1)
         item = Item(
             collection=self.collection,
             name='item-expires-before-datetime',
-            properties_datetime=utc_aware(today),
-            properties_expires=utc_aware(yesterday)
+            properties_datetime=utc_aware(tomorrow),
+            properties_expires=utc_aware(today)
         )
         item.full_clean()
         item.save()
 
     def test_item_create_model_expires_can_be_before_end_datetime(self):
         today = datetime.utcnow()
-        yesterday = today - timedelta(days=1)
+        middle = today + timedelta(days=0.5)
         tomorrow = today + timedelta(days=1)
         item = Item(
             collection=self.collection,
             name='item-expires-before-end-datetime',
             properties_start_datetime=utc_aware(today),
             properties_end_datetime=utc_aware(tomorrow),
-            properties_expires=utc_aware(yesterday)
+            properties_expires=utc_aware(middle)
         )
         item.full_clean()
         item.save()

--- a/app/tests/tests_10/test_item_model.py
+++ b/app/tests/tests_10/test_item_model.py
@@ -100,10 +100,8 @@ class ItemsModelTestCase(TestCase):
             item.full_clean()
             item.save()
 
-    def test_item_create_model_invalid_datetime_order(self):
-        with self.assertRaises(
-            ValidationError, msg="end_datetime must not be earlier than start_datetime"
-        ):
+    def test_item_create_model_raises_exception_if_end_datetime_before_start_datetime(self):
+        with self.assertRaises(ValidationError):
             today = datetime.utcnow()
             yesterday = today - timedelta(days=1)
             item = Item(
@@ -115,31 +113,31 @@ class ItemsModelTestCase(TestCase):
             item.full_clean()
             item.save()
 
-        with self.assertRaises(
-            ValidationError, msg="expires must not be earlier than end_datetime"
-        ):
-            today = datetime.utcnow()
-            yesterday = today - timedelta(days=1)
-            item = Item(
-                collection=self.collection,
-                name='item-5',
-                properties_end_datetime=utc_aware(today),
-                properties_expires=utc_aware(yesterday)
-            )
-            item.full_clean()
-            item.save()
+    def test_item_create_model_expires_can_be_before_datetime(self):
+        today = datetime.utcnow()
+        yesterday = today - timedelta(days=1)
+        item = Item(
+            collection=self.collection,
+            name='item-expires-before-datetime',
+            properties_datetime=utc_aware(today),
+            properties_expires=utc_aware(yesterday)
+        )
+        item.full_clean()
+        item.save()
 
-        with self.assertRaises(ValidationError, msg="expires must not be earlier than datetime"):
-            today = datetime.utcnow()
-            yesterday = today - timedelta(days=1)
-            item = Item(
-                collection=self.collection,
-                name='item-5',
-                properties_datetime=utc_aware(today),
-                properties_expires=utc_aware(yesterday)
-            )
-            item.full_clean()
-            item.save()
+    def test_item_create_model_expires_can_be_before_end_datetime(self):
+        today = datetime.utcnow()
+        yesterday = today - timedelta(days=1)
+        tomorrow = today + timedelta(days=1)
+        item = Item(
+            collection=self.collection,
+            name='item-expires-before-end-datetime',
+            properties_start_datetime=utc_aware(today),
+            properties_end_datetime=utc_aware(tomorrow),
+            properties_expires=utc_aware(yesterday)
+        )
+        item.full_clean()
+        item.save()
 
     def test_item_create_model_valid_geometry(self):
         # a correct geometry should not pose any problems

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 import logging
+import time
 from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
@@ -60,11 +61,12 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() - timedelta(hours=1)
+            properties_expires=timezone.now() + timedelta(milliseconds=10)
         )
         assets = self.factory.create_asset_samples(
             3, item_3.model, name=['asset-1.tiff', 'asset-0.tiff', 'asset-2.tiff'], db_create=True
         )
+        time.sleep(0.02)
         response = self.client.get(f"/{STAC_BASE_V}/collections/{self.collection.name}/items")
         self.assertStatusCode(200, response)
         json_data = response.json()
@@ -171,8 +173,9 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() - timedelta(hours=1)
+            properties_expires=timezone.now() + timedelta(milliseconds=10)
         )
+        time.sleep(0.02)
 
         response = self.client.get(
             f"/{STAC_BASE_V}/collections/{collection_name}/items/{item['name']}"

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -1,10 +1,10 @@
 # pylint: disable=too-many-lines
 import logging
-import time
 from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
 from typing import cast
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client
@@ -61,13 +61,13 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=10)
+            properties_expires=timezone.now() + timedelta(hours=1)
         )
         assets = self.factory.create_asset_samples(
             3, item_3.model, name=['asset-1.tiff', 'asset-0.tiff', 'asset-2.tiff'], db_create=True
         )
-        time.sleep(0.02)
-        response = self.client.get(f"/{STAC_BASE_V}/collections/{self.collection.name}/items")
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=2)):
+            response = self.client.get(f"/{STAC_BASE_V}/collections/{self.collection.name}/items")
         self.assertStatusCode(200, response)
         json_data = response.json()
 
@@ -173,13 +173,13 @@ class ItemsReadEndpointTestCase(StacBaseTestCase):
             self.collection,
             name='item-expired',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=10)
+            properties_expires=timezone.now() + timedelta(hours=1)
         )
-        time.sleep(0.02)
 
-        response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{collection_name}/items/{item['name']}"
-        )
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=2)):
+            response = self.client.get(
+                f"/{STAC_BASE_V}/collections/{collection_name}/items/{item['name']}"
+            )
         self.assertStatusCode(404, response)
 
     def test_items_endpoint_non_existing_collection(self):

--- a/app/tests/tests_10/test_remove_expired_items.py
+++ b/app/tests/tests_10/test_remove_expired_items.py
@@ -1,6 +1,6 @@
-import time
 from datetime import timedelta
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -37,18 +37,19 @@ class RemoveExpiredItems(TestCase):
             self.collection,
             name='item-0',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=50)
+            properties_expires=timezone.now() + timedelta(hours=1)
         )
         assets = self.factory.create_asset_samples(
             2, item_0.model, name=['asset-0.tiff', 'asset-1.tiff'], db_create=True
         )
-        min_age_hours = 1 / 60 / 60 / 1000  # = 1ms
-        time.sleep(min_age_hours * 100)
-        out = self._call_command("--dry-run", "--no-color", f"--min-age-hours={min_age_hours}")
+
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=26)):
+            out = self._call_command("--dry-run", "--no-color")
+
         self.assertEqual(
             out,
-            f"""running command to remove expired items
-deleting all items expired longer than {min_age_hours} hours
+            """running command to remove expired items
+deleting all items expired longer than 24 hours
 skipping deletion of assets <QuerySet [<Asset: asset-0.tiff>, <Asset: asset-1.tiff>]>
 skipping deletion of item collection-1/item-0
 [dry run] would have removed 1 expired items
@@ -74,17 +75,17 @@ skipping deletion of item collection-1/item-0
             self.collection,
             name='item-1',
             db_create=True,
-            properties_expires=timezone.now() + timedelta(milliseconds=50)
+            properties_expires=timezone.now() + timedelta(hours=1)
         )
         assets = self.factory.create_asset_samples(
             2, item_1.model, name=['asset-2.tiff', 'asset-3.tiff'], db_create=True
         )
-        min_age_hours = 1.0
-        out = self._call_command("--no-color", f"--min-age-hours={min_age_hours}")
+
+        out = self._call_command("--no-color")
         self.assertEqual(
             out,
-            f"""running command to remove expired items
-deleting all items expired longer than {min_age_hours} hours
+            """running command to remove expired items
+deleting all items expired longer than 24 hours
 successfully removed 0 expired items
 """
         )
@@ -102,14 +103,13 @@ successfully removed 0 expired items
             msg="not expired asset has been deleted"
         )
 
-        min_age_hours = 1 / 60 / 60 / 1000  # = 1ms
-        time.sleep(min_age_hours * 100)
-        out = self._call_command(f"--min-age-hours={min_age_hours}", "--no-color")
+        with patch.object(timezone, "now", return_value=timezone.now() + timedelta(hours=10)):
+            out = self._call_command("--min-age-hours=9", "--no-color")
         self.assertEqual(
             out,
-            f"""running command to remove expired items
-deleting all items expired longer than {min_age_hours} hours
-deleted item item-1 and 2 assets belonging to it. extra={{'item': 'item-1'}}
+            """running command to remove expired items
+deleting all items expired longer than 9 hours
+deleted item item-1 and 2 assets belonging to it. extra={'item': 'item-1'}
 successfully removed 1 expired items
 """
         )

--- a/app/tests/tests_10/test_validators.py
+++ b/app/tests/tests_10/test_validators.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
 from parameterized import parameterized
 
 from django.core.exceptions import ValidationError
@@ -10,6 +14,7 @@ from stac_api.validators import get_media_type
 from stac_api.validators import normalize_and_validate_media_type
 from stac_api.validators import validate_cache_control_header
 from stac_api.validators import validate_content_encoding
+from stac_api.validators import validate_expires
 from stac_api.validators import validate_item_properties_datetimes
 
 from tests.tests_10.data_factory import Factory
@@ -22,13 +27,22 @@ class TestValidators(TestCase):
             properties_datetime = None
             properties_start_datetime = "2001-22-66T08:00:00+00:00"
             properties_end_datetime = "2001-11-11T08:00:00+00:00"
-            properties_expires = None
             validate_item_properties_datetimes(
                 properties_datetime,
                 properties_start_datetime,
                 properties_end_datetime,
-                properties_expires
             )
+
+    def test_validate_expires_throws_exception_for_date_in_past(self):
+        with self.assertRaises(ValidationError):
+            validate_expires(properties_expires="2001-11-11T08:00:00+00:00")
+
+    def test_validate_expires_does_nothing_for_none(self):
+        validate_expires(properties_expires=None)
+
+    def test_validate_expires_does_nothing_for_timestamp_in_the_future(self):
+        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+        validate_expires(tomorrow)
 
     def test_validate_invalid_content_encoding(self):
         for value in [


### PR DESCRIPTION
In the forecast extension, `datetime` is the forecast date. So `datetime` can be anywhere in the future and `expires` might be before that. So comparing these two dates makes no sense. Same for `end_datetime`.

The `expires` field is part of the Timestamps extension, so it might be used in different contexts where this check would actually make sense. But ultimately, it is the responsibility of the data owner that the data is consistent. So we remove the check to reduce complexity on our side.

:information_source:  The definition of the fields according to the [forecast extension docs](https://github.com/stac-extensions/forecast?tab=readme-ov-file#additional-fields-from-other-extensions):
> - **datetime**: REQUIRED. The forecast datetime. It follows the definition in the [STAC Common Metdata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#date-and-time). If the forecast is not only for a specific instance in time but instead is for a certain period, you should use start_datetime and end_datetime and set datetime either to reflect the start_datetime (recommended) or to null.
> - **expires**: The datetime until the forecast is valid or gets superseded by a new forecast. It follows the definition in the [Timestamps Extension](https://github.com/stac-extensions/timestamps#item-properties-fields).