### PR TITLE
PB-1635 Hide expired items in search

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -365,9 +365,7 @@ DISALLOWED_EXTERNAL_ASSET_URL_SCHEMES = env.list(
 )
 
 # Feature flag to hide/show expired items in the search endpoint
-FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED = env(
-    'FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED', bool, default=True
-)
+HIDE_EXPIRED_ITEMS_IN_SEARCH = env('HIDE_EXPIRED_ITEMS_IN_SEARCH', bool, default=True)
 
 # These are the default values from Django as per
 # https://docs.djangoproject.com/en/5.1/ref/settings/

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -364,6 +364,11 @@ DISALLOWED_EXTERNAL_ASSET_URL_SCHEMES = env.list(
     'DISALLOWED_EXTERNAL_ASSET_URL_SCHEMES', default=['http']
 )
 
+# Feature flag to hide/show expired items in the search endpoint
+FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED = env(
+    'FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED', bool, default=True
+)
+
 # These are the default values from Django as per
 # https://docs.djangoproject.com/en/5.1/ref/settings/
 # We add them here so they can be changed through environment variables.

--- a/app/stac_api/validators_view.py
+++ b/app/stac_api/validators_view.py
@@ -1,8 +1,6 @@
 import logging
 
-from django.db.models import Q
 from django.http import Http404
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -11,6 +9,7 @@ from stac_api.models.collection import Collection
 from stac_api.models.collection import CollectionAsset
 from stac_api.models.item import Asset
 from stac_api.models.item import Item
+from stac_api.views.filters import create_is_active_filter
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ def validate_item(kwargs):
         Http404: when the item doesn't exists
     '''
     if not Item.objects.filter(
-        Q(properties_expires=None) | Q(properties_expires__gte=timezone.now()),
+        create_is_active_filter(),
         name=kwargs['item_name'],
         collection__name=kwargs['collection_name']
     ).exists():

--- a/app/stac_api/views/filters.py
+++ b/app/stac_api/views/filters.py
@@ -1,0 +1,9 @@
+from django.db.models import Q
+from django.utils import timezone
+
+
+def create_is_active_filter():
+    """
+    Create a filter to check if the item is not expired.
+    """
+    return Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None)

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -73,7 +73,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
     # pylint: disable=too-many-branches
     def get_queryset(self):
         filter_condition = Q(collection__published=True)
-        if settings.FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED:
+        if settings.HIDE_EXPIRED_ITEMS_IN_SEARCH:
             is_active = create_is_active_filter()
             filter_condition &= is_active
         queryset = Item.objects.filter(filter_condition).prefetch_related('assets', 'links')

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -72,9 +72,11 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
 
     # pylint: disable=too-many-branches
     def get_queryset(self):
-        is_active = Q(properties_expires=None) | Q(properties_expires__gte=timezone.now())
-        is_public = Q(collection__published=True)
-        queryset = Item.objects.filter(is_public & is_active).prefetch_related('assets', 'links')
+        filter_condition = Q(collection__published=True)
+        if settings.FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED:
+            is_active = Q(properties_expires=None) | Q(properties_expires__gte=timezone.now())
+            filter_condition &= is_active
+        queryset = Item.objects.filter(filter_condition).prefetch_related('assets', 'links')
 
         # harmonize GET and POST query
         query_param = harmonize_post_get_for_search(self.request)

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -74,7 +74,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
     def get_queryset(self):
         filter_condition = Q(collection__published=True)
         if settings.FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED:
-            is_active = Q(properties_expires=None) | Q(properties_expires__gte=timezone.now())
+            is_active = Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None)
             filter_condition &= is_active
         queryset = Item.objects.filter(filter_condition).prefetch_related('assets', 'links')
 

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db.models import Q
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import generics
@@ -27,6 +26,7 @@ from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import is_api_version_1
 from stac_api.utils import utc_aware
 from stac_api.validators_serializer import ValidateSearchRequest
+from stac_api.views.filters import create_is_active_filter
 from stac_api.views.mixins import patch_collections_aggregate_cache_control_header
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
     def get_queryset(self):
         filter_condition = Q(collection__published=True)
         if settings.FEATURE_HIDE_EXPIRED_ITEMS_IN_SEARCH_ENABLED:
-            is_active = Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None)
+            is_active = create_is_active_filter()
             filter_condition &= is_active
         queryset = Item.objects.filter(filter_condition).prefetch_related('assets', 'links')
 

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -3,6 +3,8 @@ import logging
 from datetime import datetime
 
 from django.conf import settings
+from django.db.models import Q
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import generics
@@ -70,8 +72,10 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
 
     # pylint: disable=too-many-branches
     def get_queryset(self):
-        queryset = Item.objects.filter(collection__published=True
-                                      ).prefetch_related('assets', 'links')
+        is_active = Q(properties_expires=None) | Q(properties_expires__gte=timezone.now())
+        is_public = Q(collection__published=True)
+        queryset = Item.objects.filter(is_public & is_active).prefetch_related('assets', 'links')
+
         # harmonize GET and POST query
         query_param = harmonize_post_get_for_search(self.request)
 

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -27,6 +27,7 @@ from stac_api.validators_view import validate_collection
 from stac_api.validators_view import validate_item
 from stac_api.validators_view import validate_renaming
 from stac_api.views import mixins
+from stac_api.views.filters import create_is_active_filter
 from stac_api.views.general import get_etag
 
 logger = logging.getLogger(__name__)
@@ -93,8 +94,7 @@ class ItemsList(generics.GenericAPIView):
     def get_queryset(self):
         # filter based on the url
         queryset = Item.objects.filter(
-            # filter expired items
-            Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None),
+            create_is_active_filter(),
             # Using a subquery to get the collection id and then filter on the id greatly improves
             # the performance over filtering by 'collection__name'.
             collection__id=Subquery(
@@ -202,8 +202,7 @@ class ItemDetail(
     def get_queryset(self):
         # filter based on the url
         queryset = Item.objects.filter(
-            # filter expired items
-            Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None),
+            create_is_active_filter(),
             # Using a subquery to get the collection id and then filter on the id greatly improves
             # the performance over filtering by 'collection__name'.
             collection__id=Subquery(

--- a/app/tests/tests_10/test_search_endpoint.py
+++ b/app/tests/tests_10/test_search_endpoint.py
@@ -514,6 +514,13 @@ class SearchEndpointTestCaseTwo(StacBaseTestCase):
         self.factory.create_item_sample(
             self.collection, name='item-expired', db_create=True, properties_expires=tomorrow
         )
+        in_a_week = timezone.now() + timedelta(days=7)
+        self.factory.create_item_sample(
+            self.collection,
+            name='item-with-expiration-date-but-active',
+            db_create=True,
+            properties_expires=in_a_week
+        )
 
         after_tomorrow = timezone.now() + timedelta(days=2)
         with patch.object(timezone, "now", return_value=after_tomorrow):
@@ -522,11 +529,19 @@ class SearchEndpointTestCaseTwo(StacBaseTestCase):
         self.assertStatusCode(200, response)
         feature_ids = [feature["id"] for feature in response.json()['features']]
         self.assertNotIn('item-expired', feature_ids)
+        self.assertIn('item-with-expiration-date-but-active', feature_ids)
 
     def test_post_does_not_show_expired_items(self):
         tomorrow = timezone.now() + timedelta(days=1)
         self.factory.create_item_sample(
             self.collection, name='item-expired', db_create=True, properties_expires=tomorrow
+        )
+        in_a_week = timezone.now() + timedelta(days=7)
+        self.factory.create_item_sample(
+            self.collection,
+            name='item-with-expiry-date-but-active',
+            db_create=True,
+            properties_expires=in_a_week
         )
 
         after_tomorrow = timezone.now() + timedelta(days=2)
@@ -536,6 +551,7 @@ class SearchEndpointTestCaseTwo(StacBaseTestCase):
         self.assertStatusCode(200, response)
         feature_ids = [feature["id"] for feature in response.json()['features']]
         self.assertNotIn('item-expired', feature_ids)
+        self.assertIn('item-with-expiry-date-but-active', feature_ids)
 
 
 @override_settings(CACHE_MIDDLEWARE_SECONDS=3600)


### PR DESCRIPTION
This hides expired items in the `/search` endpoints. That this wasn't done already only became apparent when a bug prevented the cron job `cron-delete-expired` to clean up expired items properly, see PB-1575.

There are two search endpoints affected by this change:
1. [GET /search](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/STAC/operation/getSearchSTAC): Simple filtering
2. [POST /search](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/STAC/operation/postSearchSTAC): Advanced filtering in the payload.

We hide an item if has property "expires" set to a time in the past, so in principle the same as in these endpoints:
- [GET /collections/{collectionId}/items](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data/operation/getFeatures): Fetch features
- [GET /collections/{collectionId}/items/{featureId}](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data/operation/getFeature): Fetch a single feature

To discuss:
1. There is a small difference to the Item endpoints. I first check if the field is defined and then compare timestamps, not vice versa:
   - Items endpoints: `Q(properties_expires__gte=timezone.now()) | Q(properties_expires=None)`
   - Search endpoints: `Q(properties_expires=None) | Q(properties_expires__gte=timezone.now())`
   
   I don't see why you would check for `None` only after... Is this a bug?
2. To check whether an expiry date is in the past, the reference time is the time at which the query is processed on our server. As storage and filtering is done on the same server, I don't see problems with time zones.