### PR TITLE
PB-1512: Add missing links to collection assets

### DIFF
--- a/app/stac_api/serializers/utils.py
+++ b/app/stac_api/serializers/utils.py
@@ -16,6 +16,7 @@ from stac_api.models.item import Item
 from stac_api.utils import build_asset_href
 from stac_api.utils import get_browser_url
 from stac_api.utils import get_url
+from stac_api.utils import is_api_version_1
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +187,13 @@ def get_relation_links(request, view, view_args=()):
                 ('href', get_url(request, 'items-list', view_args)),
             ])
         )
+        if is_api_version_1(request):
+            links.append(
+                OrderedDict([
+                    ('rel', 'assets'),
+                    ('href', get_url(request, 'collection-assets-list', view_args)),
+                ])
+            )
     elif view.startswith('item') or view.startswith('asset') or view.startswith('collection-asset'):
         links.append(
             OrderedDict([

--- a/app/tests/tests_10/base_test.py
+++ b/app/tests/tests_10/base_test.py
@@ -187,6 +187,10 @@ class StacTestMixin:
                 'rel': 'items',
                 'href': f'{TEST_LINK_ROOT_HREF}/collections/{name}/items',
             },
+            {
+                'rel': 'assets',
+                'href': f'{TEST_LINK_ROOT_HREF}/collections/{name}/assets',
+            },
         ]
         self._check_stac_links('item.links', links, current['links'])
 


### PR DESCRIPTION
Adds the missing links to collection assets on STAC v1.

Collection endpoint (`/api/stac/v1/collections/{name}`): link to the collection assets

```
{
  ...
  "links": [
    {
      "rel": "self",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset"
    },
    {
      "rel": "root",
      "href": "http://localhost:8000/api/stac/v1/"
    },
    {
      "rel": "parent",
      "href": "http://localhost:8000/api/stac/v1/"
    },
    {
      "rel": "items",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset/items"
    },
    {
      "rel": "assets",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset/assets"
    },
    {
      "rel": "alternate",
      "title": "STAC Browser",
      "type": "text/html",
      "href": "http://localhost:8000/browser/index.html#/collections/test-collection-asset"
    }
  ],
  ...
}
```

Collection asset endpoint (`/api/stac/v1/collections/{name}/assets/{name}`): link back to the collection

```
{
  ...
  "links": [
    {
      "rel": "self",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset/assets/test.png"
    },
    {
      "rel": "root",
      "href": "http://localhost:8000/api/stac/v1/"
    },
    {
      "rel": "parent",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset/assets"
    },
    {
      "rel": "collection",
      "href": "http://localhost:8000/api/stac/v1/collections/test-collection-asset"
    }
  ]
}
```