### PR TITLE
PB-1943: make keepalive timeout configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ The service is configured by Environment Variable:
 | GUNICORN_WORKER_TMP_DIR | `None` | Path to a tmpfs directory for Gunicorn. If `None` let gunicorn decide which path to use. See https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir. |
 | GUNICORN_STACK_DUMP_DELAY | `29` | Upon exit, how long to wait before logging stack traces. The default is one second less than `GUNICORN_GRACEFUL_TIMEOUT`. Setting this to a value equal or greater to `GUNICORN_GRACEFUL_TIMEOUT` effectively disables stack dumping. |
 | GUNICORN_GRACEFUL_TIMEOUT | `30` | The [`graceful_timeout`](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout) setting passed to gunicorn. |
+| GUNICORN_KEEPALIVE | `2` | The [`keepalive`](https://docs.gunicorn.org/en/stable/settings.html#keepalive) setting passed to gunicorn. |
 
 #### **Database settings**
 

--- a/README.md
+++ b/README.md
@@ -506,8 +506,8 @@ The service is configured by Environment Variable:
 | STAC_BROWSER_BASE_PATH | `browser/index.html` | STAC Browser base path. |
 | GUNICORN_WORKERS | `2` | Number of Gunicorn workers |
 | GUNICORN_WORKER_TMP_DIR | `None` | Path to a tmpfs directory for Gunicorn. If `None` let gunicorn decide which path to use. See https://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir. |
-| GUNICORN_STACK_DUMP_DELAY | `29` | Upon exit, how long to wait before logging stack traces. The default is one second less than `GUNICORN_GRACEFUL_TIMEOUT`. Setting this to a value equal or greater to `GUNICORN_GRACEFUL_TIMEOUT` effectively disables stack dumping.
-| GUNICORN_GRACEFUL_TIMEOUT | `30` | The [`graceful_timeout`](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout) setting passed to gunicorn.
+| GUNICORN_STACK_DUMP_DELAY | `29` | Upon exit, how long to wait before logging stack traces. The default is one second less than `GUNICORN_GRACEFUL_TIMEOUT`. Setting this to a value equal or greater to `GUNICORN_GRACEFUL_TIMEOUT` effectively disables stack dumping. |
+| GUNICORN_GRACEFUL_TIMEOUT | `30` | The [`graceful_timeout`](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout) setting passed to gunicorn. |
 
 #### **Database settings**
 

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -100,6 +100,7 @@ if __name__ == '__main__':
         'worker_tmp_dir': os.environ.get('GUNICORN_WORKER_TMP_DIR', None),
         'timeout': 60,
         'graceful_timeout': int(os.environ.get('GUNICORN_GRACEFUL_TIMEOUT', 30)),
+        'keepalive': int(os.environ.get('GUNICORN_KEEPALIVE', 2)),
         'logconfig_dict': get_logging_config(),
     }
     StandaloneApplication(application, options).run()


### PR DESCRIPTION
The default is 2 and not really suitable when we have a reverses proxy in front with a higher idle connection timeout.

This PR also includes a small Markdown syntax fix for the README.