### PR TITLE
Add ability to log stack traces on exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ The service is configured by Environment Variable:
 | STAC_BROWSER_BASE_PATH | `browser/index.html` | STAC Browser base path. |
 | GUNICORN_WORKERS | `2` | Number of Gunicorn workers |
 | GUNICORN_WORKER_TMP_DIR | `None` | Path to a tmpfs directory for Gunicorn. If `None` let gunicorn decide which path to use. See https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir. |
+| GUNICORN_DUMP_STACKS_ON_EXIT | `False` | Whether to log stack trace of all threads upon exit. |
 
 #### **Database settings**
 


### PR DESCRIPTION
This is controlled by the `GUNICORN_DUMP_STACKS_ON_EXIT` environment variable.

As gunicorn insists on doing its own signal handling, we cannot use [faulthandler](https://docs.python.org/3/library/faulthandler.html)).

As we use the gevent asynchronous workers model, we need to use the special [gevent stack dumping mechanism](https://www.gevent.org/api/gevent.util.html#gevent.util.format_run_info) (i.e. not the regular [traceback](https://docs.python.org/3/library/traceback.html)) to get something useful.

Upon
[liveness probe failure](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes), [Kubernetes sends a `SIGTERM`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) to the master, waits `terminationGracePeriodSeconds` then sends a `SIGKILL`. The [master propagates the `SIGTERM` to the workers](https://docs.gunicorn.org/en/stable/signals.html) then waits [`graceful_timeout` seconds](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout) before [sending its own `SIGKILL`](https://github.com/benoitc/gunicorn/blob/a86ea1e4e6c271d1cd1823c7e14490123f9238fe/gunicorn/arbiter.py#L374-399). The workers [handle the `SIGTERM` with their `handle_exit` method](https://github.com/benoitc/gunicorn/blob/a86ea1e4e6c271d1cd1823c7e14490123f9238fe/gunicorn/workers/base.py#L174).

The [`worker_exit` handler](https://docs.gunicorn.org/en/stable/settings.html#worker-exit) is [only called after the worker completes](https://github.com/benoitc/gunicorn/blob/a86ea1e4e6c271d1cd1823c7e14490123f9238fe/gunicorn/arbiter.py#L631). If it takes more than `graceful_timeout` or `terminationGracePeriodSeconds` to complete, it is never invoked. Thus it is not appropriate for our purpose.

We resolve this by implementing our own worker class. That class inherits from the [gevent worker class](https://github.com/benoitc/gunicorn/blob/a86ea1e4e6c271d1cd1823c7e14490123f9238fe/gunicorn/workers/ggevent.py#L32) and only overrides the `handle_exit` method. That overridden method dumps the stacks then hands over control to the parent's method.

We use the regular logger mechanism. It is not configured at the time the stack dumping method is defined but it is expected to be by the time it is called.

I tested this by doing the following:

- add a `time.sleep(1000)` to `app/config/urls.checker`
- run `GUNICORN_DUMP_STACKS_ON_EXIT=1 make gunicornserve`
- run `curl http://127.0.0.1:8000/checker`
- send SIGTERM to the master process
- verify the output contains a line pointing to `time.sleep` (before the `graceful_timeout` delay)

Example output (extract):
```
 :                  File "[...]/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
 :                    response = wrapped_callback(request, *callback_args, **callback_kwargs)
 :                  File "[...]/app/config/urls.py", line 27, in checker
 :                    time.sleep(1000)
 :                  File "[...]/.venv/lib/python3.12/site-packages/gevent/hub.py", line 166, in sleep
 :                    hub.wait(t)
```