### PR TITLE
PB-1531: Avoid unnecessary writes to the database

### DIFF
--- a/app/middleware/api_gateway_middleware.py
+++ b/app/middleware/api_gateway_middleware.py
@@ -39,6 +39,7 @@ class ApiGatewayUserBackend(RemoteUserBackend):
         if user:
             # promote authenticated user to superuser for now until proper authorization is
             # implemented
-            user.is_superuser = True
-            user.save()
+            if not user.is_superuser:
+                user.is_superuser = True
+                user.save()
         return user


### PR DESCRIPTION
Avoid unnecessary writes to the database when using the new authentication.

Might not be related to the server errors (which I think are caused by pods waiting for db connections because of some reason), but it's unnecessary the way it's currently anyway.