### PR TITLE
PB-1704: Handle application/geo+json requests

### DIFF
--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -317,7 +317,10 @@ TEST_RUNNER = 'tests.runner.TestRunner'
 # set authentication schemes
 
 REST_FRAMEWORK = {
-    'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+        'helpers.renderers.GeoJSONRenderer',
+    ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'middleware.api_gateway_authentication.ApiGatewayAuthentication',
         'middleware.rest_framework_authentication.RestrictedBasicAuthentication',

--- a/app/helpers/renderers.py
+++ b/app/helpers/renderers.py
@@ -1,0 +1,12 @@
+from rest_framework.renderers import JSONRenderer
+
+
+class GeoJSONRenderer(JSONRenderer):
+    """ Renders geojson.
+
+    It is used if a client sends an "Accept: application/geo+json" header or uses the
+    "format=geojson" query parameter.
+
+    """
+    media_type = 'application/geo+json'
+    format = 'geojson'

--- a/app/tests/tests_09/test_renderer.py
+++ b/app/tests/tests_09/test_renderer.py
@@ -1,0 +1,40 @@
+from django.test import Client
+from django.test import TestCase
+
+from tests.tests_09.base_test import STAC_BASE_V
+
+
+class RendererTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_content_type_default(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+    def test_content_type_json(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search?format=json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+        response = self.client.get(f"/{STAC_BASE_V}/search", headers={'Accept': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+    def test_content_type_geojson(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search?format=geojson")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/geo+json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+        response = self.client.get(
+            f"/{STAC_BASE_V}/search", headers={'Accept': 'application/geo+json'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/geo+json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')

--- a/app/tests/tests_10/test_renderer.py
+++ b/app/tests/tests_10/test_renderer.py
@@ -1,0 +1,40 @@
+from django.test import Client
+from django.test import TestCase
+
+from tests.tests_10.base_test import STAC_BASE_V
+
+
+class RendererTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_content_type_default(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+    def test_content_type_json(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search?format=json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+        response = self.client.get(f"/{STAC_BASE_V}/search", headers={'Accept': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+    def test_content_type_geojson(self):
+        response = self.client.get(f"/{STAC_BASE_V}/search?format=geojson")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/geo+json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')
+
+        response = self.client.get(
+            f"/{STAC_BASE_V}/search", headers={'Accept': 'application/geo+json'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/geo+json')
+        self.assertEqual(response.json()['type'], 'FeatureCollection')


### PR DESCRIPTION
Adds a new DRF renderer that accepts `geojson` request, either via `Accept: application/geo+json` header or using the `format=geojson` query parameter, and returns JSON as usual but `Content-Type: application/geo+json`. Default/unspecified is still `application/json`.