### PR TITLE
PB-1519 Issue with asset href extra prefix

### DIFF
--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -35,6 +35,7 @@ from stac_api.models.item import ItemLink
 from stac_api.utils import build_asset_href
 from stac_api.utils import get_query_params
 from stac_api.validators import validate_href_url
+from stac_api.validators import validate_href_reachability
 from stac_api.validators import validate_text_to_geometry
 
 logger = logging.getLogger(__name__)
@@ -534,6 +535,7 @@ class AssetAdminForm(forms.ModelForm):
                 file = self.cleaned_data.get('file')
 
                 validate_href_url(file, self.instance.item.collection)
+                validate_href_reachability(file, self.instance.item.collection)
 
         return self.cleaned_data.get('file')
 

--- a/app/stac_api/admin.py
+++ b/app/stac_api/admin.py
@@ -34,8 +34,8 @@ from stac_api.models.item import Item
 from stac_api.models.item import ItemLink
 from stac_api.utils import build_asset_href
 from stac_api.utils import get_query_params
-from stac_api.validators import validate_href_url
 from stac_api.validators import validate_href_reachability
+from stac_api.validators import validate_href_url
 from stac_api.validators import validate_text_to_geometry
 
 logger = logging.getLogger(__name__)

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -27,6 +27,7 @@ from stac_api.validators import validate_asset_name_with_media_type
 from stac_api.validators import validate_expires
 from stac_api.validators import validate_geoadmin_variant
 from stac_api.validators import validate_href_url
+from stac_api.validators import validate_href_reachability
 from stac_api.validators import validate_item_properties_datetimes
 from stac_api.validators import validate_name
 from stac_api.validators_serializer import validate_json_payload
@@ -266,6 +267,8 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
 
             try:
                 validate_href_url(attrs['file'], collection)
+                if self.context.get("validate_href_reachability", True):
+                    validate_href_reachability(attrs['file'], collection)
             except CoreValidationError as e:
                 errors = {'href': e.message}
                 raise serializers.ValidationError(code='payload', detail=errors)

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -26,8 +26,8 @@ from stac_api.validators import validate_asset_name
 from stac_api.validators import validate_asset_name_with_media_type
 from stac_api.validators import validate_expires
 from stac_api.validators import validate_geoadmin_variant
-from stac_api.validators import validate_href_url
 from stac_api.validators import validate_href_reachability
+from stac_api.validators import validate_href_url
 from stac_api.validators import validate_item_properties_datetimes
 from stac_api.validators import validate_name
 from stac_api.validators_serializer import validate_json_payload

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -267,6 +267,7 @@ class AssetBaseSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
 
             try:
                 validate_href_url(attrs['file'], collection)
+                # disabled in bulk upload for performance reasons
                 if self.context.get("validate_href_reachability", True):
                     validate_href_reachability(attrs['file'], collection)
             except CoreValidationError as e:

--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -521,7 +521,8 @@ class ItemListSerializer(serializers.Serializer):
             for link_in in links_per_item[item.name]:
                 links.append(ItemLink(**link_in, item=item))
             for asset_in in assets_per_item[item.name]:
-                assets.append(Asset(**asset_in, item=item))
+                # Asset files are always hosted externally for bulk upload
+                assets.append(Asset(**asset_in, is_external=True, item=item))
 
         ItemLink.objects.bulk_create(links)
         Asset.objects.bulk_create(assets)

--- a/app/stac_api/validators.py
+++ b/app/stac_api/validators.py
@@ -653,7 +653,7 @@ def _validate_href_configured_pattern(url, collection):
     raise ValidationError(error)
 
 
-def _validate_href_reachability(url, collection):
+def validate_href_reachability(url, collection):
     unreachable_error = _('Provided URL is unreachable')
     invalidcontent_error = _('Provided URL returns bad content')
     try:
@@ -719,7 +719,6 @@ def validate_href_url(url, collection):
     _validate_href_scheme(url, collection)
     _validate_href_general_pattern(url, collection)
     _validate_href_configured_pattern(url, collection)
-    _validate_href_reachability(url, collection)
 
 
 def validate_cache_control_header(value):

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -161,13 +161,17 @@ class ItemsList(generics.GenericAPIView):
                 }
                 return Response(data=message, status=code)
 
-            serializer = ItemListSerializer(data=request.data, context={"request": request})
+            collection = Collection.objects.get(name=self.kwargs['collection_name'])
+            serializer = ItemListSerializer(
+                data=request.data, context={
+                    "request": request, "collection": collection
+                }
+            )
             if not serializer.is_valid():
                 code = status.HTTP_400_BAD_REQUEST
                 message = {"code": code, "description": str(serializer.errors)}
                 return Response(data=message, status=code)
 
-            collection = Collection.objects.get(name=self.kwargs['collection_name'])
             serializer.save(collection=collection)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         except Collection.DoesNotExist as exception:

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -163,8 +163,11 @@ class ItemsList(generics.GenericAPIView):
 
             collection = Collection.objects.get(name=self.kwargs['collection_name'])
             serializer = ItemListSerializer(
-                data=request.data, context={
-                    "request": request, "collection": collection
+                data=request.data,
+                context={
+                    "request": request,
+                    "collection": collection,
+                    "validate_href_reachability": False
                 }
             )
             if not serializer.is_valid():

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import cast
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client
 from django.test import override_settings
@@ -885,7 +886,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                             "title": "My title 1",
                             "description": "My description 1",
                             "type": "text/plain",
-                            "href": "asset-1",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "roles": ["myrole"],
                             "geoadmin:variant": "komb",
                             "geoadmin:lang": "de",
@@ -913,7 +914,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                             "title": "My title 2",
                             "description": "My description 2",
                             "type": "text/plain",
-                            "href": "asset-2",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "roles": ["myrole"],
                             "geoadmin:variant": "komb",
                             "geoadmin:lang": "de",
@@ -959,7 +960,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                         "asset-1.txt": {
                             "gsd": 2.5,
                             "geoadmin:variant": "komb",
-                            "href": "http://testserver/asset-1",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "proj:epsg": 2056,
                             "type": "text/plain",
                         },
@@ -983,7 +984,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                         "asset-2.txt": {
                             "gsd": 2.5,
                             "geoadmin:variant": "komb",
-                            "href": "http://testserver/asset-2",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "proj:epsg": 2056,
                             "type": "text/plain",
                         },
@@ -1094,7 +1095,7 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
                     "title": f"My title {i}",
                     "description": f"My description {i}",
                     "type": "text/plain",
-                    "href": f"asset-{i}",
+                    "href": settings.EXTERNAL_TEST_ASSET_URL,
                     "roles": ["myrole"],
                     "geoadmin:variant": "komb",
                     "geoadmin:lang": "de",

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -877,6 +877,10 @@ class ItemsBulkCreateEndpointTestCase(StacBaseTransactionTestCase):
     def setUp(self):
         self.factory = Factory()
         self.collection = self.factory.create_collection_sample(db_create=True)
+        self.collection.model.allow_external_assets = True
+        self.collection.model.external_asset_whitelist = [settings.EXTERNAL_TEST_ASSET_URL]
+        self.collection.model.save()
+
         self.payload = {
             "features": [
                 {

--- a/app/tests/tests_10/test_serializer.py
+++ b/app/tests/tests_10/test_serializer.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from datetime import timezone
 from pprint import pformat
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.db import IntegrityError
 from django.urls import resolve
@@ -683,7 +684,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                             "title": "My title 1",
                             "description": "My description 1",
                             "type": "text/plain",
-                            "href": "asset-1",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "roles": ["myrole"],
                             "geoadmin:variant": "komb",
                             "geoadmin:lang": "de",
@@ -705,7 +706,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                             "title": "My title 2",
                             "description": "My description 2",
                             "type": "text/plain",
-                            "href": "asset-2",
+                            "href": settings.EXTERNAL_TEST_ASSET_URL,
                             "roles": ["myrole"],
                             "geoadmin:variant": "komb",
                             "geoadmin:lang": "de",
@@ -752,7 +753,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                         "name": "asset-1.txt",
                         "title": "My title 1",
                         "media_type": "text/plain",
-                        "file": "asset-1",
+                        "file": settings.EXTERNAL_TEST_ASSET_URL,
                         "description": "My description 1",
                         "roles": ["myrole"],
                         "eo_gsd": 2.5,
@@ -770,7 +771,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
                         "name": "asset-2.txt",
                         "title": "My title 2",
                         "media_type": "text/plain",
-                        "file": "asset-2",
+                        "file": settings.EXTERNAL_TEST_ASSET_URL,
                         "description": "My description 2",
                         "roles": ["myrole"],
                         "eo_gsd": 2.5,
@@ -803,7 +804,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             "asset-1.txt": {
                 "gsd": 2.5,
                 "geoadmin:variant": "komb",
-                "href": "http://testserver/asset-1",
+                "href": settings.EXTERNAL_TEST_ASSET_URL,
                 "proj:epsg": 2056,
                 "type": "text/plain",
             },
@@ -812,7 +813,7 @@ class ItemListDeserializationTestCase(StacBaseTestCase):
             "asset-2.txt": {
                 "gsd": 2.5,
                 "geoadmin:variant": "komb",
-                "href": "http://testserver/asset-2",
+                "href": settings.EXTERNAL_TEST_ASSET_URL,
                 "proj:epsg": 2056,
                 "type": "text/plain",
             },


### PR DESCRIPTION
This removes the prefix `https://sys-data.int.bgdi.ch` from the `href` field of assets uploaded via [the bulk upload](https://sys-data.int.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data-Management/operation/bulkCreateItems).

This happened because there was no `is_external` flag set when validating the `href` field from a payload. If this flag is not set, the validation builds it's own URL. This URL is prefixed with our internal hostname, e.g. `https://sys-data.int.bgdi.ch` for INT or `https://testserver` for local development. So ended up having all `href` prefixed with the `https://sys-data.int.bgdi.ch`.

The special treatment of assets' `href` was introduced in [PB-35 external asset URL](https://swissgeoplatform.atlassian.net/browse/PB-35), that is why I set @schtibe as reviewer.

To see how the validation of `href` works one can follow the example of the [putAsset endpoint](https://sys-data.int.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data-Management/operation/putAsset). Here, the asset's `href`` is set to one of our own URLs if it's not defined in the payload.

There are two changes now for the bulk upload:
1. For the bulk upload, assume that every asset points to an external resource. That is just to get early feedback before changing too much. We could also add a conditional branch to construct the URL as for putAsset.
2. Add validation of the `href` fields, just as it's done for the `putAsset` endpoint. See `validators.validate_href_url()`: This checks, among others, if the URL is white listed and reachable. **Pinging the URL probably introduces a notable performance penalty - do we really want that? @boecklic**

As I changed the relatively central `AssetBaseSerializer`, I am not 100% confident that I have not introduced accidental changes elsewhere. The tests are green but I am not sure that the asset's `href` field is checked for appropriately everywhere.