### PR TITLE
PB-1590: Added item-search conformance - #minor

### DIFF
--- a/app/stac_api/exceptions.py
+++ b/app/stac_api/exceptions.py
@@ -32,3 +32,9 @@ class UploadInProgressError(StacAPIException):
     status_code = status.HTTP_409_CONFLICT
     default_detail = _('Upload already in progress')
     default_code = 'conflict'
+
+
+class NotImplementedException(StacAPIException):
+    status_code = status.HTTP_501_NOT_IMPLEMENTED
+    default_detail = _('Not Implemented')
+    default_code = 'not_implemented'

--- a/app/stac_api/managers.py
+++ b/app/stac_api/managers.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry
@@ -8,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
+from stac_api.utils import fromisoformat
 from stac_api.utils import geometry_from_bbox
 from stac_api.validators import validate_geometry
 
@@ -158,11 +158,13 @@ class ItemQuerySet(models.QuerySet):
             ValidationError: When the date_time string is not a valid isoformat
         '''
         start, sep, end = date_time.partition('/')
+        if start == '':
+            start = '..'
         try:
             if start != '..':
-                start = datetime.fromisoformat(start.replace('Z', '+00:00'))
+                start = fromisoformat(start)
             if end and end != '..':
-                end = datetime.fromisoformat(end.replace('Z', '+00:00'))
+                end = fromisoformat(end)
         except ValueError as error:
             logger.error(
                 'Invalid datetime query parameter "%s", must be isoformat; %s', date_time, error

--- a/app/stac_api/migrations/0067_update_conformance.py
+++ b/app/stac_api/migrations/0067_update_conformance.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def update_conformance(apps, schema_editor):
+    # Add item-search conformance
+    LandingPage = apps.get_model("stac_api", "LandingPage")
+    lp = LandingPage.objects.get(version='v1')
+    lp.conformsTo = [
+        'https://api.stacspec.org/v1.0.0/core',
+        'https://api.stacspec.org/v1.0.0/collections',
+        'https://api.stacspec.org/v1.0.0/ogcapi-features',
+        'https://api.stacspec.org/v1.0.0/item-search',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+    ]
+    lp.save()
+
+
+def reverse_update_conformance(apps, schema_editor):
+    # Remove item-search conformance
+    LandingPage = apps.get_model("stac_api", "LandingPage")
+    lp = LandingPage.objects.get(version='v1')
+    lp.conformsTo = [
+        'https://api.stacspec.org/v1.0.0/core',
+        'https://api.stacspec.org/v1.0.0/collections',
+        'https://api.stacspec.org/v1.0.0/ogcapi-features',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+    ]
+    lp.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("stac_api", "0066_collectionasset_is_external"),
+    ]
+
+    operations = [migrations.RunPython(update_conformance, reverse_update_conformance)]

--- a/app/stac_api/pagination.py
+++ b/app/stac_api/pagination.py
@@ -89,15 +89,13 @@ def validate_page_size(size_string, max_page_size, log_extra=None):
             _('limit query parameter too small, must be in range 1..%d') % (max_page_size),
         )
     if max_page_size and page_size > max_page_size:
-        logger.error(
-            'Invalid query parameter limit=%d: number bigger than the max size of %d',
+        logger.warning(
+            'Invalid query parameter limit=%d: using the the max size of %d',
             page_size,
             max_page_size,
             extra=log_extra
         )
-        raise serializers.ValidationError(
-            _('limit query parameter too big, must be in range 1..%d') % (max_page_size)
-        )
+        page_size = max_page_size
     return page_size
 
 

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -308,6 +308,8 @@ def harmonize_post_get_for_search(request):
             query_param['ids'] = query_param['ids'].split(',')  # to array
         if 'collections' in query_param:
             query_param['collections'] = query_param['collections'].split(',')  # to array
+        if 'intersects' in query_param:
+            query_param['intersects'] = json.loads(query_param['intersects'])
 
         # Forecast properties can only be filtered with method POST.
         # Decision was made as `:` need to be url encoded and (at least for now) we do not need to

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -51,7 +51,7 @@ def isoformat(date_time):
 def fromisoformat(date_time):
     '''Return a datetime object from a isoformated datetime string
     '''
-    return datetime.fromisoformat(date_time.replace('Z', '+00:00'))
+    return datetime.fromisoformat(date_time.upper().replace('Z', '+00:00'))
 
 
 def utc_aware(date_time):

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -24,6 +24,8 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.urls import reverse
 
+from stac_api.exceptions import NotImplementedException
+
 logger = logging.getLogger(__name__)
 
 AVAILABLE_S3_BUCKETS = Enum('AVAILABLE_S3_BUCKETS', list(settings.AWS_SETTINGS.keys()))
@@ -455,11 +457,14 @@ def geometry_from_bbox(bbox):
         Geometry
 
     Raises:
-        ValueError, IndexError, GDALException
+        ValueError, IndexError, GDALException, NotImplementedException
     '''
     list_bbox_values = bbox.split(',')
     if len(list_bbox_values) == 6:
-        raise ValueError('3-dimensional bbox is currently not supported')
+        # According to stac search extension the bbox may contain 6 values to represent
+        # 3-dimensional bounding box. As the current implementation does not support this,
+        # return 501 Not Implemented.
+        raise NotImplementedException(detail='3-dimensional bbox is currently not supported')
     if len(list_bbox_values) != 4:
         raise ValueError('A bbox is based of four values')
     try:

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -458,6 +458,8 @@ def geometry_from_bbox(bbox):
         ValueError, IndexError, GDALException
     '''
     list_bbox_values = bbox.split(',')
+    if len(list_bbox_values) == 6:
+        raise ValueError('3-dimensional bbox is currently not supported')
     if len(list_bbox_values) != 4:
         raise ValueError('A bbox is based of four values')
     try:

--- a/app/stac_api/validators_serializer.py
+++ b/app/stac_api/validators_serializer.py
@@ -250,6 +250,8 @@ class ValidateSearchRequest:
                 The datetime to get validated
         '''
         start, sep, end = date_time.partition('/')
+        if start == '':
+            start = '..'
         message = None
         try:
             if start != '..':

--- a/app/tests/tests_09/test_generic_api.py
+++ b/app/tests/tests_09/test_generic_api.py
@@ -100,10 +100,7 @@ class ApiPaginationTestCase(StacBaseTestCase):
                                  msg='Unexpected error message')
 
                 response = self.client.get(f"/{STAC_BASE_V}/{endpoint}?limit=1000")
-                self.assertStatusCode(400, response)
-                self.assertEqual(['limit query parameter too big, must be in range 1..100'],
-                                 response.json()['description'],
-                                 msg='Unexpected error message')
+                self.assertStatusCode(200, response)
 
     @mock_s3_asset_file
     def test_pagination(self):

--- a/app/tests/tests_09/test_generic_api.py
+++ b/app/tests/tests_09/test_generic_api.py
@@ -114,7 +114,9 @@ class ApiPaginationTestCase(StacBaseTestCase):
             response = self.client.get(f"/{STAC_BASE_V}/{endpoint}?limit=1000")
             self.assertStatusCode(200, response)
             page_1 = response.json()
-            self.assertEqual(len(page_1['features']), 100)
+            self.assertEqual(
+                len(page_1['features']), 100, msg='Number of features not equal to max_page_size'
+            )
             # Make sure previous link is not present
             self.assertIsNone(
                 get_link(page_1['links'], 'previous'),

--- a/app/tests/tests_09/test_items_endpoint_bbox.py
+++ b/app/tests/tests_09/test_items_endpoint_bbox.py
@@ -76,11 +76,27 @@ class ItemsBboxQueryEndpointTestCase(StacBaseTestCase):
         )
         self.assertStatusCode(400, response)
 
+        # test invalid bbox with 5 values
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
+            f"?bbox=5.96,45.82,10.49,47.81,42;&limit=100"
+        )
+        self.assertStatusCode(400, response)
+
+        # test invalid bbox with 7 values
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
+            f"?bbox=5.96,45.82,10.49,47.81,42,42,42;&limit=100"
+        )
+        self.assertStatusCode(400, response)
+
+    def test_items_endpoint_bbox_not_implemented_query(self):
+        # 3-dimensional bbox (6 values) is not (yet) implemented
         response = self.client.get(
             f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
             f"?bbox=5.96,45.82,10.49,47.81,42,42&limit=100"
         )
-        self.assertStatusCode(400, response)
+        self.assertStatusCode(501, response)
 
     def test_items_endpoint_bbox_from_pseudo_point(self):
         response = self.client.get(

--- a/app/tests/tests_10/test_generic_api.py
+++ b/app/tests/tests_10/test_generic_api.py
@@ -100,10 +100,7 @@ class ApiPaginationTestCase(StacBaseTestCase):
                                  msg='Unexpected error message')
 
                 response = self.client.get(f"/{STAC_BASE_V}/{endpoint}?limit=1000")
-                self.assertStatusCode(400, response)
-                self.assertEqual(['limit query parameter too big, must be in range 1..100'],
-                                 response.json()['description'],
-                                 msg='Unexpected error message')
+                self.assertStatusCode(200, response)
 
     @mock_s3_asset_file
     def test_pagination(self):

--- a/app/tests/tests_10/test_generic_api.py
+++ b/app/tests/tests_10/test_generic_api.py
@@ -114,7 +114,9 @@ class ApiPaginationTestCase(StacBaseTestCase):
             response = self.client.get(f"/{STAC_BASE_V}/{endpoint}?limit=1000")
             self.assertStatusCode(200, response)
             page_1 = response.json()
-            self.assertEqual(len(page_1['features']), 100)
+            self.assertEqual(
+                len(page_1['features']), 100, msg='Number of features not equal to max_page_size'
+            )
             # Make sure previous link is not present
             self.assertIsNone(
                 get_link(page_1['links'], 'previous'),

--- a/app/tests/tests_10/test_items_endpoint_bbox.py
+++ b/app/tests/tests_10/test_items_endpoint_bbox.py
@@ -76,11 +76,27 @@ class ItemsBboxQueryEndpointTestCase(StacBaseTestCase):
         )
         self.assertStatusCode(400, response)
 
+        # test invalid bbox with 5 values
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
+            f"?bbox=5.96,45.82,10.49,47.81,42;&limit=100"
+        )
+        self.assertStatusCode(400, response)
+
+        # test invalid bbox with 7 values
+        response = self.client.get(
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
+            f"?bbox=5.96,45.82,10.49,47.81,42,42,42;&limit=100"
+        )
+        self.assertStatusCode(400, response)
+
+    def test_items_endpoint_bbox_not_implemented_query(self):
+        # 3-dimensional bbox (6 values) is not (yet) implemented
         response = self.client.get(
             f"/{STAC_BASE_V}/collections/{self.collection.name}/items"
             f"?bbox=5.96,45.82,10.49,47.81,42,42&limit=100"
         )
-        self.assertStatusCode(400, response)
+        self.assertStatusCode(501, response)
 
     def test_items_endpoint_bbox_from_pseudo_point(self):
         response = self.client.get(

--- a/app/tests/tests_10/test_search_endpoint.py
+++ b/app/tests/tests_10/test_search_endpoint.py
@@ -343,6 +343,13 @@ class SearchEndpointTestCaseOne(StacBaseTestCase):
         json_data = response.json()
         self.assertEqual(json_data['features'][0]['id'], 'item-3')
 
+    def test_get_intersects_valid(self):
+        data = {"intersects": {"type": "POINT", "coordinates": [6, 47]}}
+        response = self.client.get(f"{self.path}?intersects={json.dumps(data['intersects'])}")
+        json_data_get = response.json()
+        self.assertStatusCode(200, response)
+        self.assertEqual(json_data_get['features'][0]['id'], 'item-3')
+
     def test_post_intersects_invalid(self):
         data = {"intersects": {"type": "POINT", "coordinates": [6, 47, "kaputt"]}}
         response = self.client.post(self.path, data=data, content_type="application/json")

--- a/spec/components/parameters.yaml
+++ b/spec/components/parameters.yaml
@@ -25,6 +25,14 @@ components:
       schema:
         $ref: "./schemas.yaml#/components/schemas/bbox"
       style: form
+    intersects:
+      explode: false
+      in: query
+      name: intersects
+      required: false
+      schema:
+        $ref: "./schemas.yaml#/components/schemas/intersectsFilter"
+      style: form
     collectionId:
       description: Local identifier of a collection
       in: path

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -324,6 +324,7 @@ paths:
       operationId: getSearchSTAC
       parameters:
         - $ref: "./components/parameters.yaml#/components/parameters/bbox"
+        - $ref: "./components/parameters.yaml#/components/parameters/intersects"
         - $ref: "./components/parameters.yaml#/components/parameters/datetime"
         - $ref: "./components/parameters.yaml#/components/parameters/limit"
         - $ref: "./components/parameters.yaml#/components/parameters/ids"

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -32,6 +32,14 @@ components:
       schema:
         $ref: "#/components/schemas/bbox"
       style: form
+    intersects:
+      explode: false
+      in: query
+      name: intersects
+      required: false
+      schema:
+        $ref: "#/components/schemas/intersectsFilter"
+      style: form
     collectionId:
       description: Local identifier of a collection
       in: path
@@ -2258,6 +2266,7 @@ paths:
       operationId: getSearchSTAC
       parameters:
         - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/intersects"
         - $ref: "#/components/parameters/datetime"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/ids"

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -32,6 +32,14 @@ components:
       schema:
         $ref: "#/components/schemas/bbox"
       style: form
+    intersects:
+      explode: false
+      in: query
+      name: intersects
+      required: false
+      schema:
+        $ref: "#/components/schemas/intersectsFilter"
+      style: form
     collectionId:
       description: Local identifier of a collection
       in: path
@@ -3859,6 +3867,7 @@ paths:
       operationId: getSearchSTAC
       parameters:
         - $ref: "#/components/parameters/bbox"
+        - $ref: "#/components/parameters/intersects"
         - $ref: "#/components/parameters/datetime"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/ids"


### PR DESCRIPTION
Add item search-conformance. We still are missing a couple of points to be 100% conform to the spec, however for our use cases it is close enough and still helpful to add the item-search to our conformance list.
Missing conformance:
- Return Content-Type Header is not `application/geo+json`. This would be a breaking change
- Filter by 3d bbox (bbox with 6 values). Not a trivial change.

Changes:
- If limit is larger than the configured max_limit, use max_limit instead of returning status 400
  - According to https://github.com/radiantearth/stac-api-spec/blob/release/v1.0.0/item-search/README.md#query-parameter-table
- Datetime is case insensitive
- Filter by intersect in GET request, as is the case with a POST request
- If bbox has 6 values, return status 501 and custom error message informing that we do not support 3d bboxes
- Add item-search conformance link (https://api.stacspec.org/v1.0.0/item-search) to landing page for v1

