### PR TITLE
PB-1531: only dump stacks when exit is taking too long.

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,8 @@ The service is configured by Environment Variable:
 | STAC_BROWSER_BASE_PATH | `browser/index.html` | STAC Browser base path. |
 | GUNICORN_WORKERS | `2` | Number of Gunicorn workers |
 | GUNICORN_WORKER_TMP_DIR | `None` | Path to a tmpfs directory for Gunicorn. If `None` let gunicorn decide which path to use. See https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir. |
-| GUNICORN_DUMP_STACKS_ON_EXIT | `False` | Whether to log stack trace of all threads upon exit. |
+| GUNICORN_STACK_DUMP_DELAY | `29` | Upon exit, how long to wait before logging stack traces. The default is one second less than `GUNICORN_GRACEFUL_TIMEOUT`. Setting this to a value equal or greater to `GUNICORN_GRACEFUL_TIMEOUT` effectively disables stack dumping.
+| GUNICORN_GRACEFUL_TIMEOUT | `30` | The [`graceful_timeout`](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout) setting passed to gunicorn.
 
 #### **Database settings**
 


### PR DESCRIPTION
In https://github.com/geoadmin/service-stac/pull/558 we added the ability to log stack traces upon exit. However we did not distinguish between a normal graceful exit and an abnormal exit of a deadlocked service. This means that on every exit/restart, we clutter the logs with stack traces.

With this change, upon exit we only attempt to dump the stack if the worker is still running after a delay. This means that graceful exit that complete within that delay do not clutter the logs with stack traces.

This change removes the `GUNICORN_DUMP_STACKS_ON_EXIT` variable and adds `GUNICORN_STACK_DUMP_DELAY` and `GUNICORN_GRACEFUL_TIMEOUT`. The former being set by default to one second less than the latter. We may need to tweak `GUNICORN_GRACEFUL_TIMEOUT` to be coherent with the Kubernetes `terminationGracePeriodSeconds`.

Another way to resolve this might be implemented upstream later in https://github.com/benoitc/gunicorn/issues/3385