### PR TITLE
fix: update Access-Control-Allow-Headers for edge using `Accept-Language` header longer 128

### DIFF
--- a/app/middleware/cors.py
+++ b/app/middleware/cors.py
@@ -33,6 +33,6 @@ class CORSHeadersMiddleware:
         if request.path in (f'/{STAC_BASE}/v0.9/search', f'/{STAC_BASE}/v1/search'):
             allow_methods.append('POST')
         response['Access-Control-Allow-Methods'] = ','.join(allow_methods)
-        response['Access-Control-Allow-Headers'] = 'Content-Type,Accept'
+        response['Access-Control-Allow-Headers'] = 'Content-Type,Accept,Accept-Language'
 
         return response

--- a/app/tests/tests_09/base_test.py
+++ b/app/tests/tests_09/base_test.py
@@ -129,7 +129,7 @@ class StacTestMixin:
 
     def assertCors(self, response):  # pylint: disable=invalid-name
         for header, value in {
-            'Access-Control-Allow-Headers': 'Content-Type,Accept',
+            'Access-Control-Allow-Headers': 'Content-Type,Accept,Accept-Language',
             'Access-Control-Allow-Methods': 'GET,HEAD',
             'Access-Control-Allow-Origin': '*'
         }.items():

--- a/app/tests/tests_09/test_generic_api.py
+++ b/app/tests/tests_09/test_generic_api.py
@@ -684,7 +684,7 @@ class ApiCORSHeaderTestCase(MockS3PerTestMixin, StacBaseTestCase):
 
                 self.assertEqual(
                     response['Access-Control-Allow-Headers'],
-                    'Content-Type,Accept',
+                    'Content-Type,Accept,Accept-Language',
                     msg='Wrong CORS allow-Headers value'
                 )
 
@@ -719,6 +719,6 @@ class ApiCORSHeaderTestCase(MockS3PerTestMixin, StacBaseTestCase):
 
         self.assertEqual(
             response['Access-Control-Allow-Headers'],
-            'Content-Type,Accept',
+            'Content-Type,Accept,Accept-Language',
             msg='Wrong CORS allow-Headers value'
         )

--- a/app/tests/tests_10/base_test.py
+++ b/app/tests/tests_10/base_test.py
@@ -130,7 +130,7 @@ class StacTestMixin:
 
     def assertCors(self, response):  # pylint: disable=invalid-name
         for header, value in {
-            'Access-Control-Allow-Headers': 'Content-Type,Accept',
+            'Access-Control-Allow-Headers': 'Content-Type,Accept,Accept-Language',
             'Access-Control-Allow-Methods': 'GET,HEAD',
             'Access-Control-Allow-Origin': '*'
         }.items():

--- a/app/tests/tests_10/test_generic_api.py
+++ b/app/tests/tests_10/test_generic_api.py
@@ -677,7 +677,7 @@ class ApiCORSHeaderTestCase(MockS3PerTestMixin, StacBaseTestCase):
 
                 self.assertEqual(
                     response['Access-Control-Allow-Headers'],
-                    'Content-Type,Accept',
+                    'Content-Type,Accept,Accept-Language',
                     msg='Wrong CORS allow-Headers value'
                 )
 
@@ -712,6 +712,6 @@ class ApiCORSHeaderTestCase(MockS3PerTestMixin, StacBaseTestCase):
 
         self.assertEqual(
             response['Access-Control-Allow-Headers'],
-            'Content-Type,Accept',
+            'Content-Type,Accept,Accept-Language',
             msg='Wrong CORS allow-Headers value'
         )


### PR DESCRIPTION
currently stac-service in edge with strict mode enabled refuses to load from other pages due to CORS error.

**repro of error case**
1. use edge in strict mode (i.e. federal default setup)
2. open https://radiantearth.github.io/stac-browser/#/external/data.geo.admin.ch/api/stac/v0.9/?.language=en
3. see error message 
![image](https://github.com/user-attachments/assets/0285ac36-fb09-4a80-bb60-59eb9abf9bb1)
4. check console log
`
Access to XMLHttpRequest at 'https://data.geo.admin.ch/api/stac/v0.9/' from origin 'https://radiantearth.github.io' has been blocked by CORS policy: Request header field accept-language is not allowed by Access-Control-Allow-Headers in preflight response.
`

**measures to enable edge in strict mode**
- [ ] Allow all the occuring request headers 
  - [x] i.e. `Accept-Language` etc. (this PR)
  - [ ] more may be necessary
- [ ] alternatively: allow `*`

HTH to enable data.geo.admin.ch STAC-service for broader internal & public use 😄 