### PR TITLE
PB-1677: sort extension - Add properties prefix #minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ nose2-junit.xml
 # IDE config files
 *.sublime-*
 *.code*
+*.zed
 
 # Makefile
 .timestamps

--- a/app/stac_api/migrations/0083_add_sort_conformance_classes.py
+++ b/app/stac_api/migrations/0083_add_sort_conformance_classes.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+SORT_CONFORMANCE_CLASSES = [
+    'https://api.stacspec.org/v1.1.0/item-search#sort',
+    'https://api.stacspec.org/v1.1.0/ogcapi-features#sort',
+    'https://api.stacspec.org/v1.1.0/item-search#sortables',
+    'http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables',
+]
+
+
+def update_conformance(apps, schema_editor):
+    LandingPage = apps.get_model("stac_api", "LandingPage")
+    lp = LandingPage.objects.get(version='v1')
+    for conformance_class in SORT_CONFORMANCE_CLASSES:
+        if conformance_class not in lp.conformsTo:
+            lp.conformsTo.append(conformance_class)
+    lp.save()
+
+
+def reverse_update_conformance(apps, schema_editor):
+    LandingPage = apps.get_model("stac_api", "LandingPage")
+    lp = LandingPage.objects.get(version='v1')
+    for conformance_class in SORT_CONFORMANCE_CLASSES:
+        if conformance_class in lp.conformsTo:
+            lp.conformsTo.remove(conformance_class)
+    lp.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("stac_api", "0082_alter_collection_stac_extensions_enabled_and_more"),
+    ]
+
+    operations = [migrations.RunPython(update_conformance, reverse_update_conformance)]

--- a/app/stac_api/serializers/general.py
+++ b/app/stac_api/serializers/general.py
@@ -110,14 +110,14 @@ class LandingPageSerializer(serializers.ModelSerializer):
                 ("href", get_url(request, 'search-list')),
                 ("rel", "search"),
                 ("method", "GET"),
-                ("type", "application/json"),
+                ("type", "application/geo+json"),
                 ("title", "Search across feature collections"),
             ]),
             OrderedDict([
                 ("href", get_url(request, 'search-list')),
                 ("rel", "search"),
                 ("method", "POST"),
-                ("type", "application/json"),
+                ("type", "application/geo+json"),
                 ("title", "Search across feature collections"),
             ]),
         ]

--- a/app/stac_api/serializers/general.py
+++ b/app/stac_api/serializers/general.py
@@ -121,6 +121,12 @@ class LandingPageSerializer(serializers.ModelSerializer):
                 ("title", "Search across feature collections"),
             ]),
             OrderedDict([
+                ("rel", "http://www.opengis.net/def/rel/ogc/1.0/sortables"),
+                ("href", get_url(request, 'sortables')),
+                ("type", "application/schema+json"),
+                ("title", "Sortable fields for the sortby parameter"),
+            ]),
+            OrderedDict([
                 ("href", get_browser_url(request, 'browser-catalog')),
                 ("rel", "alternate"),
                 ("type", "text/html"),

--- a/app/stac_api/serializers/general.py
+++ b/app/stac_api/serializers/general.py
@@ -70,7 +70,7 @@ class LandingPageSerializer(serializers.ModelSerializer):
         # We use OrderedDict, although it is not necessary, because the default serializer/model for
         # links already uses OrderedDict, this way we keep consistency between auto link and user
         # link
-        representation['links'][:0] = [
+        links = [
             OrderedDict([
                 ('rel', 'root'),
                 ('href', get_url(request, 'landing-page')),
@@ -120,17 +120,23 @@ class LandingPageSerializer(serializers.ModelSerializer):
                 ("type", "application/json"),
                 ("title", "Search across feature collections"),
             ]),
-            OrderedDict([
-                ("rel", "http://www.opengis.net/def/rel/ogc/1.0/sortables"),
-                ("href", get_url(request, 'sortables')),
-                ("type", "application/schema+json"),
-                ("title", "Sortable fields for the sortby parameter"),
-            ]),
+        ]
+        if is_api_version_1(request):
+            links.append(
+                OrderedDict([
+                    ("rel", "http://www.opengis.net/def/rel/ogc/1.0/sortables"),
+                    ("href", get_url(request, 'sortables')),
+                    ("type", "application/schema+json"),
+                    ("title", "Sortable fields for the sortby parameter"),
+                ])
+            )
+        links.append(
             OrderedDict([
                 ("href", get_browser_url(request, 'browser-catalog')),
                 ("rel", "alternate"),
                 ("type", "text/html"),
                 ("title", "STAC Browser"),
-            ]),
-        ]
+            ])
+        )
+        representation['links'][:0] = links
         return representation

--- a/app/stac_api/serializers/utils.py
+++ b/app/stac_api/serializers/utils.py
@@ -106,6 +106,10 @@ view_relations = {
         'parent': 'collection-detail',
         'browser': 'browser-collection',
     },
+    'collection-sortables': {
+        'parent': 'collection-detail',
+        'browser': None,
+    },
     'item-detail': {
         'parent': 'collection-detail',
         'browser': 'browser-item',
@@ -195,6 +199,14 @@ def get_relation_links(request, view, view_args=()):
                 OrderedDict([
                     ('rel', 'assets'),
                     ('href', get_url(request, 'collection-assets-list', view_args)),
+                ])
+            )
+            links.append(
+                OrderedDict([
+                    ("rel", "http://www.opengis.net/def/rel/ogc/1.0/sortables"),
+                    ("href", get_url(request, 'collection-sortables', view_args)),
+                    ("type", "application/schema+json"),
+                    ("title", "Sortable fields for the sortby parameter"),
                 ])
             )
     elif view.startswith('item') or view.startswith('asset') or view.startswith('collection-asset'):

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -11,6 +11,7 @@ from stac_api.views.collection import CollectionList
 from stac_api.views.general import ConformancePageDetail
 from stac_api.views.general import LandingPageDetail
 from stac_api.views.general import SearchList
+from stac_api.views.general import Sortables
 from stac_api.views.general import recalculate_extent
 from stac_api.views.item import AssetDetail
 from stac_api.views.item import AssetsList
@@ -110,6 +111,7 @@ urlpatterns = [
             path("", LandingPageDetail.as_view(), name='landing-page'),
             path("conformance", ConformancePageDetail.as_view(), name='conformance'),
             path("search", SearchList.as_view(), name='search-list'),
+            path("sortables", Sortables.as_view(), name='sortables'),
             path("collections", CollectionList.as_view(), name='collections-list'),
             path("collections/", include(collection_urls)),
             path("update-extent", recalculate_extent)

--- a/app/stac_api/urls.py
+++ b/app/stac_api/urls.py
@@ -8,6 +8,7 @@ from stac_api.views.collection import CollectionAssetDetail
 from stac_api.views.collection import CollectionAssetsList
 from stac_api.views.collection import CollectionDetail
 from stac_api.views.collection import CollectionList
+from stac_api.views.general import CollectionSortables
 from stac_api.views.general import ConformancePageDetail
 from stac_api.views.general import LandingPageDetail
 from stac_api.views.general import SearchList
@@ -84,6 +85,7 @@ collection_urls = [
     path("<collection_name>", CollectionDetail.as_view(), name='collection-detail'),
     path("<collection_name>/items", ItemsList.as_view(), name='items-list'),
     path("<collection_name>/items/", include(item_urls)),
+    path("<collection_name>/sortables", CollectionSortables.as_view(), name='collection-sortables'),
     path("<collection_name>/assets", CollectionAssetsList.as_view(), name='collection-assets-list'),
     path("<collection_name>/assets/", include(collection_asset_urls))
 ]

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -651,10 +651,10 @@ class SortableField:
 SORTABLE_FIELDS: dict[str, SortableField] = {
     'id': SortableField(model_field='name'),
     'collection': SortableField(model_field='collection__name'),
-    'datetime': SortableField(model_field='properties_datetime', format='date-time'),
-    'title': SortableField(model_field='properties_title'),
-    'created': SortableField(model_field='created', format='date-time'),
-    'updated': SortableField(model_field='updated', format='date-time'),
+    'properties.datetime': SortableField(model_field='properties_datetime', format='date-time'),
+    'properties.title': SortableField(model_field='properties_title'),
+    'properties.created': SortableField(model_field='created', format='date-time'),
+    'properties.updated': SortableField(model_field='updated', format='date-time'),
 }
 
 
@@ -710,7 +710,7 @@ def parse_sortby_post(sortby_param, sortable_fields):
     The sortby parameter in the request body is a list of objects with a 'field'
     and a 'direction' ('asc' or 'desc') property.
 
-    Example: [{"field": "created", "direction": "desc"}].
+    Example: [{"field": "properties.created", "direction": "desc"}].
 
     Args:
         sortby_param: list

--- a/app/stac_api/utils.py
+++ b/app/stac_api/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from base64 import b64decode
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
 from decimal import Decimal
@@ -632,14 +633,28 @@ def parse_cache_control_header(cache_control_header):
     return {k: True if v == k else v for k, v in args.items()}
 
 
-# Maps sortby parameter values to Django model field
-SORTABLE_FIELDS = {
-    'id': 'name',
-    'collection': 'collection__name',
-    'datetime': 'properties_datetime',
-    'title': 'properties_title',
-    'created': 'created',
-    'updated': 'updated',
+@dataclass(frozen=True)
+class SortableField:
+    '''Describes a field that can be used with the sortby parameter.
+
+    Attributes:
+        model_field: The Django ORM field name to use for ordering.
+        type: The JSON Schema type of the field.
+        format: Optional JSON Schema format (e.g. "date-time").
+    '''
+    model_field: str
+    type: str = "string"
+    format: str | None = None
+
+
+# Maps sortby parameter values to their Django model field and JSON Schema metadata.
+SORTABLE_FIELDS: dict[str, SortableField] = {
+    'id': SortableField(model_field='name'),
+    'collection': SortableField(model_field='collection__name'),
+    'datetime': SortableField(model_field='properties_datetime', format='date-time'),
+    'title': SortableField(model_field='properties_title'),
+    'created': SortableField(model_field='created', format='date-time'),
+    'updated': SortableField(model_field='updated', format='date-time'),
 }
 
 
@@ -738,7 +753,7 @@ def _resolve_sort_field(field_name, sortable_fields):
         field_name: string
             The field name provided in the sortby parameter
         sortable_fields: dict
-            Mapping of allowed sortby field names to Django model fields
+            Mapping of allowed sortby field names to SortableField instances
 
     Returns:
         string: The Django model field corresponding to the given field name
@@ -751,4 +766,4 @@ def _resolve_sort_field(field_name, sortable_fields):
             f"Invalid sort field '{field_name}'. "
             f"Allowed fields are: {', '.join(sortable_fields.keys())}"
         )
-    return sortable_fields[field_name]
+    return sortable_fields[field_name].model_field

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -14,6 +14,7 @@ from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from stac_api.models.general import LandingPage
 from stac_api.models.item import Item
@@ -161,3 +162,40 @@ class SearchList(generics.GenericAPIView, mixins.ListModelMixin):
 def recalculate_extent(request):
     call_calculate_extent()
     return Response()
+
+
+class Sortables(APIView):
+    name = 'sortables'  # this name must match the name in urls.py
+    # Override the default model-based permission class since this view has no queryset.
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": request.build_absolute_uri(),
+            "title": "Sortables",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "collection": {
+                    "type": "string"
+                },
+                "properties.datetime": {
+                    "type": "string", "format": "date-time"
+                },
+                "properties.title": {
+                    "type": "string"
+                },
+                "properties.created": {
+                    "type": "string", "format": "date-time"
+                },
+                "properties.updated": {
+                    "type": "string", "format": "date-time"
+                },
+            },
+            "additionalProperties": False,
+        }
+        return Response(schema, content_type="application/schema+json")

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -23,6 +23,7 @@ from stac_api.serializers.general import ConformancePageSerializer
 from stac_api.serializers.general import LandingPageSerializer
 from stac_api.serializers.item import ItemSerializer
 from stac_api.serializers.utils import get_relation_links
+from stac_api.utils import SORTABLE_FIELDS
 from stac_api.utils import call_calculate_extent
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import is_api_version_1
@@ -171,31 +172,18 @@ class Sortables(APIView):
 
     def get(self, request, *args, **kwargs):
         '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''
+        properties = {}
+        for field_name, field in SORTABLE_FIELDS.items():
+            prop = {"type": field.type}
+            if field.format:
+                prop["format"] = field.format
+            properties[field_name] = prop
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": request.build_absolute_uri(),
             "title": "Sortables",
             "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "collection": {
-                    "type": "string"
-                },
-                "properties.datetime": {
-                    "type": "string", "format": "date-time"
-                },
-                "properties.title": {
-                    "type": "string"
-                },
-                "properties.created": {
-                    "type": "string", "format": "date-time"
-                },
-                "properties.updated": {
-                    "type": "string", "format": "date-time"
-                },
-            },
+            "properties": properties,
             "additionalProperties": False,
         }
         return Response(schema, content_type="application/schema+json")

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -28,6 +28,7 @@ from stac_api.utils import call_calculate_extent
 from stac_api.utils import harmonize_post_get_for_search
 from stac_api.utils import is_api_version_1
 from stac_api.validators_serializer import ValidateSearchRequest
+from stac_api.validators_view import validate_collection
 from stac_api.views.filters import create_is_active_filter
 from stac_api.views.mixins import patch_collections_aggregate_cache_control_header
 
@@ -165,6 +166,24 @@ def recalculate_extent(request):
     return Response()
 
 
+def build_sortables_schema(request):
+    '''Build a JSON Schema describing the sortable fields for the sortby parameter.'''
+    properties = {}
+    for field_name, field in SORTABLE_FIELDS.items():
+        prop = {"type": field.type}
+        if field.format:
+            prop["format"] = field.format
+        properties[field_name] = prop
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": request.build_absolute_uri(),
+        "title": "Sortables",
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+
+
 class Sortables(APIView):
     name = 'sortables'  # this name must match the name in urls.py
     # Override the default model-based permission class since this view has no queryset.
@@ -172,18 +191,15 @@ class Sortables(APIView):
 
     def get(self, request, *args, **kwargs):
         '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''
-        properties = {}
-        for field_name, field in SORTABLE_FIELDS.items():
-            prop = {"type": field.type}
-            if field.format:
-                prop["format"] = field.format
-            properties[field_name] = prop
-        schema = {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": request.build_absolute_uri(),
-            "title": "Sortables",
-            "type": "object",
-            "properties": properties,
-            "additionalProperties": False,
-        }
-        return Response(schema, content_type="application/schema+json")
+        return Response(build_sortables_schema(request), content_type="application/schema+json")
+
+
+class CollectionSortables(APIView):
+    name = 'collection-sortables'  # this name must match the name in urls.py
+    # Override the default model-based permission class since this view has no queryset.
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''
+        validate_collection(kwargs)
+        return Response(build_sortables_schema(request), content_type="application/schema+json")

--- a/app/stac_api/views/general.py
+++ b/app/stac_api/views/general.py
@@ -13,6 +13,7 @@ from rest_framework import permissions
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import AllowAny
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -33,6 +34,12 @@ from stac_api.views.filters import create_is_active_filter
 from stac_api.views.mixins import patch_collections_aggregate_cache_control_header
 
 logger = logging.getLogger(__name__)
+
+
+class SchemaJSONRenderer(JSONRenderer):
+    '''Renders responses with the `application/schema+json` media type.'''
+    media_type = "application/schema+json"
+    format = "schema+json"
 
 
 def get_etag(queryset):
@@ -188,6 +195,7 @@ class Sortables(APIView):
     name = 'sortables'  # this name must match the name in urls.py
     # Override the default model-based permission class since this view has no queryset.
     permission_classes = [AllowAny]
+    renderer_classes = [SchemaJSONRenderer]
 
     def get(self, request, *args, **kwargs):
         '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''
@@ -198,6 +206,7 @@ class CollectionSortables(APIView):
     name = 'collection-sortables'  # this name must match the name in urls.py
     # Override the default model-based permission class since this view has no queryset.
     permission_classes = [AllowAny]
+    renderer_classes = [SchemaJSONRenderer]
 
     def get(self, request, *args, **kwargs):
         '''Return a JSON Schema describing the fields that can be used with the sortby parameter.'''

--- a/app/tests/tests_10/test_conformance.py
+++ b/app/tests/tests_10/test_conformance.py
@@ -23,3 +23,20 @@ class ConformanceTestCase(TestCase):
         self.assertGreater(
             len(response.json()['conformsTo']), 0, msg='there are no links defined in conformsTo'
         )
+
+    def test_sort_conformance_classes(self):
+        sort_conformance_classes = [
+            'https://api.stacspec.org/v1.1.0/item-search#sort',
+            'https://api.stacspec.org/v1.1.0/ogcapi-features#sort',
+            'https://api.stacspec.org/v1.1.0/item-search#sortables',
+            'http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables',
+        ]
+        response = self.client.get(f"/{STAC_BASE_V}/conformance")
+        self.assertEqual(response.status_code, 200)
+        conforms_to = response.json()['conformsTo']
+        for conformance_class in sort_conformance_classes:
+            self.assertIn(
+                conformance_class,
+                conforms_to,
+                msg=f"missing conformance class: {conformance_class}"
+            )

--- a/app/tests/tests_10/test_items_endpoint.py
+++ b/app/tests/tests_10/test_items_endpoint.py
@@ -228,7 +228,7 @@ class ItemsReadEndpointTestCase(MockS3PerClassMixin, StacBaseTestCase):
 
         # Test ascending sort
         response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?sortby=datetime"
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?sortby=properties.datetime"
         )
 
         self.assertStatusCode(200, response)
@@ -237,7 +237,7 @@ class ItemsReadEndpointTestCase(MockS3PerClassMixin, StacBaseTestCase):
 
         # Test descending sort
         response = self.client.get(
-            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?sortby=-datetime"
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?sortby=-properties.datetime"
         )
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
@@ -268,10 +268,10 @@ class ItemsReadEndpointTestCase(MockS3PerClassMixin, StacBaseTestCase):
         )
 
         # Sort by datetime ascending, then by title descending
-        response = self.client.get(
-            (f"/{STAC_BASE_V}/collections/{self.collection.name}/items?"
-             f"sortby=datetime,-title")
-        )
+        response = self.client.get((
+            f"/{STAC_BASE_V}/collections/{self.collection.name}/items?"
+            f"sortby=properties.datetime,-properties.title"
+        ))
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
         self.assertEqual(

--- a/app/tests/tests_10/test_landing_page.py
+++ b/app/tests/tests_10/test_landing_page.py
@@ -31,6 +31,21 @@ class IndexTestCase(StacBaseTestCase):
                 msg="missing required attribute in the answer['links'] array"
             )
 
+    def test_landing_page_sortables_link(self):
+        response = self.client.get(f"/{STAC_BASE_V}/")
+        self.assertStatusCode(200, response)
+        expected_link = {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/sortables",
+            "href": f"http://testserver/{STAC_BASE_V}/sortables",
+            "type": "application/schema+json",
+            "title": "Sortable fields for the sortby parameter",
+        }
+        sortables_links = [
+            link for link in response.json()['links']
+            if link['rel'] == "http://www.opengis.net/def/rel/ogc/1.0/sortables"
+        ]
+        self.assertEqual(sortables_links, [expected_link])
+
     def test_landing_page_redirect(self):
         response = self.client.get(f"/{STAC_BASE_V}")
         self.assertEqual(response.status_code, 301)

--- a/app/tests/tests_10/test_search_endpoint_extensions.py
+++ b/app/tests/tests_10/test_search_endpoint_extensions.py
@@ -289,13 +289,13 @@ class SearchEndpointSortTestCase(StacBaseTestCase):
         )
 
         # ascending sort
-        response = self.client.get(f"{self.path}?sortby=datetime")
+        response = self.client.get(f"{self.path}?sortby=properties.datetime")
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
         self.assertEqual(item_ids, ['item-1', 'item-2', 'item-dt-2', 'item-dt-1', 'item-dt-3'])
 
         # descending sort
-        response = self.client.get(f"{self.path}?sortby=-datetime")
+        response = self.client.get(f"{self.path}?sortby=-properties.datetime")
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
         self.assertEqual(item_ids, ['item-dt-3', 'item-dt-1', 'item-dt-2', 'item-2', 'item-1'])
@@ -325,7 +325,7 @@ class SearchEndpointSortTestCase(StacBaseTestCase):
         )
 
         # Sort by datetime ascending, then by title descending
-        response = self.client.get(f"{self.path}?sortby=datetime,-title")
+        response = self.client.get(f"{self.path}?sortby=properties.datetime,-properties.title")
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
         self.assertEqual(
@@ -378,14 +378,14 @@ class SearchEndpointSortTestCase(StacBaseTestCase):
         )
 
         # ascending sort
-        payload = {"sortby": [{"field": "datetime", "direction": "asc"}]}
+        payload = {"sortby": [{"field": "properties.datetime", "direction": "asc"}]}
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
         self.assertEqual(item_ids, ['item-1', 'item-2', 'item-dt-2', 'item-dt-1', 'item-dt-3'])
 
         # descending sort
-        payload = {"sortby": [{"field": "datetime", "direction": "desc"}]}
+        payload = {"sortby": [{"field": "properties.datetime", "direction": "desc"}]}
         response = self.client.post(self.path, data=payload, content_type="application/json")
         self.assertStatusCode(200, response)
         item_ids = [item['id'] for item in response.json()['features']]
@@ -418,9 +418,9 @@ class SearchEndpointSortTestCase(StacBaseTestCase):
         # Sort by datetime ascending, then by title descending
         payload = {
             "sortby": [{
-                "field": "datetime", "direction": "asc"
+                "field": "properties.datetime", "direction": "asc"
             }, {
-                "field": "title", "direction": "desc"
+                "field": "properties.title", "direction": "desc"
             }]
         }
         response = self.client.post(self.path, data=payload, content_type="application/json")

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -31,16 +31,16 @@ class SortablesTestCase(StacBaseTestCase):
                 "collection": {
                     "type": "string"
                 },
-                "properties.datetime": {
+                "datetime": {
                     "type": "string", "format": "date-time"
                 },
-                "properties.title": {
+                "title": {
                     "type": "string"
                 },
-                "properties.created": {
+                "created": {
                     "type": "string", "format": "date-time"
                 },
-                "properties.updated": {
+                "updated": {
                     "type": "string", "format": "date-time"
                 },
             },

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -1,0 +1,49 @@
+import logging
+
+from django.test import Client
+
+from tests.tests_10.base_test import STAC_BASE_V
+from tests.tests_10.base_test import StacBaseTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class SortablesTestCase(StacBaseTestCase):
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+        self.path = f'/{STAC_BASE_V}/sortables'
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_get_sortables(self):
+        response = self.client.get(self.path)
+        self.assertStatusCode(200, response)
+        self.assertEqual(response['Content-Type'], 'application/schema+json')
+        expected_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": f'http://testserver/{STAC_BASE_V}/sortables',
+            "title": "Sortables",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "collection": {
+                    "type": "string"
+                },
+                "properties.datetime": {
+                    "type": "string", "format": "date-time"
+                },
+                "properties.title": {
+                    "type": "string"
+                },
+                "properties.created": {
+                    "type": "string", "format": "date-time"
+                },
+                "properties.updated": {
+                    "type": "string", "format": "date-time"
+                },
+            },
+            "additionalProperties": False,
+        }
+        self.assertEqual(response.json(), expected_schema)

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -49,6 +49,11 @@ class SortablesTestCase(StacBaseTestCase):
         }
         self.assertEqual(response.json(), expected_schema)
 
+    def test_get_sortables_accept_schema_json(self):
+        response = self.client.get(self.path, HTTP_ACCEPT='application/schema+json')
+        self.assertStatusCode(200, response)
+        self.assertEqual(response['Content-Type'], 'application/schema+json')
+
 
 class CollectionSortablesTestCase(StacBaseTestCase):
 
@@ -95,6 +100,11 @@ class CollectionSortablesTestCase(StacBaseTestCase):
             "additionalProperties": False,
         }
         self.assertEqual(response.json(), expected_schema)
+
+    def test_get_collection_sortables_accept_schema_json(self):
+        response = self.client.get(self.path, HTTP_ACCEPT='application/schema+json')
+        self.assertStatusCode(200, response)
+        self.assertEqual(response['Content-Type'], 'application/schema+json')
 
     def test_get_collection_sortables_not_found(self):
         response = self.client.get(f'/{STAC_BASE_V}/collections/nonexistent/sortables')

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -4,6 +4,7 @@ from django.test import Client
 
 from tests.tests_10.base_test import STAC_BASE_V
 from tests.tests_10.base_test import StacBaseTestCase
+from tests.tests_10.data_factory import Factory
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +48,54 @@ class SortablesTestCase(StacBaseTestCase):
             "additionalProperties": False,
         }
         self.assertEqual(response.json(), expected_schema)
+
+
+class CollectionSortablesTestCase(StacBaseTestCase):
+
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=invalid-name
+        cls.factory = Factory()
+        cls.collection = cls.factory.create_collection_sample().model
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.client = Client()
+        self.collection_name = self.collection.name
+        self.path = f'/{STAC_BASE_V}/collections/{self.collection_name}/sortables'
+        self.maxDiff = None  # pylint: disable=invalid-name
+
+    def test_get_collection_sortables(self):
+        response = self.client.get(self.path)
+        self.assertStatusCode(200, response)
+        self.assertEqual(response['Content-Type'], 'application/schema+json')
+        expected_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": f'http://testserver/{STAC_BASE_V}/collections/{self.collection_name}/sortables',
+            "title": "Sortables",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "collection": {
+                    "type": "string"
+                },
+                "datetime": {
+                    "type": "string", "format": "date-time"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "created": {
+                    "type": "string", "format": "date-time"
+                },
+                "updated": {
+                    "type": "string", "format": "date-time"
+                },
+            },
+            "additionalProperties": False,
+        }
+        self.assertEqual(response.json(), expected_schema)
+
+    def test_get_collection_sortables_not_found(self):
+        response = self.client.get(f'/{STAC_BASE_V}/collections/nonexistent/sortables')
+        self.assertStatusCode(404, response)

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -99,3 +99,18 @@ class CollectionSortablesTestCase(StacBaseTestCase):
     def test_get_collection_sortables_not_found(self):
         response = self.client.get(f'/{STAC_BASE_V}/collections/nonexistent/sortables')
         self.assertStatusCode(404, response)
+
+    def test_collection_detail_has_sortables_link(self):
+        response = self.client.get(f'/{STAC_BASE_V}/collections/{self.collection_name}')
+        self.assertStatusCode(200, response)
+        expected_link = {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/sortables",
+            "href": f'http://testserver/{STAC_BASE_V}/collections/{self.collection_name}/sortables',
+            "type": "application/schema+json",
+            "title": "Sortable fields for the sortby parameter",
+        }
+        sortables_links = [
+            link for link in response.json()['links']
+            if link['rel'] == "http://www.opengis.net/def/rel/ogc/1.0/sortables"
+        ]
+        self.assertEqual(sortables_links, [expected_link])

--- a/app/tests/tests_10/test_sortables_endpoint.py
+++ b/app/tests/tests_10/test_sortables_endpoint.py
@@ -32,16 +32,16 @@ class SortablesTestCase(StacBaseTestCase):
                 "collection": {
                     "type": "string"
                 },
-                "datetime": {
+                "properties.datetime": {
                     "type": "string", "format": "date-time"
                 },
-                "title": {
+                "properties.title": {
                     "type": "string"
                 },
-                "created": {
+                "properties.created": {
                     "type": "string", "format": "date-time"
                 },
-                "updated": {
+                "properties.updated": {
                     "type": "string", "format": "date-time"
                 },
             },
@@ -84,16 +84,16 @@ class CollectionSortablesTestCase(StacBaseTestCase):
                 "collection": {
                     "type": "string"
                 },
-                "datetime": {
+                "properties.datetime": {
                     "type": "string", "format": "date-time"
                 },
-                "title": {
+                "properties.title": {
                     "type": "string"
                 },
-                "created": {
+                "properties.created": {
                     "type": "string", "format": "date-time"
                 },
-                "updated": {
+                "properties.updated": {
                     "type": "string", "format": "date-time"
                 },
             },

--- a/app/tests/tests_10/test_utils.py
+++ b/app/tests/tests_10/test_utils.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from django.core.exceptions import ValidationError
 
+from stac_api.utils import SortableField
 from stac_api.utils import parse_cache_control_header
 from stac_api.utils import parse_sortby_get
 from stac_api.utils import parse_sortby_post
@@ -39,7 +40,7 @@ class TestUtils(TestCase):
         self.assertEqual(result, [])
 
     def test_parse_sortby_get_handles_single_field_correctly(self):
-        sortable_fields = {'external': 'internal'}
+        sortable_fields = {'external': SortableField(model_field='internal')}
 
         result = parse_sortby_get('external', sortable_fields)
         self.assertEqual(result, [('internal', True)])
@@ -52,9 +53,9 @@ class TestUtils(TestCase):
 
     def test_parse_sortby_get_handles_multiple_fields_correctly(self):
         sortable_fields = {
-            'external_1': 'internal_1',
-            'external_2': 'internal_2',
-            'external_3': 'internal_3',
+            'external_1': SortableField(model_field='internal_1'),
+            'external_2': SortableField(model_field='internal_2'),
+            'external_3': SortableField(model_field='internal_3'),
         }
 
         result = parse_sortby_get('external_1,-external_2', sortable_fields)
@@ -70,22 +71,22 @@ class TestUtils(TestCase):
 
     def test_parse_sortby_get_ignores_whitespace(self):
         sortable_fields = {
-            'external_1': 'internal_1',
-            'external_2': 'internal_2',
+            'external_1': SortableField(model_field='internal_1'),
+            'external_2': SortableField(model_field='internal_2'),
         }
         result = parse_sortby_get('external_1 , -external_2', sortable_fields)
         self.assertEqual(result, [('internal_1', True), ('internal_2', False)])
 
     def test_parse_sortby_get_raises_for_invalid_field(self):
         with self.assertRaises(ValidationError):
-            parse_sortby_get('invalid_field', {'external': 'internal'})
+            parse_sortby_get('invalid_field', {'external': SortableField(model_field='internal')})
 
     def test_parse_sortby_post_format_empty(self):
         result = parse_sortby_post([], {})
         self.assertEqual(result, [])
 
     def test_parse_sortby_post_format_handles_single_field_correctly(self):
-        sortable_fields = {'external': 'internal'}
+        sortable_fields = {'external': SortableField(model_field='internal')}
 
         result = parse_sortby_post([{'field': 'external', 'direction': 'asc'}], sortable_fields)
         self.assertEqual(result, [('internal', True)])
@@ -99,8 +100,8 @@ class TestUtils(TestCase):
 
     def test_parse_sortby_post_format_handles_multiple_fields_correctly(self):
         sortable_fields = {
-            'external_1': 'internal_1',
-            'external_2': 'internal_2',
+            'external_1': SortableField(model_field='internal_1'),
+            'external_2': SortableField(model_field='internal_2'),
         }
         sortby_param = [{
             'field': 'external_1',
@@ -126,14 +127,16 @@ class TestUtils(TestCase):
         with self.assertRaises(ValidationError):
             parse_sortby_post([{
                 'field': 'invalid_field', 'direction': 'asc'
-            }], {'external': 'internal'})
+            }], {'external': SortableField(model_field='internal')})
 
     def test_parse_sortby_post_format_raises_for_invalid_direction(self):
         with self.assertRaises(ValidationError):
             parse_sortby_post([{
                 'field': 'external', 'direction': 'sideways'
-            }], {'external': 'internal'})
+            }], {'external': SortableField(model_field='internal')})
 
     def test_parse_sortby_post_format_raises_for_missing_field(self):
         with self.assertRaises(ValidationError):
-            parse_sortby_post([{'direction': 'asc'}], {'external': 'internal'})
+            parse_sortby_post([{
+                'direction': 'asc'
+            }], {'external': SortableField(model_field='internal')})

--- a/spec/components/parameters.yaml
+++ b/spec/components/parameters.yaml
@@ -138,6 +138,9 @@ components:
       description: >-
         An array of property names, prefixed by either "+" for ascending or
         "-" for descending. If no prefix is provided, "+" is assumed.
+
+
+        This parameter is part of the [sort extension](https://github.com/stac-api-extensions/sort).
       required: false
       schema:
         type: string

--- a/spec/components/parameters.yaml
+++ b/spec/components/parameters.yaml
@@ -144,4 +144,4 @@ components:
       required: false
       schema:
         type: string
-        example: '-created,id'
+        example: '-properties.created,id'

--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -194,7 +194,7 @@ components:
                 title: Information about the feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
-                type: application/json
+                type: application/geo+json
                 title: Search across feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/sortables
                 rel: http://www.opengis.net/def/rel/ogc/1.0/sortables

--- a/spec/components/responses.yaml
+++ b/spec/components/responses.yaml
@@ -91,6 +91,14 @@ components:
         application/json:
           example:
             conformsTo:
+              - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -188,11 +196,22 @@ components:
                 rel: search
                 type: application/json
                 title: Search across feature collections
+              - href: http://data.geo.admin.ch/api/stac/v1/sortables
+                rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                type: application/schema+json
+                title: Sortable fields for the sortby parameter
             stac_version: 1.0.0
             title: data.geo.admin.ch
             type: Catalog
             conformsTo:
               - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -205,6 +224,13 @@ components:
         link relation `conformance`), and the Feature
         Collections (path `/collections`, link relation
         `data`).
+    Sortables:
+      content:
+        application/schema+json:
+          schema:
+            $ref: "./schemas.yaml#/components/schemas/sortables"
+      description: >-
+        A JSON Schema defining the properties allowed in `sortby`.
     NotFound:
       description: The specified resource/URI was not found
       content:

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -1754,7 +1754,7 @@ components:
               - asc
               - desc
       example:
-        - field: created
+        - field: properties.created
           direction: asc
         - field: collection
           direction: desc
@@ -1804,7 +1804,7 @@ components:
                 type:
                   type: string
                   example: string
-            datetime:
+            properties.datetime:
               type: object
               properties:
                 type:
@@ -1813,13 +1813,13 @@ components:
                 format:
                   type: string
                   example: date-time
-            title:
+            properties.title:
               type: object
               properties:
                 type:
                   type: string
                   example: string
-            created:
+            properties.created:
               type: object
               properties:
                 type:
@@ -1828,7 +1828,7 @@ components:
                 format:
                   type: string
                   example: date-time
-            updated:
+            properties.updated:
               type: object
               properties:
                 type:

--- a/spec/components/schemas.yaml
+++ b/spec/components/schemas.yaml
@@ -371,6 +371,10 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/sortables
+                  rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                  type: application/schema+json
+                  title: Sortable fields for the sortby parameter
     collections:
       properties:
         collections:
@@ -1760,6 +1764,98 @@ components:
         sortby:
           $ref: "#/components/schemas/sortby"
       type: object
+    sortables:
+      title: Sortables
+      description: >-
+        A JSON Schema describing the fields that can be used with the `sortby`
+        parameter.
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: url
+          enum:
+            - https://json-schema.org/draft/2020-12/schema
+          example: https://json-schema.org/draft/2020-12/schema
+        $id:
+          type: string
+          format: url
+          example: https://data.geo.admin.ch/api/stac/v1/sortables
+        title:
+          type: string
+          example: Sortables
+        type:
+          type: string
+          enum:
+            - object
+          example: object
+        properties:
+          type: object
+          properties:
+            id:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            collection:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            datetime:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            title:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            created:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            updated:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+          additionalProperties: false
+        additionalProperties:
+          description: >-
+            If `additionalProperties` is not included, any property name is valid
+            in a sorting expression on the collection that is evaluated by the
+            server and the property reference SHALL evaluate to `null`, if the
+            property does not exist for a resource.
+
+
+            If `additionalProperties` is set to `false`, property references that
+            are not explicitly declared in the sortables schema SHALL result in a
+            400 response.
+          type: boolean
+          example: false
+      required:
+        - $schema
+        - $id
+        - type
+        - properties
     searchBody:
       allOf:
         #        - $ref: "#/components/schemas/assetQueryFilter"

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -21,6 +21,10 @@ tags:
     name: Data
   - description: Extension to OGC API - Features to support STAC metadata model and search API
     name: STAC
+  - name: Sort Extension
+    description: |
+      [An extension to the STAC API](https://github.com/stac-api-extensions/sort) that allows sorting
+      of results based on specified properties.
 
 paths:
   /:
@@ -368,3 +372,41 @@ paths:
       summary: Search STAC items with full-featured filtering.
       tags:
         - STAC
+  /sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter
+        for the cross-collection item search (i.e. `GET /search` and `POST /search`).
+        It returns a JSON Schema that defines the properties allowed in `sortby`.
+        The precise definition of this can be found in the
+        [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getSortables
+      responses:
+        "200":
+          $ref: "./components/responses.yaml#/components/responses/Sortables"
+        "500":
+          $ref: "./components/responses.yaml#/components/responses/ServerError"
+      summary: Fetch sortable fields for /search
+      tags:
+        - Sort Extension
+  /collections/{collectionId}/sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter
+        for the item lists of a collection (i.e. `GET /collections/{collectionId}/items`).
+        It returns a JSON Schema that defines the properties allowed in `sortby`.
+        The precise definition of this can be found in the
+        [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getCollectionSortables
+      parameters:
+        - $ref: "./components/parameters.yaml#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "./components/responses.yaml#/components/responses/Sortables"
+        "404":
+          $ref: "./components/responses.yaml#/components/responses/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/components/responses/ServerError"
+      summary: Fetch sortable fields for features in a collection
+      tags:
+        - Sort Extension

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -141,7 +141,7 @@ components:
       required: false
       schema:
         type: string
-        example: '-created,id'
+        example: '-properties.created,id'
   responses:
     Collection:
       headers:
@@ -2014,7 +2014,7 @@ components:
               - asc
               - desc
       example:
-        - field: created
+        - field: properties.created
           direction: asc
         - field: collection
           direction: desc
@@ -2063,7 +2063,7 @@ components:
                 type:
                   type: string
                   example: string
-            datetime:
+            properties.datetime:
               type: object
               properties:
                 type:
@@ -2072,13 +2072,13 @@ components:
                 format:
                   type: string
                   example: date-time
-            title:
+            properties.title:
               type: object
               properties:
                 type:
                   type: string
                   example: string
-            created:
+            properties.created:
               type: object
               properties:
                 type:
@@ -2087,7 +2087,7 @@ components:
                 format:
                   type: string
                   example: date-time
-            updated:
+            properties.updated:
               type: object
               properties:
                 type:

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -292,7 +292,7 @@ components:
                 title: Information about the feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
-                type: application/json
+                type: application/geo+json
                 title: Search across feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/sortables
                 rel: http://www.opengis.net/def/rel/ogc/1.0/sortables

--- a/spec/static/spec/v1/openapi.yaml
+++ b/spec/static/spec/v1/openapi.yaml
@@ -135,6 +135,9 @@ components:
       in: query
       description: >-
         An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is provided, "+" is assumed.
+
+
+        This parameter is part of the [sort extension](https://github.com/stac-api-extensions/sort).
       required: false
       schema:
         type: string
@@ -212,6 +215,14 @@ components:
         application/json:
           example:
             conformsTo:
+              - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -283,11 +294,22 @@ components:
                 rel: search
                 type: application/json
                 title: Search across feature collections
+              - href: http://data.geo.admin.ch/api/stac/v1/sortables
+                rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                type: application/schema+json
+                title: Sortable fields for the sortby parameter
             stac_version: 1.0.0
             title: data.geo.admin.ch
             type: Catalog
             conformsTo:
               - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -295,6 +317,13 @@ components:
             $ref: "#/components/schemas/landingPage"
       description: >-
         The landing page provides links to the API definition (link relations `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`, link relation `conformance`), and the Feature Collections (path `/collections`, link relation `data`).
+    Sortables:
+      content:
+        application/schema+json:
+          schema:
+            $ref: "#/components/schemas/sortables"
+      description: >-
+        A JSON Schema defining the properties allowed in `sortby`.
     NotFound:
       description: The specified resource/URI was not found
       content:
@@ -691,6 +720,10 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/sortables
+                  rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                  type: application/schema+json
+                  title: Sortable fields for the sortby parameter
     collections:
       properties:
         collections:
@@ -1991,6 +2024,92 @@ components:
         sortby:
           $ref: "#/components/schemas/sortby"
       type: object
+    sortables:
+      title: Sortables
+      description: >-
+        A JSON Schema describing the fields that can be used with the `sortby` parameter.
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: url
+          enum:
+            - https://json-schema.org/draft/2020-12/schema
+          example: https://json-schema.org/draft/2020-12/schema
+        $id:
+          type: string
+          format: url
+          example: https://data.geo.admin.ch/api/stac/v1/sortables
+        title:
+          type: string
+          example: Sortables
+        type:
+          type: string
+          enum:
+            - object
+          example: object
+        properties:
+          type: object
+          properties:
+            id:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            collection:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            datetime:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            title:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            created:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            updated:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+          additionalProperties: false
+        additionalProperties:
+          description: >-
+            If `additionalProperties` is not included, any property name is valid in a sorting expression on the collection that is evaluated by the server and the property reference SHALL evaluate to `null`, if the property does not exist for a resource.
+
+
+            If `additionalProperties` is set to `false`, property references that are not explicitly declared in the sortables schema SHALL result in a 400 response.
+          type: boolean
+          example: false
+      required:
+        - $schema
+        - $id
+        - type
+        - properties
     searchBody:
       allOf:
         #        - $ref: "#/components/schemas/assetQueryFilter"
@@ -2079,6 +2198,10 @@ tags:
     name: Data
   - description: Extension to OGC API - Features to support STAC metadata model and search API
     name: STAC
+  - name: Sort Extension
+    description: |
+      [An extension to the STAC API](https://github.com/stac-api-extensions/sort) that allows sorting
+      of results based on specified properties.
 paths:
   /:
     get:
@@ -2413,3 +2536,33 @@ paths:
       summary: Search STAC items with full-featured filtering.
       tags:
         - STAC
+  /sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter for the cross-collection item search (i.e. `GET /search` and `POST /search`). It returns a JSON Schema that defines the properties allowed in `sortby`. The precise definition of this can be found in the [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getSortables
+      responses:
+        "200":
+          $ref: "#/components/responses/Sortables"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch sortable fields for /search
+      tags:
+        - Sort Extension
+  /collections/{collectionId}/sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter for the item lists of a collection (i.e. `GET /collections/{collectionId}/items`). It returns a JSON Schema that defines the properties allowed in `sortby`. The precise definition of this can be found in the [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getCollectionSortables
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "#/components/responses/Sortables"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch sortable fields for features in a collection
+      tags:
+        - Sort Extension

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -141,7 +141,7 @@ components:
       required: false
       schema:
         type: string
-        example: '-created,id'
+        example: '-properties.created,id'
     uploadId:
       name: uploadId
       in: path
@@ -2098,7 +2098,7 @@ components:
               - asc
               - desc
       example:
-        - field: created
+        - field: properties.created
           direction: asc
         - field: collection
           direction: desc
@@ -2147,7 +2147,7 @@ components:
                 type:
                   type: string
                   example: string
-            datetime:
+            properties.datetime:
               type: object
               properties:
                 type:
@@ -2156,13 +2156,13 @@ components:
                 format:
                   type: string
                   example: date-time
-            title:
+            properties.title:
               type: object
               properties:
                 type:
                   type: string
                   example: string
-            created:
+            properties.created:
               type: object
               properties:
                 type:
@@ -2171,7 +2171,7 @@ components:
                 format:
                   type: string
                   example: date-time
-            updated:
+            properties.updated:
               type: object
               properties:
                 type:

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -135,6 +135,9 @@ components:
       in: query
       description: >-
         An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is provided, "+" is assumed.
+
+
+        This parameter is part of the [sort extension](https://github.com/stac-api-extensions/sort).
       required: false
       schema:
         type: string
@@ -248,6 +251,14 @@ components:
         application/json:
           example:
             conformsTo:
+              - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -319,11 +330,22 @@ components:
                 rel: search
                 type: application/json
                 title: Search across feature collections
+              - href: http://data.geo.admin.ch/api/stac/v1/sortables
+                rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                type: application/schema+json
+                title: Sortable fields for the sortby parameter
             stac_version: 1.0.0
             title: data.geo.admin.ch
             type: Catalog
             conformsTo:
               - https://api.stacspec.org/v1.0.0/core
+              - https://api.stacspec.org/v1.0.0/collections
+              - https://api.stacspec.org/v1.0.0/ogcapi-features
+              - https://api.stacspec.org/v1.0.0/item-search
+              - https://api.stacspec.org/v1.1.0/item-search#sort
+              - https://api.stacspec.org/v1.1.0/ogcapi-features#sort
+              - https://api.stacspec.org/v1.1.0/item-search#sortables
+              - http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/sortables
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30
               - http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson
@@ -331,6 +353,13 @@ components:
             $ref: "#/components/schemas/landingPage"
       description: >-
         The landing page provides links to the API definition (link relations `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`, link relation `conformance`), and the Feature Collections (path `/collections`, link relation `data`).
+    Sortables:
+      content:
+        application/schema+json:
+          schema:
+            $ref: "#/components/schemas/sortables"
+      description: >-
+        A JSON Schema defining the properties allowed in `sortby`.
     NotFound:
       description: The specified resource/URI was not found
       content:
@@ -771,6 +800,10 @@ components:
                   title: Licence for the free geodata of the Federal Office of Topography swisstopo
                 - href: https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/metadata/4c8c7c58-61c7-4a61-8e7a-6ffb95d183df
                   rel: describedby
+                - href: https://data.geo.admin.ch/api/stac/v1/collections/ch.swisstopo.pixelkarte-farbe-pk50.noscale/sortables
+                  rel: http://www.opengis.net/def/rel/ogc/1.0/sortables
+                  type: application/schema+json
+                  title: Sortable fields for the sortby parameter
     collections:
       properties:
         collections:
@@ -2075,6 +2108,92 @@ components:
         sortby:
           $ref: "#/components/schemas/sortby"
       type: object
+    sortables:
+      title: Sortables
+      description: >-
+        A JSON Schema describing the fields that can be used with the `sortby` parameter.
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: url
+          enum:
+            - https://json-schema.org/draft/2020-12/schema
+          example: https://json-schema.org/draft/2020-12/schema
+        $id:
+          type: string
+          format: url
+          example: https://data.geo.admin.ch/api/stac/v1/sortables
+        title:
+          type: string
+          example: Sortables
+        type:
+          type: string
+          enum:
+            - object
+          example: object
+        properties:
+          type: object
+          properties:
+            id:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            collection:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            datetime:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            title:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+            created:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+            updated:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: string
+                format:
+                  type: string
+                  example: date-time
+          additionalProperties: false
+        additionalProperties:
+          description: >-
+            If `additionalProperties` is not included, any property name is valid in a sorting expression on the collection that is evaluated by the server and the property reference SHALL evaluate to `null`, if the property does not exist for a resource.
+
+
+            If `additionalProperties` is set to `false`, property references that are not explicitly declared in the sortables schema SHALL result in a 400 response.
+          type: boolean
+          example: false
+      required:
+        - $schema
+        - $id
+        - type
+        - properties
     searchBody:
       allOf:
         #        - $ref: "#/components/schemas/assetQueryFilter"
@@ -2917,12 +3036,10 @@ tags:
     name: Data
   - description: Extension to OGC API - Features to support STAC metadata model and search API
     name: STAC
-  - name: Data Management
+  - name: Sort Extension
     description: |
-      The endpoints in this section create, update or delete STAC metadata.
-
-      See the [Tech Docs](https://docs.geo.admin.ch/download-data/stac-api/overview.html) for more details
-      on authentication and supported media types.
+      [An extension to the STAC API](https://github.com/stac-api-extensions/sort) that allows sorting
+      of results based on specified properties.
   - name: Asset Upload Management
     description: |
       The endpoints in this section manage the process of uploading assets to the STAC catalog.
@@ -3676,6 +3793,36 @@ paths:
       summary: Search STAC items with full-featured filtering.
       tags:
         - STAC
+  /sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter for the cross-collection item search (i.e. `GET /search` and `POST /search`). It returns a JSON Schema that defines the properties allowed in `sortby`. The precise definition of this can be found in the [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getSortables
+      responses:
+        "200":
+          $ref: "#/components/responses/Sortables"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch sortable fields for /search
+      tags:
+        - Sort Extension
+  /collections/{collectionId}/sortables:
+    get:
+      description: >-
+        This endpoint returns a list of properties (or aliases) that can be used in the `sortby` parameter for the item lists of a collection (i.e. `GET /collections/{collectionId}/items`). It returns a JSON Schema that defines the properties allowed in `sortby`. The precise definition of this can be found in the [OGC API - Features - Part 5: Schemas](https://docs.ogc.org/is/23-058r2/23-058r2.html).
+      operationId: getCollectionSortables
+      parameters:
+        - $ref: "#/components/parameters/collectionId"
+      responses:
+        "200":
+          $ref: "#/components/responses/Sortables"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+      summary: Fetch sortable fields for features in a collection
+      tags:
+        - Sort Extension
   /collections/{collectionId}/items/{featureId}/assets:
     get:
       description: >-

--- a/spec/static/spec/v1/openapitransactional.yaml
+++ b/spec/static/spec/v1/openapitransactional.yaml
@@ -328,7 +328,7 @@ components:
                 title: Information about the feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/search
                 rel: search
-                type: application/json
+                type: application/geo+json
                 title: Search across feature collections
               - href: http://data.geo.admin.ch/api/stac/v1/sortables
                 rel: http://www.opengis.net/def/rel/ogc/1.0/sortables


### PR DESCRIPTION
Follow-up of https://github.com/geoadmin/service-stac/pull/664: Prepend `properties.` to certain parameters used in the `sortby` query parameter and in the `/sortables` endpoint:

- `datetime` -> `properties.datetime`
- `title` -> `properties.title`
- `created` -> `properties.created`
- `updated` -> `properties.updated`
- `id` and `collection` stay unchanged (top-level fields)

In https://github.com/geoadmin/service-stac/pull/663, we chose to omit the `properties.` prefix for the `sortby` query parameter. So we refer to `datetime`, not `properties.datetime`. This was because the "query" parameter of the [POST /search endpoint](https://data.geo.admin.ch/api/stac/static/spec/v1/apitransactional.html#tag/STAC/operation/postSearchSTAC) also omits the `properties.` prefix.

Looking into the STAC Browser code, however, I see that the `properties.` prefix is the assumed default. I think then it would be better to follow the STAC Browser. The Query extension will anyway be replaced by the Filter extension (see [PB-2392](https://swissgeoplatform.atlassian.net/browse/PB-2392)), so the inconsistency is ok.

[PB-2392]: https://swissgeoplatform.atlassian.net/browse/PB-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ