### PR TITLE
PB-1785: Support logging to queue

### DIFF
--- a/app/config/logging-cfg-local.yml
+++ b/app/config/logging-cfg-local.yml
@@ -3,9 +3,7 @@ disable_existing_loggers: False # this allow to get logger at module level
 
 root:
   handlers:
-    - console
-    - file-standard
-    - file-json
+    - queue_listener
   level: DEBUG
   propagate: True
 
@@ -156,4 +154,15 @@ handlers:
     formatter: json
     filename: ${BASE_DIR}/${LOGS_DIR}/server-json-logs.json
     mode: w
+  queue_listener:
+    class: logging.handlers.QueueHandler
+    listener: helpers.logging.AutoStartQueueListener
+    queue:
+      (): queue.Queue
+      maxsize: 1000
+    level: DEBUG
+    handlers:
+      - console
+      - file-standard
+      - file-json
 

--- a/app/helpers/logging.py
+++ b/app/helpers/logging.py
@@ -1,0 +1,8 @@
+from logging.handlers import QueueListener
+
+
+class AutoStartQueueListener(QueueListener):
+
+    def __init__(self, queue, *handlers, respect_handler_level=False):
+        super().__init__(queue, *handlers, respect_handler_level=respect_handler_level)
+        self.start()


### PR DESCRIPTION
Allow logging to be passed through a [Queue](https://docs.python.org/3/library/logging.handlers.html#queuehandler). This offloads logging to a separate thread potentially unblocking stuck `gevent` workers.

Note: The queue used by the QueueHandler should already be monkey patched.