### PR TITLE
PB-1525: Make size of logged request and response content configurable

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -303,6 +303,9 @@ def get_logging_config():
 
 LOGGING = get_logging_config()
 
+LOGGING_MAX_REQUEST_PAYLOAD_SIZE = env.int('LOGGING_MAX_REQUEST_PAYLOAD_SIZE', default=200)
+LOGGING_MAX_RESPONSE_PAYLOAD_SIZE = env.int('LOGGING_MAX_RESPONSE_PAYLOAD_SIZE', default=200)
+
 # Testing
 
 TEST_RUNNER = 'tests.runner.TestRunner'

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -1,6 +1,7 @@
 import logging
 import time
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.http import JsonResponse
 
@@ -28,7 +29,8 @@ class RequestResponseLoggingMiddleware:
         ] and request.content_type == "application/json" and not request.path.startswith(
             '/api/stac/admin'
         ):
-            extra["request.payload"] = request.body.decode()[:200]
+            extra["request.payload"] = request.body.decode()[:settings.
+                                                             LOGGING_MAX_REQUEST_PAYLOAD_SIZE]
 
         logger.debug(
             "Request %s %s?%s",
@@ -54,7 +56,8 @@ class RequestResponseLoggingMiddleware:
         # HttpResponse and JSONResponse sure have
         # (e.g. WhiteNoiseFileResponse doesn't)
         if isinstance(response, (HttpResponse, JsonResponse)):
-            extra["response"]["payload"] = response.content.decode()[:200]
+            extra["response"]["payload"] = response.content.decode(
+            )[:settings.LOGGING_MAX_RESPONSE_PAYLOAD_SIZE]
 
         logger.info("Response %s", response.status_code, extra=extra)
         # Code to be executed for each request/response after

--- a/app/tests/test_middlewares.py
+++ b/app/tests/test_middlewares.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from middleware.logging import RequestResponseLoggingMiddleware
+
+from django.http import FileResponse
+from django.http import JsonResponse
+from django.test import RequestFactory
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class RequestResponseLoggingMiddlewareTests(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(LOGGING_MAX_REQUEST_PAYLOAD_SIZE=5)
+    @override_settings(LOGGING_MAX_RESPONSE_PAYLOAD_SIZE=6)
+    @patch('middleware.logging.time.time')
+    @patch('middleware.logging.logger')
+    def test_logging_middleware_logs(self, logger, time):
+        request = self.factory.post(
+            path='/some-url/?query=café&location=New York&path=/:foo,/:bar',
+            data={'foo': 'bar'},
+            content_type='application/json'
+        )
+        response = JsonResponse(data={'bar': 'baz'}, status=204, headers={'X-Foo': 'Bar'})
+
+        time.side_effect = [1, 2]
+        middleware = RequestResponseLoggingMiddleware(lambda r: response)
+        middleware(request)
+
+        logger.debug.assert_called_once()
+        encoded = 'query=caf%C3%A9&location=New%20York&path=/:foo,/:bar'
+        logger.debug.assert_called_with(
+            'Request %s %s?%s',
+            'POST',
+            '/some-url/',
+            encoded,
+            extra={
+                'request': request, 'request.query': encoded, 'request.payload': '{"foo'
+            }
+        )
+
+        logger.info.assert_called_once()
+        logger.info.assert_called_with(
+            'Response %s',
+            204,
+            extra={
+                'request': request,
+                'response': {
+                    'code': 204,
+                    'headers': {
+                        'Content-Type': 'application/json', 'X-Foo': 'Bar'
+                    },
+                    'duration': 1,
+                    'payload': '{"bar"'
+                }
+            }
+        )
+
+    @patch('middleware.logging.time.time')
+    @patch('middleware.logging.logger')
+    def test_logging_middleware_skips_content_types(self, logger, time):
+        request = self.factory.post('/some-url/', data={'foo': 'bar'})  # multipart
+        response = FileResponse(content_type='application/octet-stream')
+
+        time.side_effect = [1, 2]
+        middleware = RequestResponseLoggingMiddleware(lambda r: response)
+        middleware(request)
+
+        logger.debug.assert_called_once()
+        logger.debug.assert_called_with(
+            'Request %s %s?%s',
+            'POST',
+            '/some-url/',
+            '',
+            extra={
+                'request': request, 'request.query': ''
+            }
+        )
+
+        logger.info.assert_called_once()
+        logger.info.assert_called_with(
+            'Response %s',
+            200,
+            extra={
+                'request': request,
+                'response': {
+                    'code': 200,
+                    'headers': {
+                        'Content-Type': 'application/octet-stream',
+                    },
+                    'duration': 1
+                }
+            }
+        )
+
+    @patch('middleware.logging.logger')
+    def test_logging_middleware_skips_admin_ui_request_content(self, logger):
+        request = self.factory.post(
+            path='/api/stac/admin/foo', data={'foo': 'bar'}, content_type='application/json'
+        )
+        response = JsonResponse(data={'bar': 'baz'}, status=204, headers={'X-Foo': 'Bar'})
+
+        middleware = RequestResponseLoggingMiddleware(lambda r: response)
+        middleware(request)
+
+        logger.debug.assert_called_once()
+        logger.debug.assert_called_with(
+            'Request %s %s?%s',
+            'POST',
+            '/api/stac/admin/foo',
+            '',
+            extra={
+                'request': request, 'request.query': ''
+            }
+        )


### PR DESCRIPTION
This PR make the size of the logged request and response content configurable with environment variables. Also adds tests for the logging middleware.