### PR TITLE
PB-1788: add way to slow down checker endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ These settings are read from `settings_dev.py`
 
 | Env         | Default               | Description                            |
 |-------------|-----------------------|----------------------------------------|
+| CHECKER_DELAY | `0`                 | Delay the response of the checker endpoint by that number of seconds. |
 | DEBUG | `False` | Set django DEBUG flag |
 | DEBUG_PROPAGATE_API_EXCEPTIONS | `False` | When `True` the API exception are treated as in production, using a JSON response. Otherwise in DEBUG mode the API exception returns an HTML response with backtrace. |
 | EXTERNAL_TEST_ASSET_URL | `"https://prod-[...].jpg"`  | The URL of an externally hosted jpg file that's used in the external asset tests |

--- a/app/config/settings_prod.py
+++ b/app/config/settings_prod.py
@@ -378,3 +378,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = env('SESSION_EXPIRE_AT_BROWSER_CLOSE', bool, d
 SESSION_COOKIE_AGE = env('SESSION_COOKIE_AGE', int, default=60 * 60 * 24 * 7 * 2)
 SESSION_COOKIE_SAMESITE = env('SESSION_COOKIE_SAMESITE', str, default='Lax')
 SESSION_COOKIE_SECURE = env('SESSION_COOKIE_SECURE', bool, default=False)
+
+# Delay to inject in the checker endpoint, in seconds. This is only meant to be
+# used for test purpose.
+CHECKER_DELAY = env('CHECKER_DELAY', int, default=0)

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -13,6 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+import time
+
 from django.conf import settings
 from django.contrib import admin
 from django.http import JsonResponse
@@ -23,6 +25,9 @@ STAC_BASE = settings.STAC_BASE
 
 
 def checker(request):
+    if settings.CHECKER_DELAY > 0:
+        time.sleep(settings.CHECKER_DELAY)
+
     data = {"success": True, "message": "OK"}
 
     return JsonResponse(data)

--- a/app/tests/test_checker.py
+++ b/app/tests/test_checker.py
@@ -1,0 +1,23 @@
+import time
+
+from django.test import Client
+from django.test import TestCase
+from django.test import override_settings
+
+
+class CheckerTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_checker(self):
+        response = self.client.get('/checker')
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(CHECKER_DELAY=2)
+    def test_checker_delayed(self):
+        start = time.time()
+        response = self.client.get('/checker')
+        end = time.time()
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(end, start + 2, f'Expected at least 2s, only took {end - start}')


### PR DESCRIPTION
We want to add a readiness probe and update the liveness probe to be more tolerant of slow responses. In order to verify this works as expected, we need to be able to inject arbitrary delays in checker responses.

This change adds a `CHECKER_DELAY` setting that allows delaying the `/checker` endpoint by a commensurate number of seconds. This also adds previously missing unit test against the checker endpoint.