### PR TITLE
chore: Fix flaky unit test

### DIFF
--- a/app/tests/tests_10/test_item_model.py
+++ b/app/tests/tests_10/test_item_model.py
@@ -118,7 +118,7 @@ class ItemsModelTestCase(TestCase):
             item.save()
 
     def test_item_create_model_expires_can_be_before_datetime(self):
-        today = datetime.now(UTC) + timedelta(milliseconds=100)
+        today = datetime.now(UTC) + timedelta(minutes=10)
         tomorrow = today + timedelta(days=1)
         item = Item(
             collection=self.collection,


### PR DESCRIPTION
This test fails occasionally with

> Property expires can't be in the past.

because sometimes it may take more than 100ms between getting the current time and validating the item.

To mitigate that, I increased the delta from 100ms to 10m.