### PR TITLE
Add TODO to clean up authentication code.

### DIFF
--- a/app/middleware/api_gateway.py
+++ b/app/middleware/api_gateway.py
@@ -24,6 +24,12 @@ def validate_username_header(request):
     Geoadmin-Authenticated is set to "true".
 
     Based on discussion in https://code.djangoproject.com/ticket/35971
+    That ticket requested to add a `get_username` method to `RemoteUserMiddleware`.
+    It was rejected and we implemented this workaround. It has since been
+    implemented for other reasons. Once that change has propagated to a release
+    that we use, we can remove this workaround and just override `get_username`.
+
+    TODO: remove this workaround and just override `get_username`
     """
     apigw_auth = request.META.get("HTTP_GEOADMIN_AUTHENTICATED", "false").lower() == "true"
     if not apigw_auth and REMOTE_USER_HEADER in request.META:


### PR DESCRIPTION
In https://code.djangoproject.com/ticket/35971 we requested a change in Django's `RemoteUserMiddleware` to make our authentication easier. It was rejected and we implemented [a workaround](https://github.com/geoadmin/service-stac/commit/aaa0de549b8fec4d53fc1d5e6af55c73c2e11d23), later [simplified](https://github.com/geoadmin/service-stac/commit/220487f950b4e3fc96ecb2852c76cbc274ba6eb7). The requested change has now been implemented by upstream for other reasons. Once that change has propagated to a release that we use, we can remove our workaround and just override the `RemoteUserMiddleware.get_username` method.

This change adds a comment to remind us to perform the cleanup when appropriate.