### PR TITLE
PB-1600: Update image to debian 12/bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Container that contains basic configurations used by all other containers
 # It should only contain variables that don't change or change very infrequently
 # so that the cache is not needlessly invalidated
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 ENV HTTP_PORT=8080
 ENV USER=geoadmin
 ENV GROUP=geoadmin


### PR DESCRIPTION
Update base image to debian 12/bookworm.

There have been some reports with `gevent` issues being resolved by updating debian to 12+.