### PR TITLE
PB-1575: make remove_expired_items more memory-efficient, probably.

### DIFF
--- a/app/stac_api/management/commands/remove_expired_items.py
+++ b/app/stac_api/management/commands/remove_expired_items.py
@@ -38,7 +38,7 @@ class Handler(CommandHandler):
                     "These are likely stale, so we'll abort them"
                 )
                 uploads_in_progress.update(status=BaseAssetUpload.Status.ABORTED)
-            self.delete(item.assets.all(), 'assets')
+            self.delete(item.assets.get_queryset(), 'assets')
             self.delete(item, 'item')
             if not self.options['dry_run']:
                 self.print_success(


### PR DESCRIPTION
The cron jobs running this command often runs out of memory in production. The calls to [`all()`](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#all) are likely consuming a relatively large amount of memory. This change replaces them with [iterators](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#iterator) which are supposed to be cheaper.

Tests still pass but I have not verified actual memory usage before/after. I propose to just push as is and monitor the situation. If it resolves the problem, great. Otherwise we can still benchmark or consider other actions later.