### PR TITLE
PB-1434 : Add back 'file' field to Collections and CollectionAssets

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -607,7 +607,7 @@ class AssetAdmin(admin.ModelAdmin):
         if obj:
             # Don't allow to modify Asset name and media type, because they are tightly coupled
             # with the asset data file. Changing them require to re-upload the data.
-            # As file upload through admin has been disabled, the field is read-only unless the field is external.
+            # As file upload through admin has been disabled, the field is read-only unless the asset is external.
             if not obj.is_external:
                 return self.readonly_fields + ['file', 'name', 'media_type']
 

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -406,7 +406,7 @@ class CollectionAssetAdmin(admin.ModelAdmin):
             'File',
             {
                 'fields': (
-                    'file'
+                    'file',
                     'media_type',
                     'href',
                     'checksum_multihash',

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -370,6 +370,11 @@ class CollectionAssetAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields['file'] = forms.CharField(
+            label='File',
+            required=False,
+            widget=LabelWidget(attrs={'size': 150}),
+        )
 
 
 @admin.register(CollectionAsset)
@@ -401,6 +406,7 @@ class CollectionAssetAdmin(admin.ModelAdmin):
             'File',
             {
                 'fields': (
+                    'file'
                     'media_type',
                     'href',
                     'checksum_multihash',

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -607,7 +607,8 @@ class AssetAdmin(admin.ModelAdmin):
         if obj:
             # Don't allow to modify Asset name and media type, because they are tightly coupled
             # with the asset data file. Changing them require to re-upload the data.
-            # As file upload through admin has been disabled, the field is read-only unless the asset is external.
+            # As file upload through admin has been disabled,
+            # the field is read-only unless the asset is external.
             if not obj.is_external:
                 return self.readonly_fields + ['file', 'name', 'media_type']
 

--- a/app/stac_api/models/collection.py
+++ b/app/stac_api/models/collection.py
@@ -137,6 +137,7 @@ class CollectionAsset(AssetBase):
         ordering = ['id']
         triggers = generates_collection_asset_triggers()
 
+
     collection = models.ForeignKey(
         Collection,
         related_name='assets',

--- a/app/stac_api/widgets/label_widget.py
+++ b/app/stac_api/widgets/label_widget.py
@@ -1,9 +1,0 @@
-from django.forms.widgets import Widget
-from django.utils.safestring import mark_safe
-
-
-class LabelWidget(Widget):
-    """Custom widget to display a label without input"""
-
-    def render(self, name, value, attrs=None, renderer=None):
-        return mark_safe(f'<div class="readonly" >{value}</div>')


### PR DESCRIPTION
The 'file' field has been added back to the Collections and CollectionsAsset form after I removed in the previous PR.

UPDATE : I also found a better implementation for removing the upload button, which involves simply setting the 'file' field as read-only by default, and only making it editable for external assets. This also solves the missing href problem we had with the custom widget. 

LabelWidget has therefore been removed.