### PR TITLE
PB-1575: don't attempt to delete externally hosted S3 objects.

### DIFF
--- a/app/stac_api/signals.py
+++ b/app/stac_api/signals.py
@@ -54,8 +54,9 @@ def delete_s3_asset(sender, instance, **kwargs):
     # The file is not automatically deleted by Django
     # when the object holding its reference is deleted
     # hence it has to be done here.
-    logger.info("The asset %s is deleted from s3", instance.file.name)
-    instance.file.delete(save=False)
+    if not instance.is_external:
+        logger.info("The asset %s is deleted from s3", instance.file.name)
+        instance.file.delete(save=False)
 
 
 @receiver(pre_delete, sender=CollectionAsset)
@@ -63,5 +64,6 @@ def delete_s3_collection_asset(sender, instance, **kwargs):
     # The file is not automatically deleted by Django
     # when the object holding its reference is deleted
     # hence it has to be done here.
-    logger.info("The collection asset %s is deleted from s3", instance.file.name)
-    instance.file.delete(save=False)
+    if not instance.is_external:
+        logger.info("The collection asset %s is deleted from s3", instance.file.name)
+        instance.file.delete(save=False)


### PR DESCRIPTION
Every time we delete an `Asset` or `CollectionAsset`, we make a call to the corresponding S3 `DeleteObjects` method. For objects that are hosted externally (i.e. not in an S3 bucket we control), this call always fails silently and we can just as well not do it.

With this change, we stop attempting to call `DeleteObjects` for externally hosted `Assets` and `CollectionAssets`, thus speeding up deletion.