### PR TITLE
Attempt to work around gevent/urllib3 deadlock.

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -30,7 +30,12 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/
 import logging
 import os
 
+import gevent.queue
 import gevent.util
+
+if os.environ.get('GEVENT_PATCH_URLLIB3_CPOOL_QUEUE', False):
+    import urllib3.connectionpool
+    urllib3.connectionpool.ConnectionPool.QueueCls = gevent.queue.LifoQueue
 
 from gunicorn.app.base import BaseApplication
 from gunicorn.workers.ggevent import GeventWorker


### PR DESCRIPTION
We often see deadlocks involving urllib3's connection pool queue. Its looks likely to be related to https://github.com/gevent/gevent/issues/1957#issuecomment-1900138350 A workaround suggested in that issue is to explicitely patch `urllib3.ConnectionPool.QueueCls` after the call to `gevent.monkey.patch_all`.

This change does that, guarded by the `GEVENT_PATCH_URLLIB3_CPOOL_QUEUE` environment variable.