### PR TITLE
PB-1403: test and refactor the timestamp-updating trigger.

### DIFF
--- a/app/stac_api/pgtriggers.py
+++ b/app/stac_api/pgtriggers.py
@@ -3,7 +3,7 @@ from enum import Enum
 import pgtrigger
 
 
-def auto_variables_triggers(name):
+def auto_variables_triggers(name, *fields):
     '''Triggers used by various tables to update the `etag` and `updated` fields.'''
     auto_variables_func = '''
     -- update auto variables
@@ -25,7 +25,7 @@ def auto_variables_triggers(name):
             name=f"update_{name}_auto_variables_trigger",
             operation=pgtrigger.Update,
             when=pgtrigger.Before,
-            condition=pgtrigger.Condition('OLD.* IS DISTINCT FROM NEW.*'),
+            condition=pgtrigger.AnyChange(*fields),
             func=auto_variables_func
         )
     ]

--- a/app/tests/tests_10/test_pgtriggers.py
+++ b/app/tests/tests_10/test_pgtriggers.py
@@ -66,3 +66,24 @@ class PgTriggersFileSizeTestCase(MockS3PerTestMixin, StacBaseTransactionTestCase
 
         self.assertEqual(self.collection.total_data_size, 2 * file_size)
         self.assertEqual(self.item.total_data_size, 1 * file_size)
+
+
+class PgTriggersUpdated(MockS3PerTestMixin, StacBaseTransactionTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.factory = Factory()
+        self.collection = self.factory.create_collection_sample().model
+        self.item = self.factory.create_item_sample(collection=self.collection).model
+        self.asset = self.factory.create_asset_sample(
+            self.item, sample='asset-1', db_create=True
+        ).model
+
+    def test_file_update_changes_timestamps(self):
+        prev_mtime = self.asset.updated
+
+        self.asset.checksum_multihash = 'new hash'
+        self.asset.save()
+        self.asset.refresh_from_db()
+
+        self.assertGreater(self.asset.updated, prev_mtime)

--- a/app/tests/tests_10/test_pgtriggers.py
+++ b/app/tests/tests_10/test_pgtriggers.py
@@ -79,7 +79,7 @@ class PgTriggersUpdated(MockS3PerTestMixin, StacBaseTransactionTestCase):
             self.item, sample='asset-1', db_create=True
         ).model
 
-    def test_file_update_changes_timestamps(self):
+    def test_checksum_update_changes_timestamps(self):
         prev_mtime = self.asset.updated
 
         self.asset.checksum_multihash = 'new hash'


### PR DESCRIPTION
Updating any field of an Asset triggers an update of its timestamp as stored in the `updated` field. There is no test for that trigger.

In PB-1403 we want to change this behaviour and for the trigger to become conditional.

This change updates the trigger generator to allow it to be conditional. It also adds tests. There is no actual change in behaviour. A future change will make use of this new parametre.