### PR TITLE
PB-1608 Reject assets in putFeature payload #patch

### DIFF
--- a/app/stac_api/serializers/item.py
+++ b/app/stac_api/serializers/item.py
@@ -467,6 +467,15 @@ class ItemSerializer(NonNullModelSerializer, UpsertModelSerializerMixin):
         return attrs
 
 
+class ItemDetailSerializer(ItemSerializer):
+    '''ItemSerializer variant used by the single-item detail view.
+
+    We set assets to read-only because they should not be supplied in single-item write payloads.
+    Instead, the dedicated asset endpoints or the bulk item upload should be used for that.
+    '''
+    assets = AssetsForItemSerializer(many=True, read_only=True)
+
+
 class ItemListSerializer(serializers.Serializer):
     '''Handle serialization and deserialization of a list of Items.'''
 

--- a/app/stac_api/views/item.py
+++ b/app/stac_api/views/item.py
@@ -19,6 +19,7 @@ from stac_api.models.collection import Collection
 from stac_api.models.item import Asset
 from stac_api.models.item import Item
 from stac_api.serializers.item import AssetSerializer
+from stac_api.serializers.item import ItemDetailSerializer
 from stac_api.serializers.item import ItemListSerializer
 from stac_api.serializers.item import ItemSerializer
 from stac_api.serializers.utils import get_relation_links
@@ -195,7 +196,7 @@ class ItemDetail(
 ):
     # this name must match the name in urls.py and is used by the DestroyModelMixin
     name = 'item-detail'
-    serializer_class = ItemSerializer
+    serializer_class = ItemDetailSerializer
     lookup_url_kwarg = "item_name"
     lookup_field = "name"
 

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -694,6 +694,19 @@ class ItemsUpdateEndpointTestCase(StacBaseTestCase):
             msg="Renamed item shouldn't exist"
         )
 
+    def test_item_endpoint_put_assets_in_body_rejected(self):
+        sample = self.factory.create_item_sample(
+            self.collection.model, sample='item-2', name=self.item['name']
+        )
+        payload = sample.get_json('put')
+        payload['assets'] = {'asset-1.tiff': {'type': 'image/tiff; application=geotiff',}}
+        path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'
+        response = self.client.put(path, data=payload, content_type='application/json')
+        self.assertStatusCode(400, response)
+        self.assertEqual(
+            response.json()['description'], {'assets': ['Found read-only property in payload']}
+        )
+
     def test_item_endpoint_patch(self):
         data = {"properties": {"title": "patched title"}}
         path = f'/{STAC_BASE_V}/collections/{self.collection["name"]}/items/{self.item["name"]}'

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -682,7 +682,9 @@ components:
         STAC entity
       properties:
         assets:
-          $ref: "#/components/schemas/itemAssets"
+          readOnly: true
+          allOf:
+            - $ref: "#/components/schemas/itemAssets"
         bbox:
           $ref: "#/components/schemas/bbox"
         geometry:

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -963,7 +963,9 @@ components:
         A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
       properties:
         assets:
-          $ref: "#/components/schemas/itemAssets"
+          readOnly: true
+          allOf:
+            - $ref: "#/components/schemas/itemAssets"
         bbox:
           $ref: "#/components/schemas/bbox"
         geometry:

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -1043,7 +1043,9 @@ components:
         A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
       properties:
         assets:
-          $ref: "#/components/schemas/itemAssets"
+          readOnly: true
+          allOf:
+            - $ref: "#/components/schemas/itemAssets"
         bbox:
           $ref: "#/components/schemas/bbox"
         geometry:


### PR DESCRIPTION
This fixes an inconsistency in the PUT endpoint to create/update a feature ([putFeature](https://sys-data.dev.bgdi.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data-Management/operation/putFeature)). The API docs list "assets" as required for the request payload but the endpoint returns a 500 if it is actually included.

Assets in a `putFeature` payload passed validation but caused a 500 because update_or_create rejected it. Since assets are managed through the dedicated asset endpoints, they are now explicitly rejected at the serializer level with a 400.

To that end, a separate `ItemDetailSerializer` was created. We need a separate one from `ItemSerializer` because the POST endpoint `bulkCreateItems` still needs to be able to have assets in the payload.

The API docs are updated accordingly: "assets" is removed from the request body schema. As before, the request sample payload does not include "assets".

<img width="3065" height="2040" alt="image" src="https://github.com/user-attachments/assets/4bbd1226-b181-406a-a025-ac0e7710d09b" />
